### PR TITLE
bugfix: resolve issue in Raft model a follower's crash may lead to the continued use of expired tokens

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -53,6 +53,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [dsomehan](https://github.com/dsomehan)
 - [psxjoy](https://github.com/psxjoy)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [lixingjia77](https://github.com/lixingjia77)
 
 
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -12,6 +12,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6899](https://github.com/apache/incubator-seata/pull/6899)] fix file.conf read failed after package
 - [[#6890](https://github.com/apache/incubator-seata/pull/6890)] fix designerJson to standardJson: subStateMachine compensateState cannot be recognized
 - [[#6907](https://github.com/apache/incubator-seata/pull/6907)] fix the issue of Codecov not generating reports
+- [[#6925](https://github.com/apache/incubator-seata/pull/6925)] fix the issue in Raft model a follower's crash may lead to the continued use of expired tokens
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] remove the branch registration operation of the XA read-only transaction

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -55,6 +55,7 @@
 - [dsomehan](https://github.com/dsomehan)
 - [psxjoy](https://github.com/psxjoy)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [lixingjia77](https://github.com/lixingjia77)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -12,6 +12,7 @@
 - [[#6899](https://github.com/apache/incubator-seata/pull/6899)] 修复file.conf打包后的读取
 - [[#6890](https://github.com/apache/incubator-seata/pull/6890)] 修复saga设计json转标准json过程中: 子状态机补偿节点无法被识别
 - [[#6907](https://github.com/apache/incubator-seata/pull/6907)] 修复Codecov未生成报告的问题
+- [[#6925](https://github.com/apache/incubator-seata/pull/6925)] 修复Raft模式下，Follower崩溃可能导致Client继续使用过期令牌的问题
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] 移除只读XA事务的分支注册操作

--- a/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
+++ b/discovery/seata-discovery-raft/src/main/java/org/apache/seata/discovery/registry/raft/RaftRegistryServiceImpl.java
@@ -414,7 +414,6 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
         Map<String, String> header = new HashMap<>();
         header.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
         String response = null;
-        tokenTimeStamp = System.currentTimeMillis();
         try (CloseableHttpResponse httpResponse =
             HttpClientUtil.doPost("http://" + tcAddress + "/api/v1/auth/login", param, header, 1000)) {
             if (httpResponse != null) {
@@ -427,6 +426,7 @@ public class RaftRegistryServiceImpl implements RegistryService<ConfigChangeList
                         throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");
                     }
                     jwtToken = jsonNode.get("data").asText();
+                    tokenTimeStamp = System.currentTimeMillis();
                 } else {
                     //authorized failed,throw exception to kill process
                     throw new AuthenticationFailedException("Authentication failed! you should configure the correct username and password.");


### PR DESCRIPTION
… client to continued use of expired tokens

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

解决raft模式下，follower崩溃可能导致client继续使用过期令牌的问题
resolve issue in Raft model where follower crashes could lead client to continued use of expired tokens


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #6917

In RaftRegistryServiceImpl#refreshToken, the tokenTimeStamp is updated before the request to obtain the token is sent, and there is no check for whether the HTTP status is normal.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

