### PR TITLE
bugfix: change RaftServer#destroy to wait all shutdown procedures done

### DIFF
--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -88,6 +88,7 @@ The version is updated as follows:
 - [[#6018](https://github.com/seata/seata/pull/6018)] fix incorrect metric report
 - [[#6024](https://github.com/seata/seata/pull/6024)] fix the white screen after click the "View Global Lock" button on the transaction info page in the console
 - [[#6015](https://github.com/seata/seata/pull/6015)] fix can't integrate dubbo with spring
+- [[#6050](https://github.com/seata/seata/pull/6050)] change RaftServer#destroy to wait all shutdown procedures done
 
 ### optimize：
 - [[#6033](https://github.com/seata/seata/pull/6033)] optimize the isReference judgment logic in HSFRemotingParser, remove unnecessary judgment about FactoryBean

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -87,6 +87,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 - [[#6018](https://github.com/seata/seata/pull/6018)] 修复错误的 metric 上报
 - [[#6024](https://github.com/seata/seata/pull/6024)] 修复控制台点击事务信息页面中的"查看全局锁"按钮之后白屏的问题
 - [[#6015](https://github.com/seata/seata/pull/6015)] 修复在spring环境下无法集成dubbo
+- [[#6050](https://github.com/seata/seata/pull/6050)] 修改 RaftServer#destroy 为等待所有关闭流程结束
 
 
 ### optimize：

--- a/server/src/main/java/io/seata/server/cluster/raft/RaftServer.java
+++ b/server/src/main/java/io/seata/server/cluster/raft/RaftServer.java
@@ -105,7 +105,14 @@ public class RaftServer implements Disposable, Closeable {
 
     @Override
     public void destroy() {
-        Optional.ofNullable(raftGroupService).ifPresent(RaftGroupService::shutdown);
+        Optional.ofNullable(raftGroupService).ifPresent(r -> {
+            r.shutdown();
+            try {
+                r.join();
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted when RaftServer destroying", e);
+            }
+        });
     }
 
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

`RaftGroupService::shutdown` is an asynchronized procedure, add `RaftGroupService::join` to wait all shutdown procedures done.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #6046

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

