### PR TITLE
security: upgrade com.google.guava:guava to 32.0.0-jre

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -12,7 +12,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] A brief and accurate description of PR
 
 ### security:
-- [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] A brief and accurate description of PR
+- [[#6069](https://github.com/seata/seata/pull/6069)] Upgrade Guava dependencies to fix security vulnerabilities
 
 ### test:
 - [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] A brief and accurate description of PR
@@ -21,6 +21,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 - [slievrly](https://github.com/slievrly)
-
+- [imcmai](https://github.com/imcmai)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -12,7 +12,7 @@
 - [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] 准确简要的PR描述
 
 ### security:
-- [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] 准确简要的PR描述
+- [[#6069](https://github.com/seata/seata/pull/6069)] 升级Guava依赖版本，修复安全漏洞
 
 ### test:
 - [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] 准确简要的PR描述
@@ -21,5 +21,6 @@
 
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 - [slievrly](https://github.com/slievrly)
+- [imcmai](https://github.com/imcmai)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,7 +56,7 @@
         <nacos-client.version>1.4.2</nacos-client.version>
         <etcd-client-v3.version>0.5.0</etcd-client-v3.version>
         <testcontainers.version>1.11.2</testcontainers.version>
-        <guava.version>30.1-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <javax-inject.version>1</javax-inject.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 30.1-jre
- [CVE-2023-2976](https://www.oscs1024.com/hd/CVE-2023-2976)


### What did I do？
Upgrade com.google.guava:guava from 30.1-jre to 32.0.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.
