### PR TITLE
feature : TransactionHook support xid parameter

### DIFF
--- a/saga/seata-saga-engine-store/src/main/java/io/seata/saga/engine/store/db/DbAndReportTcStateLogStore.java
+++ b/saga/seata-saga-engine-store/src/main/java/io/seata/saga/engine/store/db/DbAndReportTcStateLogStore.java
@@ -197,8 +197,9 @@ public class DbAndReportTcStateLogStore extends AbstractStore implements StateLo
 
     protected void reportTransactionFinished(StateMachineInstance machineInstance, ProcessContext context) {
         if (sagaTransactionalTemplate != null) {
+            GlobalTransaction globalTransaction = null;
             try {
-                GlobalTransaction globalTransaction = getGlobalTransaction(machineInstance, context);
+                globalTransaction = getGlobalTransaction(machineInstance, context);
                 if (globalTransaction == null) {
 
                     throw new EngineExecutionException("Global transaction is not exists",
@@ -234,7 +235,7 @@ public class DbAndReportTcStateLogStore extends AbstractStore implements StateLo
                 // clear
                 RootContext.unbind();
                 RootContext.unbindBranchType();
-                sagaTransactionalTemplate.triggerAfterCompletion();
+                sagaTransactionalTemplate.triggerAfterCompletion(globalTransaction);
                 sagaTransactionalTemplate.cleanUp();
             }
         }

--- a/saga/seata-saga-tm/src/main/java/io/seata/saga/tm/DefaultSagaTransactionalTemplate.java
+++ b/saga/seata-saga-tm/src/main/java/io/seata/saga/tm/DefaultSagaTransactionalTemplate.java
@@ -61,9 +61,9 @@ public class DefaultSagaTransactionalTemplate
     @Override
     public void commitTransaction(GlobalTransaction tx) throws TransactionalExecutor.ExecutionException {
         try {
-            triggerBeforeCommit();
+            triggerBeforeCommit(tx);
             tx.commit();
-            triggerAfterCommit();
+            triggerAfterCommit(tx);
         } catch (TransactionException txe) {
             // 4.1 Failed to commit
             throw new TransactionalExecutor.ExecutionException(tx, txe, TransactionalExecutor.Code.CommitFailure);
@@ -73,9 +73,9 @@ public class DefaultSagaTransactionalTemplate
     @Override
     public void rollbackTransaction(GlobalTransaction tx, Throwable ex)
         throws TransactionException, TransactionalExecutor.ExecutionException {
-        triggerBeforeRollback();
+        triggerBeforeRollback(tx);
         tx.rollback();
-        triggerAfterRollback();
+        triggerAfterRollback(tx);
         // Successfully rolled back
     }
 
@@ -85,7 +85,7 @@ public class DefaultSagaTransactionalTemplate
         try {
             triggerBeforeBegin();
             tx.begin(txInfo.getTimeOut(), txInfo.getName());
-            triggerAfterBegin();
+            triggerAfterBegin(tx);
         } catch (TransactionException txe) {
             throw new TransactionalExecutor.ExecutionException(tx, txe, TransactionalExecutor.Code.BeginFailure);
 
@@ -103,7 +103,7 @@ public class DefaultSagaTransactionalTemplate
         throws TransactionalExecutor.ExecutionException {
         try {
             tx.globalReport(globalStatus);
-            triggerAfterCompletion();
+            triggerAfterCompletion(tx);
         } catch (TransactionException txe) {
 
             throw new TransactionalExecutor.ExecutionException(tx, txe, TransactionalExecutor.Code.ReportFailure);
@@ -133,50 +133,50 @@ public class DefaultSagaTransactionalTemplate
         }
     }
 
-    protected void triggerAfterBegin() {
+    protected void triggerAfterBegin(GlobalTransaction tx) {
         for (TransactionHook hook : getCurrentHooks()) {
             try {
-                hook.afterBegin();
+                hook.afterBegin(tx.getXid());
             } catch (Exception e) {
                 LOGGER.error("Failed execute afterBegin in hook {} ", e.getMessage(), e);
             }
         }
     }
 
-    protected void triggerBeforeRollback() {
+    protected void triggerBeforeRollback(GlobalTransaction tx) {
         for (TransactionHook hook : getCurrentHooks()) {
             try {
-                hook.beforeRollback();
+                hook.beforeRollback(tx.getXid());
             } catch (Exception e) {
                 LOGGER.error("Failed execute beforeRollback in hook {} ", e.getMessage(), e);
             }
         }
     }
 
-    protected void triggerAfterRollback() {
+    protected void triggerAfterRollback(GlobalTransaction tx) {
         for (TransactionHook hook : getCurrentHooks()) {
             try {
-                hook.afterRollback();
+                hook.afterRollback(tx.getXid());
             } catch (Exception e) {
                 LOGGER.error("Failed execute afterRollback in hook {}", e.getMessage(), e);
             }
         }
     }
 
-    protected void triggerBeforeCommit() {
+    protected void triggerBeforeCommit(GlobalTransaction tx) {
         for (TransactionHook hook : getCurrentHooks()) {
             try {
-                hook.beforeCommit();
+                hook.beforeCommit(tx.getXid());
             } catch (Exception e) {
                 LOGGER.error("Failed execute beforeCommit in hook {}", e.getMessage(), e);
             }
         }
     }
 
-    protected void triggerAfterCommit() {
+    protected void triggerAfterCommit(GlobalTransaction tx) {
         for (TransactionHook hook : getCurrentHooks()) {
             try {
-                hook.afterCommit();
+                hook.afterCommit(tx.getXid());
             } catch (Exception e) {
                 LOGGER.error("Failed execute afterCommit in hook {}", e.getMessage(), e);
             }
@@ -184,10 +184,10 @@ public class DefaultSagaTransactionalTemplate
     }
 
     @Override
-    public void triggerAfterCompletion() {
+    public void triggerAfterCompletion(GlobalTransaction tx) {
         for (TransactionHook hook : getCurrentHooks()) {
             try {
-                hook.afterCompletion();
+                hook.afterCompletion(tx.getXid());
             } catch (Exception e) {
                 LOGGER.error("Failed execute afterCompletion in hook {}", e.getMessage(), e);
             }

--- a/saga/seata-saga-tm/src/main/java/io/seata/saga/tm/SagaTransactionalTemplate.java
+++ b/saga/seata-saga-tm/src/main/java/io/seata/saga/tm/SagaTransactionalTemplate.java
@@ -48,7 +48,7 @@ public interface SagaTransactionalTemplate {
     void branchReport(String xid, long branchId, BranchStatus status, String applicationData)
         throws TransactionException;
 
-    void triggerAfterCompletion();
+    void triggerAfterCompletion(GlobalTransaction tx);
 
     void cleanUp();
 }

--- a/test/src/test/java/io/seata/saga/engine/mock/MockSagaTransactionTemplate.java
+++ b/test/src/test/java/io/seata/saga/engine/mock/MockSagaTransactionTemplate.java
@@ -73,7 +73,7 @@ public class MockSagaTransactionTemplate implements SagaTransactionalTemplate {
     }
 
     @Override
-    public void triggerAfterCompletion() {
+    public void triggerAfterCompletion(GlobalTransaction tx) {
 
     }
 

--- a/tm/src/main/java/io/seata/tm/api/transaction/TransactionHook.java
+++ b/tm/src/main/java/io/seata/tm/api/transaction/TransactionHook.java
@@ -28,30 +28,30 @@ public interface TransactionHook {
     /**
      * after tx begin
      */
-    void afterBegin();
+    void afterBegin(String xid);
 
     /**
      * before tx commit
      */
-    void beforeCommit();
+    void beforeCommit(String xid);
 
     /**
      * after tx commit
      */
-    void afterCommit();
+    void afterCommit(String xid);
 
     /**
      * before tx rollback
      */
-    void beforeRollback();
+    void beforeRollback(String xid);
 
     /**
      * after tx rollback
      */
-    void afterRollback();
+    void afterRollback(String xid);
 
     /**
      * after tx all Completed
      */
-    void afterCompletion();
+    void afterCompletion(String xid);
 }

--- a/tm/src/main/java/io/seata/tm/api/transaction/TransactionHookAdapter.java
+++ b/tm/src/main/java/io/seata/tm/api/transaction/TransactionHookAdapter.java
@@ -26,32 +26,32 @@ public class TransactionHookAdapter implements TransactionHook {
     }
 
     @Override
-    public void afterBegin() {
+    public void afterBegin(String xid) {
 
     }
 
     @Override
-    public void beforeCommit() {
+    public void beforeCommit(String xid) {
 
     }
 
     @Override
-    public void afterCommit() {
+    public void afterCommit(String xid) {
 
     }
 
     @Override
-    public void beforeRollback() {
+    public void beforeRollback(String xid) {
 
     }
 
     @Override
-    public void afterRollback() {
+    public void afterRollback(String xid) {
 
     }
 
     @Override
-    public void afterCompletion() {
+    public void afterCompletion(String xid) {
 
     }
 }

--- a/tm/src/test/java/io/seata/tm/api/TransactionTemplateTest.java
+++ b/tm/src/test/java/io/seata/tm/api/TransactionTemplateTest.java
@@ -140,18 +140,20 @@ public class TransactionTemplateTest {
     }
 
     private void verifyCommit(TransactionHook transactionHook) {
+        String xid = "test-xid";
         verify(transactionHook).beforeBegin();
-        verify(transactionHook).afterBegin();
-        verify(transactionHook).beforeCommit();
-        verify(transactionHook).afterCommit();
-        verify(transactionHook).afterCompletion();
+        verify(transactionHook).afterBegin(xid);
+        verify(transactionHook).beforeCommit(xid);
+        verify(transactionHook).afterCommit(xid);
+        verify(transactionHook).afterCompletion(xid);
     }
 
     private void verifyRollBack(TransactionHook transactionHook) {
+        String xid = "test-xid";
         verify(transactionHook).beforeBegin();
-        verify(transactionHook).afterBegin();
-        verify(transactionHook).beforeRollback();
-        verify(transactionHook).afterRollback();
-        verify(transactionHook).afterCompletion();
+        verify(transactionHook).afterBegin(xid);
+        verify(transactionHook).beforeRollback(xid);
+        verify(transactionHook).afterRollback(xid);
+        verify(transactionHook).afterCompletion(xid);
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
为TransactionHook接口新增参数，目前只有xid，本来想把GlobalTransaction和TransactionInfo都传进去的，但TransactionInfo里面信息现在利用率比较低（方法拿到这个参数后里面也没有很多关键信息），而GlobalTransaction传给hook的话权限过大，用户有可能会对transaction进行更改，感觉还是谨慎开放的好

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix https://github.com/seata/seata/issues/4554


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

