### PR TITLE
optimize: When the number of primary keys exceeds 1000, use union to concatenate the SQL #6957

### DIFF
--- a/compatible/src/test/java/io/seata/rm/datasource/mock/MockExecuteHandlerImpl.java
+++ b/compatible/src/test/java/io/seata/rm/datasource/mock/MockExecuteHandlerImpl.java
@@ -71,7 +71,7 @@ public class MockExecuteHandlerImpl implements MockExecuteHandler {
         List<Object[]> metas = new ArrayList<>();
         if(asts.get(0) instanceof SQLSelectStatement) {
             SQLSelectStatement ast = (SQLSelectStatement) asts.get(0);
-            SQLSelectQueryBlock queryBlock = ast.getSelect().getQueryBlock();
+            SQLSelectQueryBlock queryBlock = ast.getSelect().getFirstQueryBlock();
             String tableName = "";
             if (queryBlock.getFrom() instanceof SQLExprTableSource) {
                 MySQLSelectForUpdateRecognizer recognizer = new MySQLSelectForUpdateRecognizer(sql, ast);

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutor.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutor.java
@@ -520,16 +520,17 @@ public abstract class BaseTransactionalExecutor<T, S extends Statement> implemen
         // build check sql
         String firstKey = pkValuesMap.keySet().stream().findFirst().get();
         int rowSize = pkValuesMap.get(firstKey).size();
-        suffix.append(WHERE).append(SqlGenerateUtils.buildWhereConditionByPKs(pkColumnNameList, rowSize, getDbType()));
+        suffix.append(WHERE);
         StringJoiner selectSQLJoin = new StringJoiner(", ", prefix, suffix.toString());
         List<String> insertColumnsUnEscape = recognizer.getInsertColumnsUnEscape();
         List<String> needColumns =
             getNeedColumns(tableMeta.getTableName(), sqlRecognizer.getTableAlias(), insertColumnsUnEscape);
         needColumns.forEach(selectSQLJoin::add);
         PreparedStatement ps = null;
+        String sqlStr = SqlGenerateUtils.buildSQLByPKs(selectSQLJoin.toString(), "", pkColumnNameList, rowSize, getDbType());
         ResultSet rs = null;
         try {
-            ps = statementProxy.getConnection().prepareStatement(selectSQLJoin.toString());
+            ps = statementProxy.getConnection().prepareStatement(sqlStr);
             int paramIndex = 1;
             for (int r = 0; r < rowSize; r++) {
                 for (int c = 0; c < pkColumnNameList.size(); c++) {

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/MultiUpdateExecutor.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/MultiUpdateExecutor.java
@@ -147,9 +147,8 @@ public class MultiUpdateExecutor<T, S extends Statement> extends AbstractDMLBase
             SQLUpdateRecognizer sqlUpdateRecognizer = (SQLUpdateRecognizer) sqlRecognizer;
             updateColumnsSet.addAll(sqlUpdateRecognizer.getUpdateColumnsUnEscape());
         }
-        StringBuilder prefix = new StringBuilder("SELECT ");
-        String suffix = " FROM " + getFromTableInSQL() + " WHERE " + SqlGenerateUtils.buildWhereConditionByPKs(tableMeta.getPrimaryKeyOnlyName(), beforeImage.pkRows().size(), getDbType());
-        StringJoiner selectSQLJoiner = new StringJoiner(", ", prefix.toString(), suffix);
+        StringJoiner selectSQLJoiner = new StringJoiner(", ", "SELECT ",
+                " FROM " + getFromTableInSQL() + " WHERE ");
         if (ONLY_CARE_UPDATE_COLUMNS) {
             if (!containsPK(new ArrayList<>(updateColumnsSet))) {
                 selectSQLJoiner.add(getColumnNamesInSQL(tableMeta.getEscapePkNameList(getDbType())));
@@ -162,7 +161,7 @@ public class MultiUpdateExecutor<T, S extends Statement> extends AbstractDMLBase
                 selectSQLJoiner.add(ColumnUtils.addEscape(columnName, getDbType()));
             }
         }
-        return selectSQLJoiner.toString();
+        return SqlGenerateUtils.buildSQLByPKs(selectSQLJoiner.toString(), "", tableMeta.getPrimaryKeyOnlyName(), beforeImage.pkRows().size(), getDbType());
     }
 
     protected String buildSuffixSql(String whereCondition) {

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/UpdateExecutor.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/UpdateExecutor.java
@@ -113,14 +113,12 @@ public class UpdateExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
     }
 
     private String buildAfterImageSQL(TableMeta tableMeta, TableRecords beforeImage) throws SQLException {
-        String prefix = "SELECT ";
-        String whereSql = SqlGenerateUtils.buildWhereConditionByPKs(tableMeta.getPrimaryKeyOnlyName(), beforeImage.pkRows().size(), getDbType());
-        String suffix = " FROM " + getFromTableInSQL() + " WHERE " + whereSql;
-        StringJoiner selectSQLJoiner = new StringJoiner(", ", prefix, suffix);
+        StringJoiner selectSQLJoiner = new StringJoiner(", ", "SELECT "
+                , " FROM " + getFromTableInSQL() + " WHERE ");
         SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) sqlRecognizer;
         List<String> needUpdateColumns = getNeedColumns(tableMeta.getTableName(), sqlRecognizer.getTableAlias(), recognizer.getUpdateColumnsUnEscape());
         needUpdateColumns.forEach(selectSQLJoiner::add);
-        return selectSQLJoiner.toString();
+        return SqlGenerateUtils.buildSQLByPKs(selectSQLJoiner.toString(), "", tableMeta.getPrimaryKeyOnlyName(), beforeImage.pkRows().size(), getDbType());
     }
 
 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/mysql/MySQLUpdateJoinExecutor.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/mysql/MySQLUpdateJoinExecutor.java
@@ -199,18 +199,12 @@ public class MySQLUpdateJoinExecutor<T, S extends Statement> extends UpdateExecu
         TableRecords beforeImage) throws SQLException {
         SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) sqlRecognizer;
         TableMeta itemTableMeta = getTableMeta(itemTable);
-        StringBuilder prefix = new StringBuilder("SELECT ");
         List<String> pkColumns = getColumnNamesWithTablePrefixList(itemTable, recognizer.getTableAlias(itemTable), itemTableMeta.getPrimaryKeyOnlyName());
-        String whereSql = SqlGenerateUtils.buildWhereConditionByPKs(pkColumns, beforeImage.pkRows().size(), getDbType());
-        String suffix = " FROM " + joinTable + " WHERE " + whereSql;
-        //maybe duplicate row for select join sql.remove duplicate row by 'group by' condition
-        suffix += GROUP_BY;
         List<String> itemTableUpdateColumns = getItemUpdateColumns(itemTableMeta, recognizer.getUpdateColumns());
         List<String> needUpdateColumns = getNeedColumns(itemTable, recognizer.getTableAlias(itemTable), itemTableUpdateColumns);
-        suffix += buildGroupBy(pkColumns, needUpdateColumns);
-        StringJoiner selectSQLJoiner = new StringJoiner(", ", prefix.toString(), suffix);
+        StringJoiner selectSQLJoiner = new StringJoiner(", ", "SELECT ", " FROM " + joinTable + " WHERE ");
         needUpdateColumns.forEach(selectSQLJoiner::add);
-        return selectSQLJoiner.toString();
+        return SqlGenerateUtils.buildSQLByPKs(selectSQLJoiner.toString(), GROUP_BY + buildGroupBy(pkColumns, needUpdateColumns), pkColumns, beforeImage.pkRows().size(), getDbType());
     }
 
     private List<String> getItemUpdateColumns(TableMeta itemTableMeta, List<String> updateColumns) {

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/SqlGenerateUtilsTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/SqlGenerateUtilsTest.java
@@ -16,28 +16,49 @@
  */
 package org.apache.seata.rm.datasource;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.seata.rm.datasource.SqlGenerateUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
 
 
 class SqlGenerateUtilsTest {
 
 
     @Test
-    void testBuildWhereConditionByPKs() throws SQLException {
-        List<String> pkNameList=new ArrayList<>();
+    void testBuildWhereConditionListByPKs() {
+        List<String> pkNameList = new ArrayList<>();
         pkNameList.add("id");
         pkNameList.add("name");
-        String result = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList,4,"mysql",2);
-        Assertions.assertEquals("(id,name) in ( (?,?),(?,?) ) or (id,name) in ( (?,?),(?,?) )", result);
-        result = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList,5,"mysql",2);
-        Assertions.assertEquals("(id,name) in ( (?,?),(?,?) ) or (id,name) in ( (?,?),(?,?) ) or (id,name) in ( (?,?)"
-                + " )",
-            result);
+        List<SqlGenerateUtils.WhereSql> results1 = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, 4, "mysql", 2);
+        Assertions.assertEquals(2, results1.size());
+        results1.forEach(result -> {
+            Assertions.assertEquals("(id,name) in ( (?,?),(?,?) )", result.getSql());
+            Assertions.assertEquals(2, result.getRowSize());
+            Assertions.assertEquals(2, result.getPkSize());
+        });
+        List<SqlGenerateUtils.WhereSql> results2 = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, 5, "mysql", 2);
+        Assertions.assertEquals(3, results2.size());
+        Assertions.assertEquals("(id,name) in ( (?,?),(?,?) )", results2.get(0).getSql());
+        Assertions.assertEquals(2, results2.get(0).getRowSize());
+        Assertions.assertEquals(2, results2.get(0).getPkSize());
+        Assertions.assertEquals("(id,name) in ( (?,?),(?,?) )", results2.get(1).getSql());
+        Assertions.assertEquals("(id,name) in ( (?,?) )", results2.get(2).getSql());
+        Assertions.assertEquals(1, results2.get(2).getRowSize());
+        Assertions.assertEquals(2, results2.get(2).getPkSize());
+    }
+
+    @Test
+    void testBuildSQLByPKs() {
+        String sqlPrefix = "select id,name from t_order where ";
+        List<String> pkNameList = new ArrayList<>();
+        pkNameList.add("id");
+        pkNameList.add("name");
+        List<SqlGenerateUtils.WhereSql> whereList = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, 4, "mysql", 2);
+        StringJoiner sqlJoiner = new StringJoiner(" union ");
+        whereList.forEach(whereSql -> sqlJoiner.add(sqlPrefix + " " + whereSql.getSql()));
+        Assertions.assertEquals("select id,name from t_order where  (id,name) in ( (?,?),(?,?) ) union select id,name from t_order where  (id,name) in ( (?,?),(?,?) )", sqlJoiner.toString());
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/UpdateJoinExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/UpdateJoinExecutorTest.java
@@ -32,7 +32,6 @@ import org.apache.seata.rm.datasource.ConnectionProxy;
 import org.apache.seata.rm.datasource.DataSourceProxy;
 import org.apache.seata.rm.datasource.DataSourceProxyTest;
 import org.apache.seata.rm.datasource.StatementProxy;
