### PR TITLE
bugfix: Enhance 401 Error Handling by Refreshing Token in acquireClusterMetaData Method

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -12,6 +12,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6899](https://github.com/apache/incubator-seata/pull/6899)] fix file.conf read failed after package
 - [[#6890](https://github.com/apache/incubator-seata/pull/6890)] fix designerJson to standardJson: subStateMachine compensateState cannot be recognized
 - [[#6907](https://github.com/apache/incubator-seata/pull/6907)] fix the issue of Codecov not generating reports
+- [[#6923](https://github.com/apache/incubator-seata/pull/6923)] Enhance 401 Error Handling by Refreshing Token
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] remove the branch registration operation of the XA read-only transaction
@@ -52,6 +53,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [dsomehan](https://github.com/dsomehan)
 - [psxjoy](https://github.com/psxjoy)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [o-jimin](https://github.com/o-jimin)
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -12,6 +12,7 @@
 - [[#6899](https://github.com/apache/incubator-seata/pull/6899)] 修复file.conf打包后的读取
 - [[#6890](https://github.com/apache/incubator-seata/pull/6890)] 修复saga设计json转标准json过程中: 子状态机补偿节点无法被识别
 - [[#6907](https://github.com/apache/incubator-seata/pull/6907)] 修复Codecov未生成报告的问题
+- [[#6923](https://github.com/apache/incubator-seata/pull/6923)] 增强 401 错误处理，通过刷新令牌
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] 移除只读XA事务的分支注册操作
@@ -54,6 +55,7 @@
 - [dsomehan](https://github.com/dsomehan)
 - [psxjoy](https://github.com/psxjoy)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [o-jimin](https://github.com/o-jimin)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。
 

--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -381,8 +381,8 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
                     if (statusCode == HttpStatus.SC_OK) {
                         response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
                     } else if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
-                        refreshToken(tcAddress);
                         if (StringUtils.isNotBlank(USERNAME) && StringUtils.isNotBlank(PASSWORD)) {
+                            refreshToken(tcAddress);
                             throw new RetryableException("Token refreshed, retrying request.");
                         } else {
                             throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");

--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -377,14 +377,23 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
             try (CloseableHttpResponse httpResponse =
                 HttpClientUtil.doGet("http://" + tcAddress + "/metadata/v1/cluster", param, header, 1000)) {
                 if (httpResponse != null) {
-                    if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                    int statusCode = httpResponse.getStatusLine().getStatusCode();
+                    if (statusCode == HttpStatus.SC_OK) {
                         response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
-                    } else if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED) {
-                        if (StringUtils.isNotBlank(USERNAME) && StringUtils.isNotBlank(PASSWORD)) {
-                            throw new RetryableException("Authentication failed!");
+                    } else if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
+                        refreshToken(tcAddress);
+
+                        header.put(AUTHORIZATION_HEADER, jwtToken);
+                        httpResponse = HttpClientUtil.doGet("http://" + tcAddress + "/metadata/v1/cluster", param, header, 1000);
+                        statusCode = httpResponse.getStatusLine().getStatusCode();
+
+                        if (statusCode == HttpStatus.SC_OK) {
+                            response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
                         } else {
                             throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
                         }
+                    } else {
+                        throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
                     }
                 }
                 MetadataResponse metadataResponse;

--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -382,16 +382,7 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
                         response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
                     } else if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
                         refreshToken(tcAddress);
-
-                        header.put(AUTHORIZATION_HEADER, jwtToken);
-                        httpResponse = HttpClientUtil.doGet("http://" + tcAddress + "/metadata/v1/cluster", param, header, 1000);
-                        statusCode = httpResponse.getStatusLine().getStatusCode();
-
-                        if (statusCode == HttpStatus.SC_OK) {
-                            response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
-                        } else {
-                            throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
-                        }
+                        throw new RetryableException("Token refreshed, retrying request.");
                     } else {
                         throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
                     }

--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -382,7 +382,11 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
                         response = EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);
                     } else if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
                         refreshToken(tcAddress);
-                        throw new RetryableException("Token refreshed, retrying request.");
+                        if (StringUtils.isNotBlank(USERNAME) && StringUtils.isNotBlank(PASSWORD)) {
+                            throw new RetryableException("Token refreshed, retrying request.");
+                        } else {
+                            throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
+                        }
                     } else {
                         throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
                     }


### PR DESCRIPTION
…thod

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
This pull request modifies the acquireClusterMetaData method in the RaftRegistryServiceImpl class to improve the handling of 401 Unauthorized errors. When a 401 error occurs during metadata retrieval, the code now attempts to refresh the authentication token and retry the request with the new token. This enhancement ensures that the application can recover from token expiration without manual intervention, thus improving user experience and system reliability.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6919 


