### PR TITLE
bugfix: fix XA rollback on commit failure (#6492)

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -36,6 +36,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6385](https://github.com/apache/incubator-seata/pull/6385)] fix the bug where Role.participant does not execute hooks but clears them.
 - [[#6465](https://github.com/apache/incubator-seata/pull/6465)] fix(6257): fix saga mode replay context lost start in 2.x
 - [[#6469](https://github.com/apache/incubator-seata/pull/6469)] fix Error in insert sql of [lock_table] data table to sqlserver database
+- [[#6492](https://github.com/apache/incubator-seata/pull/6492)] fix XA did not rollback but close when executing a long-running SQL(or deadlock SQL)
 
 ### optimize:
 - [[#6031](https://github.com/apache/incubator-seata/pull/6031)] add a check for the existence of the undolog table
@@ -186,5 +187,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [yixia](https://github.com/wt-better)
 - [MikhailNavitski](https://github.com/MikhailNavitski)
 - [deung](https://github.com/deung)
+- [tanyaofei](https://github.com/tanyaofei)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -36,6 +36,7 @@
 - [[#6385](https://github.com/apache/incubator-seata/pull/6385)] 修复Role.Participant不执行hook但会清理的问题
 - [[#6465](https://github.com/apache/incubator-seata/pull/6465)] 修复2.0下saga模式的context replay丢失start问题
 - [[#6469](https://github.com/apache/incubator-seata/pull/6469)] 修复在sqlserver数据库下[lock_table]数据表的插入操作sql中存在的错误
+- [[#6492](https://github.com/apache/incubator-seata/pull/6492)] 修复XA执行长时间SQL(或死锁SQL)没有完成回滚就释放连接
 
 
 ### optimize:
@@ -185,5 +186,6 @@
 - [yixia](https://github.com/wt-better)
 - [MikhailNavitski](https://github.com/MikhailNavitski)
 - [deung](https://github.com/deung)
+- [tanyaofei](https://github.com/tanyaofei)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXA.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXA.java
@@ -221,7 +221,7 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
                 // Rollback immediately before the XA Branch Context is deleted.
                 String xaBranchXid = this.xaBranchXid.toString();
                 rollback();
-                throw new SQLException("Branch " + xaBranchXid + " was rollbacked on commiting since " + sqle.getMessage(), SQLSTATE_XA_NOT_END, sqle);
+                throw new SQLException("Branch " + xaBranchXid + " was rollbacked on committing since " + sqle.getMessage(), SQLSTATE_XA_NOT_END, sqle);
             }
             long now = System.currentTimeMillis();
             checkTimeout(now);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
修复 XA 模式下执行长时间 SQL(或死锁 SQL) 没有完成回滚就 `close`

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6492 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
1. `autoCommit = true` 的情况下 `SQLSTATE_XA_NOT_END` 可以避免 `ExecuteTemplateXA` 再次 `rollback`
2. `autoCommit = false` 的情况下不会 doRollbackOnCommitException