-import org.apache.seata.rm.datasource.exec.UpdateExecutor;
 import org.apache.seata.rm.datasource.exec.mysql.MySQLUpdateJoinExecutor;
 import org.apache.seata.rm.datasource.mock.MockDriver;
 import org.apache.seata.rm.datasource.sql.struct.TableRecords;
@@ -58,6 +57,7 @@ public class UpdateJoinExecutorTest {
         };
         Object[][] beforeReturnValue = new Object[][]{
                 new Object[]{1, "Tom"},
+                new Object[]{2, "Tony"},
         };
         StatementProxy beforeMockStatementProxy = mockStatementProxy(returnValueColumnLabels, beforeReturnValue, columnMetas, indexMetas);
         String sql = "update t1 inner join t2 on t1.id = t2.id set t1.name = 'WILL',t2.name = 'WILL'";
@@ -69,6 +69,7 @@ public class UpdateJoinExecutorTest {
         TableRecords beforeImage = mySQLUpdateJoinExecutor.beforeImage();
         Object[][] afterReturnValue = new Object[][]{
                 new Object[]{1, "WILL"},
+                new Object[]{2, "Tony"},
         };
         StatementProxy afterMockStatementProxy = mockStatementProxy(returnValueColumnLabels, afterReturnValue, columnMetas, indexMetas);
         mySQLUpdateJoinExecutor.statementProxy = afterMockStatementProxy;

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/mock/MockExecuteHandlerImpl.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/mock/MockExecuteHandlerImpl.java
@@ -70,7 +70,7 @@ public class MockExecuteHandlerImpl implements MockExecuteHandler {
         List<Object[]> metas = new ArrayList<>();
         if(asts.get(0) instanceof SQLSelectStatement) {
             SQLSelectStatement ast = (SQLSelectStatement) asts.get(0);
-            SQLSelectQueryBlock queryBlock = ast.getSelect().getQueryBlock();
+            SQLSelectQueryBlock queryBlock = ast.getSelect().getFirstQueryBlock();
             String tableName = "";
             if (queryBlock.getFrom() instanceof SQLExprTableSource) {
                 MySQLSelectForUpdateRecognizer recognizer = new MySQLSelectForUpdateRecognizer(sql, ast);

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/AbstractUndoExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/AbstractUndoExecutorTest.java
@@ -209,12 +209,12 @@ public class AbstractUndoExecutorTest extends BaseH2Test {
         pkRowValues.put("id1", pkId1Values);
         pkRowValues.put("id2", pkId2Values);
 
-        String sql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MYSQL);
-        Assertions.assertEquals("(id1,id2) in ( (?,?),(?,?),(?,?) )", sql);
-        sql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MARIADB);
-        Assertions.assertEquals("(id1,id2) in ( (?,?),(?,?),(?,?) )", sql);
-        sql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.POLARDBX);
-        Assertions.assertEquals("(id1,id2) in ( (?,?),(?,?),(?,?) )", sql);
+        List<SqlGenerateUtils.WhereSql> sql = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MYSQL, 1000);
+        Assertions.assertEquals("(id1,id2) in ( (?,?),(?,?),(?,?) )", sql.get(0).getSql());
+        sql = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MARIADB, 1000);
+        Assertions.assertEquals("(id1,id2) in ( (?,?),(?,?),(?,?) )", sql.get(0).getSql());
+        sql = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.POLARDBX, 1000);
+        Assertions.assertEquals("(id1,id2) in ( (?,?),(?,?),(?,?) )", sql.get(0).getSql());
     }
 
     @Test
