### PR TITLE
bugfix: sqlserver lock_table missing status placeholder

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -35,6 +35,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6380](https://github.com/apache/incubator-seata/pull/6380)] fix sql exception when checking for the existence of the UNDO_LOG table on SQL server
 - [[#6385](https://github.com/apache/incubator-seata/pull/6385)] fix the bug where Role.participant does not execute hooks but clears them.
 - [[#6465](https://github.com/apache/incubator-seata/pull/6465)] fix(6257): fix saga mode replay context lost start in 2.x
+- [[#6468](https://github.com/apache/incubator-seata/pull/6469)] fix Error in insert sql of [lock_table] data table to sqlserver database
 
 ### optimize:
 - [[#6031](https://github.com/apache/incubator-seata/pull/6031)] add a check for the existence of the undolog table
@@ -173,5 +174,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [jonasHanhan](https://github.com/jonasHanhan)
 - [Code-breaker1998](https://github.com/Code-breaker1998)
 - [MikhailNavitski](https://github.com/MikhailNavitski)
+- [deung](https://github.com/deung)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -35,7 +35,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6380](https://github.com/apache/incubator-seata/pull/6380)] fix sql exception when checking for the existence of the UNDO_LOG table on SQL server
 - [[#6385](https://github.com/apache/incubator-seata/pull/6385)] fix the bug where Role.participant does not execute hooks but clears them.
 - [[#6465](https://github.com/apache/incubator-seata/pull/6465)] fix(6257): fix saga mode replay context lost start in 2.x
-- [[#6468](https://github.com/apache/incubator-seata/pull/6469)] fix Error in insert sql of [lock_table] data table to sqlserver database
+- [[#6469](https://github.com/apache/incubator-seata/pull/6469)] fix Error in insert sql of [lock_table] data table to sqlserver database
 
 ### optimize:
 - [[#6031](https://github.com/apache/incubator-seata/pull/6031)] add a check for the existence of the undolog table

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -35,6 +35,7 @@
 - [[#6380](https://github.com/apache/incubator-seata/pull/6380)] 修复针对sql server检查UNDO_LOG表是否存在时的SQL异常
 - [[#6385](https://github.com/apache/incubator-seata/pull/6385)] 修复Role.Participant不执行hook但会清理的问题
 - [[#6465](https://github.com/apache/incubator-seata/pull/6465)] 修复2.0下saga模式的context replay丢失start问题
+- [[#6468](https://github.com/apache/incubator-seata/pull/6469)] 修复在sqlserver数据库下[lock_table]数据表的插入操作sql中存在的错误
 
 
 ### optimize:
@@ -172,5 +173,6 @@
 - [jonasHanhan](https://github.com/jonasHanhan)
 - [Code-breaker1998](https://github.com/Code-breaker1998)
 - [MikhailNavitski](https://github.com/MikhailNavitski)
+- [deung](https://github.com/deung)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -35,7 +35,7 @@
 - [[#6380](https://github.com/apache/incubator-seata/pull/6380)] 修复针对sql server检查UNDO_LOG表是否存在时的SQL异常
 - [[#6385](https://github.com/apache/incubator-seata/pull/6385)] 修复Role.Participant不执行hook但会清理的问题
 - [[#6465](https://github.com/apache/incubator-seata/pull/6465)] 修复2.0下saga模式的context replay丢失start问题
-- [[#6468](https://github.com/apache/incubator-seata/pull/6469)] 修复在sqlserver数据库下[lock_table]数据表的插入操作sql中存在的错误
+- [[#6469](https://github.com/apache/incubator-seata/pull/6469)] 修复在sqlserver数据库下[lock_table]数据表的插入操作sql中存在的错误
 
 
 ### optimize:

--- a/core/src/main/java/org/apache/seata/core/store/db/sql/lock/AbstractLockStoreSql.java
+++ b/core/src/main/java/org/apache/seata/core/store/db/sql/lock/AbstractLockStoreSql.java
@@ -65,7 +65,7 @@ public class AbstractLockStoreSql implements LockStoreSql {
 
     /**
      * The constant ALL_COLUMNS.
-     * xid, transaction_id, branch_id, resource_id, table_name, pk, row_key, gmt_create, gmt_modified
+     * xid, transaction_id, branch_id, resource_id, table_name, pk, row_key, gmt_create, gmt_modified, status
      */
     protected static final String ALL_COLUMNS =
         ServerTableColumnsName.LOCK_TABLE_XID + ", " + ServerTableColumnsName.LOCK_TABLE_TRANSACTION_ID + ", "

--- a/core/src/main/java/org/apache/seata/core/store/db/sql/lock/SqlServerLockStoreSql.java
+++ b/core/src/main/java/org/apache/seata/core/store/db/sql/lock/SqlServerLockStoreSql.java
@@ -29,7 +29,7 @@ public class SqlServerLockStoreSql extends AbstractLockStoreSql {
      * The constant INSERT_LOCK_SQL_MYSQL.
      */
     private static final String INSERT_LOCK_SQL_SQLSERVER = "insert into " + LOCK_TABLE_PLACE_HOLD + "(" + ALL_COLUMNS + ")"
-            + " values (?, ?, ?, ?, ?, ?, ?, SYSDATETIME(), SYSDATETIME())";
+            + " values (?, ?, ?, ?, ?, ?, ?, SYSDATETIME(), SYSDATETIME(), ?)";
 
     @Override
     public String getInsertLockSQL(String lockTable) {

--- a/script/client/at/db/sqlserver.sql
+++ b/script/client/at/db/sqlserver.sql
@@ -29,3 +29,9 @@ CREATE TABLE [undo_log]
         WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
 )
 GO
+
+CREATE NONCLUSTERED INDEX [ix_log_created]
+    ON [undo_log] (
+                     [log_created]
+        )
+GO

--- a/script/server/db/sqlserver.sql
+++ b/script/server/db/sqlserver.sql
@@ -83,6 +83,7 @@ CREATE TABLE [lock_table]
     [resource_id]    nvarchar(256) NULL,
     [table_name]     nvarchar(32)  NULL,
     [pk]             nvarchar(36)  NULL,
+    [status]            tinyint       NULL,
     [gmt_create]     datetime2     NULL,
     [gmt_modified]   datetime2     NULL,
     PRIMARY KEY CLUSTERED ([row_key])
@@ -90,8 +91,35 @@ CREATE TABLE [lock_table]
 )
 GO
 
+CREATE NONCLUSTERED INDEX [idx_status]
+    ON [lock_table] (
+                     [status]
+        )
+GO
+
 CREATE NONCLUSTERED INDEX [idx_branch_id]
     ON [lock_table] (
                      [branch_id]
         )
 GO
+
+CREATE NONCLUSTERED INDEX [idx_xid]
+    ON [branch_table] (
+                       [xid]
+        )
+GO
+
+CREATE TABLE [distributed_lock]
+(
+    [lock_key]       VARCHAR(20) NOT NULL,
+    [lock_value]     VARCHAR(20) NOT NULL,
+    [expire]         bigint,
+    PRIMARY KEY CLUSTERED ([lock_key])
+    WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON);
+)
+GO
+
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('AsyncCommitting', ' ', 0);
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('RetryCommitting', ' ', 0);
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('RetryRollbacking', ' ', 0);
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('TxTimeoutCheck', ' ', 0);


### PR DESCRIPTION
fix Error in insert operation sql of [lock_table] datasheet adapted to sqlserver database (#6468)
1. The [lock_table] data table insert statement INSERT_LOCK_SQL_SQLSERVER adds the placeholder [?] corresponding to the [status] field.
2. file  sqlserver.sql [lock_table] create sql add [status] field.
3. Refer to the mysql.sql improve sqlserver.sql.