### PR TITLE
bugfix: The TCC aspect does not handle internal invocation exceptions and directly throws them externally.

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -6,6 +6,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] A brief and accurate description of PR
 
 ### bugfix:
+- [[#6090](https://github.com/seata/seata/pull/6090)] fix the TCC aspect exception handling process, do not wrapping the internal call exceptions
 - [[#6075](https://github.com/seata/seata/pull/6075)] fix missing table alias for on update column of image SQL
 - [[#6086](https://github.com/seata/seata/pull/6086)] fix oracle column alias cannot find
 - [[#6085](https://github.com/seata/seata/pull/6085)] fix jdk9+ compile error
@@ -30,5 +31,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [imcmai](https://github.com/imcmai)
 - [DroidEye2ONGU](https://github.com/DroidEye2ONGU)
 - [funky-eyes](https://github.com/funky-eyes)
+- [leezongjie](https://github.com/leezongjie)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -6,6 +6,7 @@
 - [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] 准确简要的PR描述
 
 ### bugfix:
+- [[#6090](https://github.com/seata/seata/pull/6090)] 修复tcc切面异常处理过程，不对内部调用异常做包装处理，直接向外抛出
 - [[#6075](https://github.com/seata/seata/pull/6075)] 修复镜像SQL对于on update列没有添加表别名的问题
 - [[#6086](https://github.com/seata/seata/pull/6086)] 修复oracle alias 解析异常
 - [[#6085](https://github.com/seata/seata/pull/6085)] 修复jdk9+版本编译后，引入后ByteBuffer#flip NoSuchMethodError的问题
@@ -31,6 +32,7 @@
 - [imcmai](https://github.com/imcmai)
 - [DroidEye2ONGU](https://github.com/DroidEye2ONGU)
 - [funky-eyes](https://github.com/funky-eyes)
+- [leezongjie](https://github.com/leezongjie)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/integration-tx-api/src/main/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapper.java
+++ b/integration-tx-api/src/main/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapper.java
@@ -15,6 +15,7 @@
  */
 package io.seata.integration.tx.api.interceptor;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
@@ -55,6 +56,14 @@ public class DefaultInvocationWrapper implements InvocationWrapper {
 
     @Override
     public Object proceed() throws Throwable {
-        return method.invoke(delegate, args);
+        try {
+            return method.invoke(delegate, args);
+        } catch (Throwable t) {
+            if (t instanceof InvocationTargetException) {
+                t = t.getCause();
+            }
+            throw t;
+        }
+
     }
 }

--- a/integration-tx-api/src/main/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapper.java
+++ b/integration-tx-api/src/main/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapper.java
@@ -54,11 +54,7 @@ public class DefaultInvocationWrapper implements InvocationWrapper {
     }
 
     @Override
-    public Object proceed() {
-        try {
-            return method.invoke(delegate, args);
-        } catch (Throwable t) {
-            throw new RuntimeException(t);
-        }
+    public Object proceed() throws Throwable {
+        return method.invoke(delegate, args);
     }
 }

--- a/integration-tx-api/src/main/java/io/seata/integration/tx/api/interceptor/InvocationWrapper.java
+++ b/integration-tx-api/src/main/java/io/seata/integration/tx/api/interceptor/InvocationWrapper.java
@@ -30,7 +30,7 @@ public interface InvocationWrapper {
 
     Object[] getArguments();
 
-    Object proceed();
+    Object proceed() throws Throwable;
 
 
 }

--- a/integration-tx-api/src/test/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapperTest.java
+++ b/integration-tx-api/src/test/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapperTest.java
@@ -1,0 +1,38 @@
+package io.seata.integration.tx.api.interceptor;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author leezongjie
+ * @date 2023/11/29
+ */
+class DefaultInvocationWrapperTest {
+
+    @Test
+    void proceed() throws Throwable {
+        //given
+        MyMockMethodInvocation myMockMethodInvocation = new MyMockMethodInvocation();
+        Method method = MyMockMethodInvocation.class.getDeclaredMethod("proceed", int.class);
+
+        //when
+        DefaultInvocationWrapper invocationWrapper = new DefaultInvocationWrapper(myMockMethodInvocation, myMockMethodInvocation, method, new Object[]{1});
+        //then
+        Assertions.assertEquals(1, invocationWrapper.proceed());
+
+        //when
+        DefaultInvocationWrapper invocationWrapperThrowException = new DefaultInvocationWrapper(myMockMethodInvocation, myMockMethodInvocation, method, new Object[]{0});
+        //then should throw raw exception
+        Assertions.assertThrows(ArithmeticException.class, () -> invocationWrapperThrowException.proceed());
+    }
+
+
+    static class MyMockMethodInvocation {
+        public Object proceed(int divisor) {
+            return 1 / divisor;
+        }
+    }
+
+}

--- a/integration-tx-api/src/test/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapperTest.java
+++ b/integration-tx-api/src/test/java/io/seata/integration/tx/api/interceptor/DefaultInvocationWrapperTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package io.seata.integration.tx.api.interceptor;
 
 import java.lang.reflect.Method;

--- a/spring/src/main/java/io/seata/spring/annotation/AdapterInvocationWrapper.java
+++ b/spring/src/main/java/io/seata/spring/annotation/AdapterInvocationWrapper.java
@@ -52,11 +52,7 @@ public class AdapterInvocationWrapper implements InvocationWrapper {
     }
 
     @Override
-    public Object proceed() {
-        try {
-            return invocation.proceed();
-        } catch (Throwable throwable) {
-            throw new RuntimeException("try to proceed invocation error", throwable);
-        }
+    public Object proceed() throws Throwable {
+        return invocation.proceed();
     }
 }

--- a/spring/src/test/java/io/seata/spring/annotation/AdapterSpringSeataInterceptorTest.java
+++ b/spring/src/test/java/io/seata/spring/annotation/AdapterSpringSeataInterceptorTest.java
@@ -1,0 +1,88 @@
+package io.seata.spring.annotation;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.seata.integration.tx.api.interceptor.handler.ProxyInvocationHandler;
+import io.seata.integration.tx.api.interceptor.parser.DefaultInterfaceParser;
+import io.seata.rm.tcc.api.BusinessActionContext;
+import io.seata.spring.tcc.NormalTccAction;
+import io.seata.spring.tcc.NormalTccActionImpl;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author leezongjie
+ * @date 2023/11/29
+ */
+class AdapterSpringSeataInterceptorTest {
+
+    @Test
+    void should_throw_raw_exception_when_call_prepareWithException() throws Throwable {
+        //given
+        NormalTccActionImpl normalTccAction = new NormalTccActionImpl();
+        ProxyInvocationHandler proxyInvocationHandler = DefaultInterfaceParser.get().parserInterfaceToProxy(normalTccAction, "proxyTccAction");
+        AdapterSpringSeataInterceptor adapterSpringSeataInterceptor = new AdapterSpringSeataInterceptor(proxyInvocationHandler);
+        MyMockMethodInvocation myMockMethodInvocation = new MyMockMethodInvocation(NormalTccAction.class.getMethod("prepareWithException", BusinessActionContext.class), () -> normalTccAction.prepareWithException(null));
+
+        //when then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> adapterSpringSeataInterceptor.invoke(myMockMethodInvocation));
+    }
+
+    @Test
+    void should_success_when_call_prepare_with_ProxyInvocationHandler() throws Throwable {
+        //given
+        NormalTccActionImpl normalTccAction = new NormalTccActionImpl();
+        ProxyInvocationHandler proxyInvocationHandler = DefaultInterfaceParser.get().parserInterfaceToProxy(normalTccAction, "proxyTccAction");
+        AdapterSpringSeataInterceptor adapterSpringSeataInterceptor = new AdapterSpringSeataInterceptor(proxyInvocationHandler);
+        MyMockMethodInvocation myMockMethodInvocation = new MyMockMethodInvocation(NormalTccAction.class.getMethod("prepare", BusinessActionContext.class), () -> normalTccAction.prepare(null));
+
+        //when then
+        Assertions.assertTrue((Boolean) adapterSpringSeataInterceptor.invoke(myMockMethodInvocation));
+    }
+
+    static class MyMockMethodInvocation implements MethodInvocation {
+
+        private Callable callable;
+        private Method method;
+
+        public MyMockMethodInvocation(Method method, Callable callable) {
+            this.method = method;
+            this.callable = callable;
+        }
+
+        @Nullable
+        @Override
+        public Object proceed() throws Throwable {
+            return callable.call();
+        }
+
+        @Nonnull
+        @Override
+        public Method getMethod() {
+            return method;
+        }
+
+        @Nonnull
+        @Override
+        public Object[] getArguments() {
+            return new Object[0];
+        }
+
+        @Nullable
+        @Override
+        public Object getThis() {
+            return null;
+        }
+
+        @Nonnull
+        @Override
+        public AccessibleObject getStaticPart() {
+            return null;
+        }
+    }
+}

--- a/spring/src/test/java/io/seata/spring/annotation/AdapterSpringSeataInterceptorTest.java
+++ b/spring/src/test/java/io/seata/spring/annotation/AdapterSpringSeataInterceptorTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package io.seata.spring.annotation;
 
 import java.lang.reflect.AccessibleObject;

--- a/spring/src/test/java/io/seata/spring/tcc/NormalTccAction.java
+++ b/spring/src/test/java/io/seata/spring/tcc/NormalTccAction.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.tcc;
+
+import io.seata.rm.tcc.api.BusinessActionContext;
+import io.seata.rm.tcc.api.LocalTCC;
+import io.seata.rm.tcc.api.TwoPhaseBusinessAction;
+
+@LocalTCC
+public interface NormalTccAction {
+
+    @TwoPhaseBusinessAction(name = "tccActionForTestWithException")
+    boolean prepare(BusinessActionContext actionContext);
+
+    @TwoPhaseBusinessAction(name = "tccActionForTestWithException")
+    boolean prepareWithException(BusinessActionContext actionContext);
+
+    boolean commit(BusinessActionContext actionContext);
+
+    boolean rollback(BusinessActionContext actionContext);
+
+}

--- a/spring/src/test/java/io/seata/spring/tcc/NormalTccActionImpl.java
+++ b/spring/src/test/java/io/seata/spring/tcc/NormalTccActionImpl.java
@@ -1,0 +1,29 @@
+package io.seata.spring.tcc;
+
+import io.seata.rm.tcc.api.BusinessActionContext;
+
+/**
+ * @author leezongjie
+ * @date 2023/11/29
+ */
+public class NormalTccActionImpl implements NormalTccAction {
+    @Override
+    public boolean prepare(BusinessActionContext actionContext) {
+        return true;
+    }
+
+    @Override
+    public boolean prepareWithException(BusinessActionContext actionContext) {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean commit(BusinessActionContext actionContext) {
+        return false;
+    }
+
+    @Override
+    public boolean rollback(BusinessActionContext actionContext) {
+        return false;
+    }
+}

--- a/spring/src/test/java/io/seata/spring/tcc/NormalTccActionImpl.java
+++ b/spring/src/test/java/io/seata/spring/tcc/NormalTccActionImpl.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package io.seata.spring.tcc;
 
 import io.seata.rm.tcc.api.BusinessActionContext;

--- a/tcc/src/test/java/io/seata/rm/tcc/NormalTccAction.java
+++ b/tcc/src/test/java/io/seata/rm/tcc/NormalTccAction.java
@@ -61,4 +61,12 @@ public interface NormalTccAction {
      * @return the boolean
      */
     boolean rollback(BusinessActionContext actionContext, @BusinessActionContextParameter("tccParam") TccParam param);
+
+
+    @TwoPhaseBusinessAction(name = "tccActionForTestWithException", commitMethod = "commit", rollbackMethod = "rollback", commitArgsClasses = {BusinessActionContext.class, TccParam.class}, rollbackArgsClasses = {BusinessActionContext.class, TccParam.class})
+    String prepareWithException(BusinessActionContext actionContext,
+                   @BusinessActionContextParameter("a") int a,
+                   @BusinessActionContextParameter(paramName = "b", index = 0) List b,
+                   @BusinessActionContextParameter(isParamInProperty = true) TccParam tccParam);
+
 }

--- a/tcc/src/test/java/io/seata/rm/tcc/NormalTccActionImpl.java
+++ b/tcc/src/test/java/io/seata/rm/tcc/NormalTccActionImpl.java
@@ -16,9 +16,9 @@
 package io.seata.rm.tcc;
 
 
-import io.seata.rm.tcc.api.BusinessActionContext;
-
 import java.util.List;
+
+import io.seata.rm.tcc.api.BusinessActionContext;
 
 /**
  * @author leezongjie
@@ -40,8 +40,13 @@ public class NormalTccActionImpl implements NormalTccAction {
         return false;
     }
 
-    public boolean otherMethod(){
+    public boolean otherMethod() {
         return true;
+    }
+
+    @Override
+    public String prepareWithException(BusinessActionContext actionContext, int a, List b, TccParam tccParam) {
+        throw new IllegalArgumentException();
     }
 
 }

--- a/tcc/src/test/java/io/seata/rm/tcc/interceptor/ProxyUtilsTccTest.java
+++ b/tcc/src/test/java/io/seata/rm/tcc/interceptor/ProxyUtilsTccTest.java
@@ -15,24 +15,24 @@
  */
 package io.seata.rm.tcc.interceptor;
 
-import io.seata.integration.tx.api.util.ProxyUtil;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
 import io.seata.core.context.RootContext;
 import io.seata.core.exception.TransactionException;
 import io.seata.core.model.BranchStatus;
 import io.seata.core.model.BranchType;
 import io.seata.core.model.Resource;
 import io.seata.core.model.ResourceManager;
+import io.seata.integration.tx.api.util.ProxyUtil;
 import io.seata.rm.DefaultResourceManager;
 import io.seata.rm.tcc.NormalTccAction;
 import io.seata.rm.tcc.NormalTccActionImpl;
 import io.seata.rm.tcc.TccParam;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author leezongjie
@@ -41,68 +41,68 @@ public class ProxyUtilsTccTest {
 
     private final String DEFAULT_XID = "default_xid";
 
+    AtomicReference<String> branchReference = new AtomicReference<String>();
+
+
+    ResourceManager resourceManager = new ResourceManager() {
+
+        @Override
+        public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String applicationData, String lockKeys) throws TransactionException {
+            branchReference.set(resourceId);
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public void branchReport(BranchType branchType, String xid, long branchId, BranchStatus status, String applicationData) throws TransactionException {
+
+        }
+
+        @Override
+        public boolean lockQuery(BranchType branchType, String resourceId, String xid, String lockKeys) throws TransactionException {
+            return false;
+        }
+
+        @Override
+        public BranchStatus branchCommit(BranchType branchType, String xid, long branchId, String resourceId, String applicationData) throws TransactionException {
+            return null;
+        }
+
+        @Override
+        public BranchStatus branchRollback(BranchType branchType, String xid, long branchId, String resourceId, String applicationData) throws TransactionException {
+            return null;
+        }
+
+        @Override
+        public void registerResource(Resource resource) {
+
+        }
+
+        @Override
+        public void unregisterResource(Resource resource) {
+
+        }
+
+        @Override
+        public Map<String, Resource> getManagedResources() {
+            return null;
+        }
+
+        @Override
+        public BranchType getBranchType() {
+            return null;
+        }
+    };
+
+
     @Test
     public void testTcc() {
         //given
         NormalTccActionImpl tccAction = new NormalTccActionImpl();
-
         NormalTccAction tccActionProxy = ProxyUtil.createProxy(tccAction);
-
         RootContext.bind(DEFAULT_XID);
 
         TccParam tccParam = new TccParam(1, "abc@163.com");
         List<String> listB = Arrays.asList("b");
-
-        AtomicReference<String> branchReference = new AtomicReference<String>();
-
-        ResourceManager resourceManager = new ResourceManager() {
-
-            @Override
-            public Long branchRegister(BranchType branchType, String resourceId, String clientId, String xid, String applicationData, String lockKeys) throws TransactionException {
-                branchReference.set(resourceId);
-                return System.currentTimeMillis();
-            }
-
-            @Override
-            public void branchReport(BranchType branchType, String xid, long branchId, BranchStatus status, String applicationData) throws TransactionException {
-
-            }
-
-            @Override
-            public boolean lockQuery(BranchType branchType, String resourceId, String xid, String lockKeys) throws TransactionException {
-                return false;
-            }
-
-            @Override
-            public BranchStatus branchCommit(BranchType branchType, String xid, long branchId, String resourceId, String applicationData) throws TransactionException {
-                return null;
-            }
-
-            @Override
-            public BranchStatus branchRollback(BranchType branchType, String xid, long branchId, String resourceId, String applicationData) throws TransactionException {
-                return null;
-            }
-
-            @Override
-            public void registerResource(Resource resource) {
-
-            }
-
-            @Override
-            public void unregisterResource(Resource resource) {
-
-            }
-
-            @Override
-            public Map<String, Resource> getManagedResources() {
-                return null;
-            }
-
-            @Override
-            public BranchType getBranchType() {
-                return null;
-            }
-        };
 
         DefaultResourceManager.mockResourceManager(BranchType.TCC, resourceManager);
 
@@ -113,7 +113,23 @@ public class ProxyUtilsTccTest {
         Assertions.assertEquals("a", result);
         Assertions.assertNotNull(result);
         Assertions.assertEquals("tccActionForTest", branchReference.get());
+    }
 
+    @Test
+    public void testTccThrowRawException() {
+        //given
+        NormalTccActionImpl tccAction = new NormalTccActionImpl();
+        NormalTccAction tccActionProxy = ProxyUtil.createProxy(tccAction);
+        RootContext.bind(DEFAULT_XID);
+
+        TccParam tccParam = new TccParam(1, "abc@163.com");
+        List<String> listB = Arrays.asList("b");
+
+        DefaultResourceManager.mockResourceManager(BranchType.TCC, resourceManager);
+
+        //when
+        //then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> tccActionProxy.prepareWithException(null, 0, listB, tccParam));
     }
 
     @Test


### PR DESCRIPTION
2.x版本中支持去spring能力，对切面部分做了重构处理，如果tcc一二阶段rpc调用过程出现异常，会多加一层框架内部异常，部分业务之前会严格校验rpc调用产生的原生异常，这样会导致原判断失效不成立。为了兼容做处理，直接将异常抛出。

fixes #6084 