@@ -227,12 +227,12 @@ public class AbstractUndoExecutorTest extends BaseH2Test {
         pkId1Values.add(new Field());
         pkRowValues.put("id1", pkId1Values);
 
-        String sql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MYSQL);
-        Assertions.assertEquals("(id1) in ( (?) )", sql);
-        sql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MARIADB);
-        Assertions.assertEquals("(id1) in ( (?) )", sql);
-        sql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.POLARDBX);
-        Assertions.assertEquals("(id1) in ( (?) )", sql);
+        List<SqlGenerateUtils.WhereSql> sql = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MYSQL);
+        Assertions.assertEquals("(id1) in ( (?) )", sql.get(0).getSql());
+        sql = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.MARIADB);
+        Assertions.assertEquals("(id1) in ( (?) )", sql.get(0).getSql());
+        sql = SqlGenerateUtils.buildWhereConditionListByPKs(pkNameList, pkRowValues.get("id1").size(), JdbcConstants.POLARDBX);
+        Assertions.assertEquals("(id1) in ( (?) )", sql.get(0).getSql());
     }
 }
 

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/dm/DmSelectForUpdateRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/dm/DmSelectForUpdateRecognizer.java
@@ -76,7 +76,7 @@ public class DmSelectForUpdateRecognizer extends BaseDmRecognizer implements SQL
         if (select == null) {
             throw new SQLParsingException("should never happen!");
         }
