### PR TITLE
bugfix: Corrected an issue in the Seata AT mode where, upon multiple …

### DIFF
--- a/core/src/main/java/org/apache/seata/core/store/db/sql/log/AbstractLogStoreSqls.java
+++ b/core/src/main/java/org/apache/seata/core/store/db/sql/log/AbstractLogStoreSqls.java
@@ -107,7 +107,7 @@ public abstract class AbstractLogStoreSqls implements LogStoreSqls {
     public static final String QUERY_BRANCH_TRANSACTION = "select " + ALL_BRANCH_COLUMNS
             + "  from " + BRANCH_TABLE_PLACEHOLD
             + " where " + ServerTableColumnsName.BRANCH_TABLE_XID + " = ?"
-            + " order by " + ServerTableColumnsName.BRANCH_TABLE_GMT_CREATE + " asc";
+            + " order by " + ServerTableColumnsName.BRANCH_TABLE_BRANCH_ID + " desc";
 
     /**
      * The constant QUERY_BRANCH_TRANSACTION_XIDS.
@@ -115,7 +115,7 @@ public abstract class AbstractLogStoreSqls implements LogStoreSqls {
     public static final String QUERY_BRANCH_TRANSACTION_XIDS = "select " + ALL_BRANCH_COLUMNS
             + "  from " + BRANCH_TABLE_PLACEHOLD
             + " where " + ServerTableColumnsName.BRANCH_TABLE_XID + " in (" + PRAMETER_PLACEHOLD + ")"
-            + " order by " + ServerTableColumnsName.BRANCH_TABLE_GMT_CREATE + " asc";
+            + " order by " + ServerTableColumnsName.BRANCH_TABLE_BRANCH_ID + " desc";
 
     /**
      * The constant CHECK_MAX_TRANS_ID.

--- a/server/src/main/java/org/apache/seata/server/session/GlobalSession.java
+++ b/server/src/main/java/org/apache/seata/server/session/GlobalSession.java
@@ -325,6 +325,7 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
                     branchSessions = new ArrayList<>();
                     Optional.ofNullable(SessionHolder.getRootSessionManager().findGlobalSession(xid, true))
                         .ifPresent(globalSession -> branchSessions.addAll(globalSession.getBranchSessions()));
+                    Collections.reverse(branchSessions);
                 }
             }
         }

--- a/server/src/main/java/org/apache/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/org/apache/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -662,7 +662,7 @@ public class RedisTransactionStoreManager extends AbstractTransactionStoreManage
             }
         }
         if (CollectionUtils.isNotEmpty(branchTransactionDOs)) {
-            Collections.sort(branchTransactionDOs);
+            Collections.reverse(branchTransactionDOs);
         }
         return branchTransactionDOs;
     }


### PR DESCRIPTION
…modifications to the same record and encountering an exception during business execution, the rollback process would fail.

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
When a business operation fails, Seata initiates a data rollback and concurrently checks if the data has been modified. If modifications are found, the rollback process may fail. In scenarios where the same record is updated multiple times, Seata's default sequential rollback approach can lead to rollback failures. By altering Seata's rollback strategy to perform rollbacks in reverse order—starting with the most recent modification and proceeding backwards—the issue can be resolved. This adjustment ensures that changes are undone from the latest to the earliest, effectively addressing the problem. (The fix involves storages such as DB, Redis, and file systems correctly returning branchIDs.)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

