### PR TITLE
optimize: remove JVM parameter app.id

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -34,7 +34,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6911](https://github.com/apache/incubator-seata/pull/6911)] fix some typos in project
 - [[#6918](https://github.com/apache/incubator-seata/pull/6918)] Use the openjdk image of eclipse-temurin as the base image
 - [[#6938](https://github.com/apache/incubator-seata/pull/6938)] Update online chat information in README.md 
-
+- [[#6950](https://github.com/apache/incubator-seata/pull/6950)] Remove JVM parameter app.id
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -36,6 +36,7 @@
 - [[#6911](https://github.com/apache/incubator-seata/pull/6911)] 修正项目中的部分拼写错误
 - [[#6918](https://github.com/apache/incubator-seata/pull/6918)] 使用eclipse-temurin的openjdk镜像作为基础镜像
 - [[#6938](https://github.com/apache/incubator-seata/pull/6938)] 更新 README.md 中的社区联系信息
+- [[#6950](https://github.com/apache/incubator-seata/pull/6950)] 移除JVM参数app.id
 
 ### refactor:
 

--- a/distribution/bin/seata-setup.sh
+++ b/distribution/bin/seata-setup.sh
@@ -150,7 +150,7 @@ else
 fi
 
 JAVA_OPT="${JAVA_OPT} -Dio.netty.leakDetectionLevel=advanced"
-JAVA_OPT="${JAVA_OPT} -Dapp.name=seata-server -Dapp.pid=${$} -Dapp.home=${BASEDIR} -Dbasedir=${BASEDIR}"
+JAVA_OPT="${JAVA_OPT} -Dapp.name=seata-server -Dapp.home=${BASEDIR} -Dbasedir=${BASEDIR}"
 
 if [ "$JMX_ENABLE" = "true" ]; then
   JMX_PORT=$JMX_PORT


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
The pid passed in by -Dapp.pid=${$} is actually the pid of seata-server.sh, not the java process id of seata-server; at the same time, it is impossible to get the pid of the current java process when starting seata-server, so remove it.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #5692

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

