### PR TITLE
bugfix: Lock contention failure in file & Raft mode did not exit

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -14,6 +14,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6907](https://github.com/apache/incubator-seata/pull/6907)] fix the issue of Codecov not generating reports
 - [[#6923](https://github.com/apache/incubator-seata/pull/6923)] Enhance 401 Error Handling by Refreshing Token
 - [[#6925](https://github.com/apache/incubator-seata/pull/6925)] fix the issue in Raft model a follower's crash may lead to the continued use of expired tokens
+- [[#6932](https://github.com/apache/incubator-seata/pull/6932)] when enabling local transactions, the lock contention failure in file & raft mode does not exit, leading to a lingering lock
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] remove the branch registration operation of the XA read-only transaction

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -14,6 +14,7 @@
 - [[#6907](https://github.com/apache/incubator-seata/pull/6907)] 修复Codecov未生成报告的问题
 - [[#6923](https://github.com/apache/incubator-seata/pull/6923)] 增强 401 错误处理，通过刷新令牌
 - [[#6925](https://github.com/apache/incubator-seata/pull/6925)] 修复Raft模式下，Follower崩溃可能导致Client继续使用过期令牌的问题
+- [[#6932](https://github.com/apache/incubator-seata/pull/6932)] 修复开启本地事务时file&raft模式下锁争抢失败未退出导致可能出现残留锁
 
 
 ### optimize:

--- a/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLocker.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLocker.java
@@ -108,12 +108,8 @@ public class FileLocker extends AbstractLocker {
                     failFast = true;
                     break;
                 }
-                if (canLock) {
-                    canLock = false;
-                    if (autoCommit) {
-                        break;
-                    }
-                }
+                canLock = false;
+                break;
             }
         }
         if (failFast) {


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
when enabling local transactions, the lock contention failure in file & raft mode does not exit, leading to a lingering lock

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

