### PR TITLE
bugfix: fix the issue of xaEnded not being reset

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -35,5 +35,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [YeonCheolGit](https://github.com/YeonCheolGit)
 - [liuqiufeng](https://github.com/liuqiufeng)
 - [Bughue](https://github.com/Bughue)
+- [tanyaofei](https://github.com/tanyaofei)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -8,6 +8,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### bugfix:
 - [[#6592](https://github.com/apache/incubator-seata/pull/6592)] fix @Async annotation not working in ClusterWatcherManager
 - [[#6624](https://github.com/apache/incubator-seata/pull/6624)] fix Alibaba Dubbo convert error
+- [[#6627](https://github.com/apache/incubator-seata/pull/6627)] fix the issue of xaEnded not being reset
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -7,6 +7,7 @@
 ### bugfix:
 - [[#6592](https://github.com/apache/incubator-seata/pull/6592)] fix @Async注解ClusterWatcherManager中不生效的问题
 - [[#6624](https://github.com/apache/incubator-seata/pull/6624)] 修复 Alibaba Dubbo 转换错误
+- [[#6627](https://github.com/apache/incubator-seata/pull/6627)] 修复 xaEnded 没有重置
 
 
 ### optimize:
@@ -31,5 +32,6 @@
 - [YeonCheolGit](https://github.com/YeonCheolGit)
 - [liuqiufeng](https://github.com/liuqiufeng)
 - [Bughue](https://github.com/Bughue)
+- [tanyaofei](https://github.com/tanyaofei)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXA.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXA.java
@@ -290,6 +290,7 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
     }
 
     private void cleanXABranchContext() {
+        xaEnded = false;
         branchRegisterTime = null;
         prepareTime = null;
         xaActive = false;
@@ -323,7 +324,6 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
         }
         // Force close the physical connection
         physicalConn.close();
-        xaEnded = false;
         rollBacked = false;
         cleanXABranchContext();
         originalConnection.close();


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
用来判断当前是否执行过 XA End 的上下文变量 `xaEnded` 应当在 `cleanXABranchContext` 中重置而不是在 `close` 中

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6492 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

