### PR TITLE
optimize: using namespace from command line when deployment with helm charts

### DIFF
--- a/script/server/helm/seata-server/templates/deployment.yaml
+++ b/script/server/helm/seata-server/templates/deployment.yaml
@@ -1,9 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-{{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-{{- end}}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "seata-server.name" . }}
   labels:
 {{ include "seata-server.labels" . | indent 4 }}

--- a/script/server/helm/seata-server/templates/service.yaml
+++ b/script/server/helm/seata-server/templates/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "seata-server.fullname" . }}
   labels:
 {{ include "seata-server.labels" . | indent 4 }}

--- a/script/server/helm/seata-server/templates/tests/test-connection.yaml
+++ b/script/server/helm/seata-server/templates/tests/test-connection.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: "{{ include "seata-server.fullname" . }}-test-connection"
   labels:
 {{ include "seata-server.labels" . | indent 4 }}

--- a/script/server/helm/seata-server/values.yaml
+++ b/script/server/helm/seata-server/values.yaml
@@ -1,7 +1,5 @@
 replicaCount: 1
 
-namespace: default
-
 image:
   repository: seataio/seata-server
   tag: latest


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

1. Currently, the namespace set in Values.yaml only takes effect for deployment-type resources, while service and pod resources ignore this value. 
2. It is customary to specify the namespace using the `-n` parameter in the `helm install` command, but currently, deployment ignores the namespace specified in the command line.

so in this PR:

1. The configuration for `namespace` has been removed from values.yaml. 
2. When creating all Kubernetes resources, specify the value to use for the namespace as `{{ .Release.Namespace }}`.



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 

 I confirmed the correctness of the execution result through `helm template --dry-run`.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

