### PR TITLE
bugfix: Support serialization for dm.jdbc.driver.DmdbTimestamp (#6701)

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -20,6 +20,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6707](https://github.com/apache/incubator-seata/pull/6707)] fix readonly branch commit errors in Oracle XA transactions
 - [[#6711](https://github.com/apache/incubator-seata/pull/6711)] fix dameng rollback info un compress fail
 - [[#6714](https://github.com/apache/incubator-seata/pull/6714)] fix dameng delete undo fail
+- [[#6701](https://github.com/apache/incubator-seata/pull/6728)] fix support serialization for dm.jdbc.driver.DmdbTimestamp
 
 
 ### optimize:
@@ -72,6 +73,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [GoodBoyCoder](https://github.com/GoodBoyCoder)
 - [liuqiufeng](https://github.com/liuqiufeng)
 - [caohdgege](https://github.com/caohdgege)
+- [lyl2008dsg](https://github.com/lyl2008dsg)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -22,6 +22,7 @@
 - [[#6707](https://github.com/apache/incubator-seata/pull/6707)] 修复Oracle XA事务中只读分支提交出错的问题
 - [[#6711](https://github.com/apache/incubator-seata/pull/6711)] 修复达梦数据库的getRollbackInfo没有解压缩的问题
 - [[#6714](https://github.com/apache/incubator-seata/pull/6714)] 修复达梦数据库的delete sql回滚失败的问题
+- [[#6701](https://github.com/apache/incubator-seata/pull/6728)] 修复达梦数据库的对dm.jdbc.driver.DmdbTimestamp的支持
 
 ### optimize:
 - [[#6499](https://github.com/apache/incubator-seata/pull/6499)] 拆分 committing 和 rollbacking 状态的任务线程池
@@ -76,6 +77,7 @@
 - [GoodBoyCoder](https://github.com/GoodBoyCoder)
 - [liuqiufeng](https://github.com/liuqiufeng)
 - [caohdgege](https://github.com/caohdgege)
+- [lyl2008dsg](https://github.com/lyl2008dsg)
 
 
 

--- a/rm-datasource/pom.xml
+++ b/rm-datasource/pom.xml
@@ -132,5 +132,10 @@
             <artifactId>commons-logging</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.dameng</groupId>
+            <artifactId>DmJdbcDriver18</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/JacksonUndoLogParserTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/JacksonUndoLogParserTest.java
@@ -111,8 +111,6 @@ public class JacksonUndoLogParserTest extends BaseUndoLogParserTest {
 
     @Test
     public void testSerializeAndDeserializeDmdbTimestamp() throws NoSuchFieldException, IllegalAccessException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IOException {
-        Assumptions.assumeTrue(checkClassExists("dm.jdbc.driver.DmdbTimestamp"), "DmdbTimestamp class not found, skipping tests.");
-
         java.lang.reflect.Field reflectField = parser.getClass().getDeclaredField("mapper");
         reflectField.setAccessible(true);
         ObjectMapper mapper = (ObjectMapper)reflectField.get(parser);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
This pull request introduces support for serialization and deserialization of the dm.jdbc.driver.DmdbTimestamp class. The changes ensure that environments lacking the DM JDBC driver do not encounter errors or unnecessary logging.

Changes Made

1. Conditional Registration of Serializers and Deserializers:
* Added logic to register serializers and deserializers for dm.jdbc.driver.DmdbTimestamp only if the class is present in the classpath.
* This avoids issues in environments where the DM JDBC driver is not available.

2. Error Handling:
* No error logs are recorded if the dm.jdbc.driver.DmdbTimestamp class is not found.
* This is to prevent confusion for users who do not have the DM JDBC driver installed.




### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/apache/incubator-seata/issues/6701

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

