### PR TITLE
bugfix: fix the problem of building undoLog exception when update join does not update data

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -23,6 +23,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6948](https://github.com/apache/incubator-seata/pull/6948)] Fix the CI build issue on the ARM64 platform
 - [[#6947](https://github.com/apache/incubator-seata/pull/6947)] fix npe for nacos registry when look up address
 - [[#6984](https://github.com/apache/incubator-seata/pull/6984)] support building docker image on openjdk23
+- [[#6994](https://github.com/apache/incubator-seata/pull/6994)] fix the problem of building undoLog exception when update join does not update data
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] remove the branch registration operation of the XA read-only transaction

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -23,6 +23,8 @@
 - [[#6948](https://github.com/apache/incubator-seata/pull/6948)] 修复在ARM64平台下CI构建出错的问题
 - [[#6947](https://github.com/apache/incubator-seata/pull/6947)] 修复nacos注册中心查询可用地址时的空指针问题
 - [[#6984](https://github.com/apache/incubator-seata/pull/6984)] 修复 openjdk23 版本下无法构建 docker 镜像的问题
+- [[#6994](https://github.com/apache/incubator-seata/pull/6994)] 修复updateJoin语句未更新到数据时prepareUndoLog异常
+
 
 ### optimize:
 - [[#6826](https://github.com/apache/incubator-seata/pull/6826)] 移除只读XA事务的分支注册操作


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
If the before and agter images are both empty, skip prepareUndoLog directly

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6976 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
make an updateJoin statement with an empty query result to test

### Ⅴ. Special notes for reviews

