### PR TITLE
bug: setting up a Raft cluster using domain, the listening request port is error

### DIFF
--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -234,12 +234,12 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
             Map<String, Node> map = new HashMap<>();
             if (CollectionUtils.isNotEmpty(nodeList)) {
                 for (Node node : nodeList) {
-                    map.put(node.getTransaction().getHost() + IP_PORT_SPLIT_CHAR + node.getTransaction().getPort(),
-                        node);
+                    map.put(new InetSocketAddress(node.getTransaction().getHost(), node.getTransaction().getPort()).getAddress().getHostAddress()
+                            + IP_PORT_SPLIT_CHAR + node.getTransaction().getPort(), node);
                 }
             }
             addressList = stream.map(inetSocketAddress -> {
-                String host = inetSocketAddress.getHostName();
+                String host = inetSocketAddress.getAddress().getHostAddress();
                 Node node = map.get(host + IP_PORT_SPLIT_CHAR + inetSocketAddress.getPort());
                 return host + IP_PORT_SPLIT_CHAR
                     + (node != null ? node.getControl().getPort() : inetSocketAddress.getPort());

--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -239,7 +239,7 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
                 }
             }
             addressList = stream.map(inetSocketAddress -> {
-                String host = inetSocketAddress.getAddress().getHostAddress();
+                String host = inetSocketAddress.getHostName();
                 Node node = map.get(host + IP_PORT_SPLIT_CHAR + inetSocketAddress.getPort());
                 return host + IP_PORT_SPLIT_CHAR
                     + (node != null ? node.getControl().getPort() : inetSocketAddress.getPort());


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
raft模式，客户端watch集群时，会使用解析后的IP地址查询raft节点。
如果客户端配置中使用域名，则无法用IP找到节点，导致获取http端口号错误。
这里修改为使用域名。
修改后，如果环境中存在DNS（如在k8s等环境中），需要优先使用域名，否则仍会出现匹配问题。
建议后续修改METADATA的数据结构，保存DNS解析结果，避免在queryHttpAddress中重复解析node地址。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6532

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
修改内容较少，如果环境中不存在DNS，不造成任何影响

### Ⅳ. Describe how to verify it
在k8s环境中直接使用集群内部域名时，个人已验证

### Ⅴ. Special notes for reviews
由于METADATA中只记录了原始节点信息，不区分域名或IP，所以无法确保比较结果。
如果直接在queryHttpAddress解析原始节点信息会造成不必要的网络压力和性能损失。
要彻底修复该问题，建议修改METADATA中的节点信息，解析并保存DNS解析结果，避免在queryHttpAddress中重复解析。