-        SQLSelectQueryBlock selectQueryBlock = select.getQueryBlock();
+        SQLSelectQueryBlock selectQueryBlock = select.getFirstQueryBlock();
         if (selectQueryBlock == null) {
             throw new SQLParsingException("should never happen!");
         }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/mysql/MySQLSelectForUpdateRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/mysql/MySQLSelectForUpdateRecognizer.java
@@ -102,7 +102,7 @@ public class MySQLSelectForUpdateRecognizer extends BaseMySQLRecognizer implemen
         if (select == null) {
             throw new SQLParsingException("should never happen!");
         }
-        SQLSelectQueryBlock selectQueryBlock = select.getQueryBlock();
+        SQLSelectQueryBlock selectQueryBlock = select.getFirstQueryBlock();
         if (selectQueryBlock == null) {
             throw new SQLParsingException("should never happen!");
         }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleSelectForUpdateRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleSelectForUpdateRecognizer.java
@@ -102,7 +102,7 @@ public class OracleSelectForUpdateRecognizer extends BaseOracleRecognizer implem
         if (select == null) {
             throw new SQLParsingException("should never happen!");
         }
-        SQLSelectQueryBlock selectQueryBlock = select.getQueryBlock();
+        SQLSelectQueryBlock selectQueryBlock = select.getFirstQueryBlock();
         if (selectQueryBlock == null) {
             throw new SQLParsingException("should never happen!");
         }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlSelectForUpdateRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlSelectForUpdateRecognizer.java
