### PR TITLE
bugfix:  raft-discovery cannot read registry configuration for seata-all sdk

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -18,6 +18,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6143](https://github.com/apache/incubator-seata/pull/6143)] gracefully shut down the server
 - [[#6204](https://github.com/apache/incubator-seata/pull/6204)] fix the problem that The incorrect configuration needs to be fixed
 - [[#6248](https://github.com/apache/incubator-seata/pull/6248)] fix JDBC resultSet, statement, connection closing order
+- [[#6248](https://github.com/apache/incubator-seata/pull/6256)] fix raft-discovery cannot read registry configuration for seata-all sdk
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -18,7 +18,7 @@
 - [[#6143](https://github.com/apache/incubator-seata/pull/6143)] 修复优雅停机
 - [[#6204](https://github.com/apache/incubator-seata/pull/6204)] 修复错误配置问题
 - [[#6248](https://github.com/apache/incubator-seata/pull/6248)] 修复JDBC resultSet, statement, connection关闭顺序
-
+- [[#6248](https://github.com/apache/incubator-seata/pull/6256)] 修复在seata-all sdk下，raft-discovery模块不能读取registry.conf的配置的问题
 
 ### optimize:
 - [[#6031](https://github.com/apache/incubator-seata/pull/6031)] 添加undo_log表的存在性校验

--- a/discovery/seata-discovery-raft/src/main/java/io/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/io/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -91,7 +91,7 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
 
     private static volatile RaftRegistryServiceImpl instance;
 
-    private static final Configuration CONFIG = ConfigurationFactory.getInstance();
+    private static final Configuration CONFIG = ConfigurationFactory.CURRENT_FILE_INSTANCE;
 
     private static final String IP_PORT_SPLIT_CHAR = ":";
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
使用seata-all sdk，在raft mode下不能读取到registry的配置

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
seata-all: 2.0.0
seata raft 集群

### Ⅴ. Special notes for reviews

