### PR TITLE
bugfix: fix incorrect metric report

### DIFF
--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -85,7 +85,7 @@ The version is updated as follows:
 - [[#5954](https://github.com/seata/seata/pull/5954)] fix the issue of saved branch session status does not match the actual branch session status
 - [[#5990](https://github.com/seata/seata/pull/5990)] fix the issue that the Lua script is not synchronized when the redis sentinel master node is down
 - [[#5887](https://github.com/seata/seata/pull/5887)] fix global transaction hook repeat execute
-
+- [[#6018](https://github.com/seata/seata/pull/6018)] fix incorrect metric report
 
 ### optimize：
 - [[#5966](https://github.com/seata/seata/pull/5966)] decouple saga expression handling and remove evaluator package

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -84,6 +84,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 - [[#5954](https://github.com/seata/seata/pull/5954)] 修复保存的分支会话状态与实际的分支会话状态不一致的问题
 - [[#5990](https://github.com/seata/seata/pull/5990)] 修复redis sentinel master node 宕机时，lua脚本未同步的问题
 - [[#5887](https://github.com/seata/seata/pull/5887)] 修复全局事务钩子重复执行
+- [[#6018](https://github.com/seata/seata/pull/6018)] 修复错误的 metric 上报
 
 
 ### optimize：

--- a/server/src/main/java/io/seata/server/session/SessionHelper.java
+++ b/server/src/main/java/io/seata/server/session/SessionHelper.java
@@ -147,7 +147,7 @@ public class SessionHelper {
             }
             globalSession.end();
             if (!DELAY_HANDLE_SESSION) {
-                MetricsPublisher.postSessionDoneEvent(globalSession, false, false);
+                MetricsPublisher.postSessionDoneEvent(globalSession, retryGlobal, false);
             }
             MetricsPublisher.postSessionDoneEvent(globalSession, IdConstants.STATUS_VALUE_AFTER_COMMITTED_KEY, true,
                 beginTime, retryBranch);
@@ -219,7 +219,7 @@ public class SessionHelper {
             }
             globalSession.end();
             if (!DELAY_HANDLE_SESSION && !timeoutDone) {
-                MetricsPublisher.postSessionDoneEvent(globalSession, false, false);
+                MetricsPublisher.postSessionDoneEvent(globalSession, retryGlobal, false);
             }
             MetricsPublisher.postSessionDoneEvent(globalSession, IdConstants.STATUS_VALUE_AFTER_ROLLBACKED_KEY, true,
                     beginTime, retryBranch);
@@ -331,7 +331,7 @@ public class SessionHelper {
     public static Boolean forEach(Collection<BranchSession> sessions, BranchSessionHandler handler) throws TransactionException {
         return forEach(sessions, handler, false);
     }
-    
+
     /**
      * Foreach branch sessions.
      *

--- a/server/src/main/java/io/seata/server/session/SessionHelper.java
+++ b/server/src/main/java/io/seata/server/session/SessionHelper.java
@@ -146,7 +146,7 @@ public class SessionHelper {
                 globalSession.changeGlobalStatus(GlobalStatus.Committed);
             }
             globalSession.end();
-            if (!DELAY_HANDLE_SESSION) {
+            if (!retryGlobal) {
                 MetricsPublisher.postSessionDoneEvent(globalSession, false, false);
             }
             MetricsPublisher.postSessionDoneEvent(globalSession, IdConstants.STATUS_VALUE_AFTER_COMMITTED_KEY, true,
@@ -218,7 +218,7 @@ public class SessionHelper {
                 globalSession.changeGlobalStatus(GlobalStatus.Rollbacked);
             }
             globalSession.end();
-            if (!DELAY_HANDLE_SESSION && !timeoutDone) {
+            if (!retryGlobal && !timeoutDone) {
                 MetricsPublisher.postSessionDoneEvent(globalSession, false, false);
             }
             MetricsPublisher.postSessionDoneEvent(globalSession, IdConstants.STATUS_VALUE_AFTER_ROLLBACKED_KEY, true,
@@ -331,7 +331,7 @@ public class SessionHelper {
     public static Boolean forEach(Collection<BranchSession> sessions, BranchSessionHandler handler) throws TransactionException {
         return forEach(sessions, handler, false);
     }
-    
+
     /**
      * Foreach branch sessions.
      *

--- a/server/src/main/java/io/seata/server/session/SessionHelper.java
+++ b/server/src/main/java/io/seata/server/session/SessionHelper.java
@@ -146,7 +146,7 @@ public class SessionHelper {
                 globalSession.changeGlobalStatus(GlobalStatus.Committed);
             }
             globalSession.end();
-            if (!retryGlobal) {
+            if (!DELAY_HANDLE_SESSION) {
                 MetricsPublisher.postSessionDoneEvent(globalSession, false, false);
             }
             MetricsPublisher.postSessionDoneEvent(globalSession, IdConstants.STATUS_VALUE_AFTER_COMMITTED_KEY, true,
@@ -218,7 +218,7 @@ public class SessionHelper {
                 globalSession.changeGlobalStatus(GlobalStatus.Rollbacked);
             }
             globalSession.end();
-            if (!retryGlobal && !timeoutDone) {
+            if (!DELAY_HANDLE_SESSION && !timeoutDone) {
                 MetricsPublisher.postSessionDoneEvent(globalSession, false, false);
             }
             MetricsPublisher.postSessionDoneEvent(globalSession, IdConstants.STATUS_VALUE_AFTER_ROLLBACKED_KEY, true,
@@ -331,7 +331,7 @@ public class SessionHelper {
     public static Boolean forEach(Collection<BranchSession> sessions, BranchSessionHandler handler) throws TransactionException {
         return forEach(sessions, handler, false);
     }
-
+    
     /**
      * Foreach branch sessions.
      *


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

Fix incorrect metric report. 

![](https://user-images.githubusercontent.com/32592585/282104750-e81007f0-04c9-427a-bdf9-ae05fc0f337b.png)

It's actually a accidental code error. The conditions in

https://github.com/seata/seata/blob/8192138895ada3cc7cd09977f3219ed8371c17ae/server/src/main/java/io/seata/server/session/SessionHelper.java#L149

and in

https://github.com/seata/seata/blob/8192138895ada3cc7cd09977f3219ed8371c17ae/server/src/main/java/io/seata/server/session/SessionHelper.java#L221

intend to distinguish whether `retryGlobal` is true or false. Therefore, `retryGlobal` should be evaluated instead of `DELAY_HANDLE_SESSION`.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #6016 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

