### PR TITLE
optimize: using namespace from command line when deployment with helm charts

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -45,5 +45,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [ggbocoder](https://github.com/ggbocoder)
 - [leezongjie](https://github.com/leezongjie)
 - [l81893521](https://github.com/l81893521)
+- [baiyangtx](https://github.com/baiyangtx)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -21,6 +21,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6042](https://github.com/seata/seata/pull/6042)] add secure authentication to interfaces in ClusterController
 - [[#6091](https://github.com/seata/seata/pull/6091)] Optimizing the method of obtaining the tc address during raft authentication
 - [[#6098](https://github.com/seata/seata/pull/6098)] optimize the retry logic in the acquireMetadata method
+- [[#6034](https://github.com/seata/seata/pull/6034)] using namespace from command line when deployment with helm charts
 
 
 ### security:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -21,6 +21,7 @@
 - [[#6042](https://github.com/seata/seata/pull/6042)] 增加raft模式鉴权机制
 - [[#6091](https://github.com/seata/seata/pull/6091)] 优化raft鉴权时获取tc地址的方式
 - [[#6098](https://github.com/seata/seata/pull/6098)] 优化acquireMetadata方法的重试逻辑
+- [[#6034](https://github.com/seata/seata/pull/6034)] 使用helm图表进行部署时使用命令行中的命名空间
 
 ### security:
 - [[#6069](https://github.com/seata/seata/pull/6069)] 升级Guava依赖版本，修复安全漏洞

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -44,5 +44,6 @@
 - [ggbocoder](https://github.com/ggbocoder)
 - [leezongjie](https://github.com/leezongjie)
 - [l81893521](https://github.com/l81893521)
+- [baiyangtx](https://github.com/baiyangtx)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/script/server/helm/seata-server/templates/deployment.yaml
+++ b/script/server/helm/seata-server/templates/deployment.yaml
@@ -1,9 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-{{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-{{- end}}
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "seata-server.name" . }}
   labels:
 {{ include "seata-server.labels" . | indent 4 }}

--- a/script/server/helm/seata-server/templates/service.yaml
+++ b/script/server/helm/seata-server/templates/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ include "seata-server.fullname" . }}
   labels:
 {{ include "seata-server.labels" . | indent 4 }}

--- a/script/server/helm/seata-server/templates/tests/test-connection.yaml
+++ b/script/server/helm/seata-server/templates/tests/test-connection.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  namespace: {{ .Release.Namespace | quote }}
   name: "{{ include "seata-server.fullname" . }}-test-connection"
   labels:
 {{ include "seata-server.labels" . | indent 4 }}

--- a/script/server/helm/seata-server/values.yaml
+++ b/script/server/helm/seata-server/values.yaml
@@ -1,7 +1,5 @@
 replicaCount: 1
 
-namespace: default
-
 image:
   repository: seataio/seata-server
   tag: latest


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

1. Currently, the namespace set in Values.yaml only takes effect for deployment-type resources, while service and pod resources ignore this value. 
2. It is customary to specify the namespace using the `-n` parameter in the `helm install` command, but currently, deployment ignores the namespace specified in the command line.

so in this PR:

1. The configuration for `namespace` has been removed from values.yaml. 
2. When creating all Kubernetes resources, specify the value to use for the namespace as `{{ .Release.Namespace }}`.



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 

 I confirmed the correctness of the execution result through `helm template --dry-run`.

### Ⅳ. Describe how to verify it

Install with -n

```
$ helm template --dry-run instance  -n middleware   ./seata-server 
---
# Source: seata-server/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  namespace: "middleware"
  name: instance-seata-server
  labels:
    app.kubernetes.io/name: seata-server
    helm.sh/chart: seata-server-1.0.0
    app.kubernetes.io/instance: instance
    app.kubernetes.io/version: "1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: NodePort
  ports:
    - port: 30091
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: seata-server
    app.kubernetes.io/instance: instance

```


Install without `-n` 

```
$ helm template --dry-run instance    ./seata-server 
---
# Source: seata-server/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  namespace: "default"
  name: instance-seata-server
  labels:
    app.kubernetes.io/name: seata-server
    helm.sh/chart: seata-server-1.0.0
    app.kubernetes.io/instance: instance
    app.kubernetes.io/version: "1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: NodePort
  ports:
    - port: 30091
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: seata-server
    app.kubernetes.io/instance: instance

```

### Ⅴ. Special notes for reviews