@@ -74,7 +74,7 @@ public class PostgresqlSelectForUpdateRecognizer extends BasePostgresqlRecognize
         if (select == null) {
             throw new SQLParsingException("should never happen!");
         }
-        SQLSelectQueryBlock selectQueryBlock = select.getQueryBlock();
+        SQLSelectQueryBlock selectQueryBlock = select.getFirstQueryBlock();
         if (selectQueryBlock == null) {
             throw new SQLParsingException("should never happen!");
         }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/sqlserver/SqlServerOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/sqlserver/SqlServerOperateRecognizerHolder.java
@@ -55,7 +55,7 @@ public class SqlServerOperateRecognizerHolder implements SQLOperateRecognizerHol
 
     @Override
     public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast) {
-        List<SQLHint> hints = ((SQLSelectStatement) ast).getSelect().getQueryBlock().getFrom().getHints();
+        List<SQLHint> hints = ((SQLSelectStatement) ast).getSelect().getFirstQueryBlock().getFrom().getHints();
         if (CollectionUtils.isNotEmpty(hints)) {
             List<String> hintsTexts = hints
                     .stream()


### PR DESCRIPTION
…oncatenate the SQL (#6957)

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
When the number of primary keys exceeds 1000, use union to concatenate the SQL

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6957 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

sql生成有测试用例：
io.seata.rm.datasource.SqlGenerateUtilsTest
此测试类之前已经存在，此次在此基础上进行了修改

其它受影响的地方依赖其它已有测试用例，由于该问题的触发场景比较极端，必须要超过1000个主键，并且该1000的配置是private的，有部分场景没看到之前有编写超过1000时的测试用例，本地通过修改配置值进行了单元测试，不确定集成测试是否有此场景的测试。

### Ⅴ. Special notes for reviews

1、io.seata.rm.datasource.undo.AbstractUndoExecutor#queryCurrentRecords 该方法是使用了`For Update`，之前是一条sql一次性执行完，当主键数量超过1000时现在会拆分成多条sql循环执行，每条执行会有间隔，如果有同样的数据重复处理，并且是不同事务的，可能会导致死锁。

2、由于sql采用了union拼接，影响到了`SQLSelectQueryBlock`的获取，因此在`*SelectForUpdateRecognizer`此种类中，如`io.seata.sqlparser.druid.mysql.MySQLSelectForUpdateRecognizer#getSelect`，修改了获取方式，是否有可能造成影响。
