### PR TITLE
bugfix: support building docker image on openjdk23

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -120,7 +120,7 @@
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
         <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
-        <jib-maven-plugin.version>3.2.0</jib-maven-plugin.version>
+        <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
         <!-- Deploy && GPG -->

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -21,6 +21,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6943](https://github.com/apache/incubator-seata/pull/6943)] fix the conversion error for `convertBranchSession` in concurrent environment.
 - [[#6948](https://github.com/apache/incubator-seata/pull/6948)] Fix the CI build issue on the ARM64 platform
 - [[#6947](https://github.com/apache/incubator-seata/pull/6947)] fix npe for nacos registry when look up address
+- [[#6984](https://github.com/apache/incubator-seata/pull/6984)] support building docker image on openjdk23
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] remove the branch registration operation of the XA read-only transaction
@@ -40,6 +41,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6938](https://github.com/apache/incubator-seata/pull/6938)] Update online chat information in README.md 
 - [[#6950](https://github.com/apache/incubator-seata/pull/6950)] Remove JVM parameter app.id
 - [[#6959](https://github.com/apache/incubator-seata/pull/6959)] update the naming and description for the `seata-http-jakarta` module
+
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -21,6 +21,7 @@
 - [[#6943](https://github.com/apache/incubator-seata/pull/6943)] 修复并发状态下 `convertBranchSession` 转换报错问题
 - [[#6948](https://github.com/apache/incubator-seata/pull/6948)] 修复在ARM64平台下CI构建出错的问题
 - [[#6947](https://github.com/apache/incubator-seata/pull/6947)] 修复nacos注册中心查询可用地址时的空指针问题
+- [[#6984](https://github.com/apache/incubator-seata/pull/6984)] 修复 openjdk23 版本下无法构建 docker 镜像的问题
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] 移除只读XA事务的分支注册操作


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Support building Seata Server Docker Image on OpenJDK23.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
resolve #6965 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Not applicable.

### Ⅳ. Describe how to verify it
1. Start with a minimal Docker image. 
2. Install Git, Maven, SDKMAN, and other necessary tools. 
3. Run the commands specified in the issue. 
```BASH
sdk install java 23-open
sdk use java 23-open
git clone git@github.com:apache/incubator-seata.git
cd ./incubator-seata/
./mvnw -T 4C clean package -Dimage.name=eclipse-temurin:21.0.4_7-jdk       -Pimage,release-image-based-on-java21      -DskipTests -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
```
4. when package finished ,we can see a new seata-server image.

-----
1. 启动一个空白的docker镜像；
2. 安装 git, maven, sdkman 和其他工具；
3. 按照issue中的操作执行命令；
4. maven 构建完成，得到一个新的 seata-server 镜像。
### Ⅴ. Special notes for reviews
Since there’s no key for `apache/seata-server` on Docker Hub, I had to verify it using my own image. You can view the built `seata-server` image via [this link](https://hub.docker.com/r/psxjoy/seata-server/tags).

因为没有apache/seata-server 在dockerhub上的密钥。因此我只能通过自己的账号进行验证。可以通过[这个链接](https://hub.docker.com/r/psxjoy/seata-server/tags) 来查看构建完成的seata-server镜像。

There are other possible fixes, but I believe upgrading the version is the best approach. According to the [Jib official announcement](https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/CHANGELOG.md#added-1), this issue was addressed in version 3.3.0.

事实上还有其他的修复方式。但我认为升级版本是最好的解决方法。根据 [jib官方公告](https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/CHANGELOG.md#added-1)中的宣称，它们在3.3.0版本中支持了该问题。


