### PR TITLE
optimize: raft mode maintains the reload logic consistent with the file

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -52,6 +52,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#6995](https://github.com/apache/incubator-seata/pull/6995)] upgrade outdate npmjs dependencies
 - [[#6996](https://github.com/apache/incubator-seata/pull/6996)] optimize lock release logic in AT transaction mode
 - [[#7023](https://github.com/apache/incubator-seata/pull/7023)] optimize fail fast, when all server not available
+- [[#7027](https://github.com/apache/incubator-seata/pull/7027)] raft mode maintains the reload logic consistent with the file
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -55,6 +55,7 @@
 - [[#6995](https://github.com/apache/incubator-seata/pull/6995)] 升级过时的 npmjs 依赖
 - [[#6996](https://github.com/apache/incubator-seata/pull/6996)] 优化 AT 事务模式锁释放逻辑
 - [[#7023](https://github.com/apache/incubator-seata/pull/7023)] 优化快速失败
+- [[#7027](https://github.com/apache/incubator-seata/pull/7027)] raft模式下reload行为于file保持一致
 
 ### refactor:
 

--- a/server/src/main/java/org/apache/seata/server/storage/file/session/FileSessionManager.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/session/FileSessionManager.java
@@ -66,7 +66,7 @@ public class FileSessionManager extends AbstractSessionManager implements Reload
     /**
      * The Session map.
      */
-    private Map<String, GlobalSession> sessionMap = new ConcurrentHashMap<>(64);
+    protected Map<String, GlobalSession> sessionMap = new ConcurrentHashMap<>(64);
 
 
     /**

--- a/server/src/main/java/org/apache/seata/server/storage/raft/session/RaftSessionManager.java
+++ b/server/src/main/java/org/apache/seata/server/storage/raft/session/RaftSessionManager.java
@@ -17,10 +17,12 @@
 package org.apache.seata.server.storage.raft.session;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import com.alipay.sofa.jraft.Closure;
 import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.common.loader.Scope;
+import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.exception.TransactionExceptionCode;
 import org.apache.seata.core.model.BranchStatus;
@@ -80,7 +82,7 @@ public class RaftSessionManager extends FileSessionManager {
                             "seata raft state machine exception: " + status.getErrorMsg()));
                 } finally {
                     try {
-                        super.removeGlobalSession(globalSession);
+                        removeGlobalSession(globalSession);
                     } catch (TransactionException e) {
                         completableFuture.completeExceptionally(e);
                     }
@@ -91,6 +93,19 @@ public class RaftSessionManager extends FileSessionManager {
         SessionConverter.convertGlobalTransactionDO(globalTransactionDTO, globalSession);
         RaftGlobalSessionSyncMsg raftSyncMsg = new RaftGlobalSessionSyncMsg(ADD_GLOBAL_SESSION, globalTransactionDTO);
         RaftTaskUtil.createTask(closure, raftSyncMsg, completableFuture);
+    }
+
+    @Override
+    public void removeGlobalSession(GlobalSession session) throws TransactionException {
+        GlobalSession globalSession = sessionMap.remove(session.getXid());
+        if (globalSession != null) {
+            List<BranchSession> branchSessionList = globalSession.getBranchSessions();
+            if (CollectionUtils.isNotEmpty(branchSessionList)) {
+                for (BranchSession branchSession : branchSessionList) {
+                    branchSession.unlock();
+                }
+            }
+        }
     }
 
     @Override
@@ -191,7 +206,7 @@ public class RaftSessionManager extends FileSessionManager {
         Closure closure = status -> {
             if (status.isOk()) {
                 try {
-                    super.removeGlobalSession(globalSession);
+                    removeGlobalSession(globalSession);
                     completableFuture.complete(true);
                 } catch (TransactionException e) {
                     completableFuture.completeExceptionally(e);

--- a/server/src/main/java/org/apache/seata/server/storage/raft/session/RaftSessionManager.java
+++ b/server/src/main/java/org/apache/seata/server/storage/raft/session/RaftSessionManager.java
@@ -100,10 +100,14 @@ public class RaftSessionManager extends FileSessionManager {
         GlobalSession globalSession = sessionMap.remove(session.getXid());
         if (globalSession != null) {
             List<BranchSession> branchSessionList = globalSession.getBranchSessions();
+            // For the follower, the following code will not be executed because when the follower receives the remove global session
+            // the branch session on the leader side has already been completely cleared.
             if (CollectionUtils.isNotEmpty(branchSessionList)) {
                 for (BranchSession branchSession : branchSessionList) {
                     branchSession.unlock();
+                    onRemoveBranch(globalSession, branchSession);
                 }
+                end(globalSession);
             }
         }
     }
@@ -202,6 +206,10 @@ public class RaftSessionManager extends FileSessionManager {
 
     @Override
     public void onSuccessEnd(GlobalSession globalSession) throws TransactionException {
+        end(globalSession);
+    }
+
+    public void end(GlobalSession globalSession) throws TransactionException {
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
         Closure closure = status -> {
             if (status.isOk()) {

--- a/server/src/test/java/org/apache/seata/server/raft/execute/BranchSessionExecuteTest.java
+++ b/server/src/test/java/org/apache/seata/server/raft/execute/BranchSessionExecuteTest.java
@@ -102,7 +102,7 @@ class BranchSessionExecuteTest {
             boolean success = execute.execute(convertToBranchSessionMsg(branchSession));
             Assertions.assertTrue(success);
 
-            branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
+            branchSession = GLOBAL_SESSION.getBranch(branchSession.getBranchId());
             Assertions.assertNull(branchSession);
         }
     }

--- a/server/src/test/java/org/apache/seata/server/raft/execute/BranchSessionExecuteTest.java
+++ b/server/src/test/java/org/apache/seata/server/raft/execute/BranchSessionExecuteTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.seata.server.raft.execute;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.seata.common.XID;
 import org.apache.seata.common.util.NetUtil;
+import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchStatus;
@@ -33,10 +37,8 @@ import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.storage.SessionConverter;
 import org.apache.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
@@ -51,8 +53,6 @@ class BranchSessionExecuteTest {
 
     private static GlobalSession GLOBAL_SESSION;
 
-    private static final String XID = "123:123";
-
     private static final long BRANCH_ID = 0L;
 
     @BeforeAll
@@ -61,10 +61,14 @@ class BranchSessionExecuteTest {
         SessionHolder.init(StoreConfig.SessionMode.RAFT);
         LockerManagerFactory.destroy();
         LockerManagerFactory.init(StoreConfig.LockMode.RAFT);
+        GLOBAL_SESSION = mockGlobalSession();
+        SessionHolder.getRootSessionManager().addGlobalSession(GLOBAL_SESSION);
     }
 
     @AfterAll
-    public static void destroy() throws TransactionException {
+    public static void destroy() throws Throwable {
+        testRemove();
+        SessionHolder.getRootSessionManager().removeGlobalSession(GLOBAL_SESSION);
         // Clear configuration
         ConfigurationCache.clear();
         System.clearProperty("server.raft.serverAddr");
@@ -75,75 +79,66 @@ class BranchSessionExecuteTest {
         LockerManagerFactory.destroy();
     }
 
-    @BeforeEach
-    public void addGlobalSession() throws TransactionException {
-        GLOBAL_SESSION = mockGlobalSession();
-        SessionHolder.getRootSessionManager().addGlobalSession(GLOBAL_SESSION);
-    }
 
-    @AfterEach
-    public void removeTestSession() throws TransactionException {
-        SessionHolder.getRootSessionManager().removeGlobalSession(GLOBAL_SESSION);
-    }
 
     @Test
     public void testAdd() throws Throwable {
-        BranchSession expected = mockBranchSession();
+        BranchSession expected = mockBranchSession(GLOBAL_SESSION.getXid(), GLOBAL_SESSION.getTransactionId());
 
         AddBranchSessionExecute execute = new AddBranchSessionExecute();
         boolean success = execute.execute(convertToBranchSessionMsg(expected));
         Assertions.assertTrue(success);
 
-        BranchSession branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
+        BranchSession branchSession = GLOBAL_SESSION.getBranch(expected.getBranchId());
         assertBranchSessionValid(expected, branchSession);
     }
 
-    @Test
-    public void testRemove() throws Throwable {
-        GLOBAL_SESSION.add(mockBranchSession());
+    public static void testRemove() throws Throwable {
+        List<BranchSession> list = new ArrayList<>(GLOBAL_SESSION.getBranchSessions());
+        for (BranchSession branchSession : list) {
+            Assertions.assertNotNull(branchSession);
 
-        BranchSession branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
-        Assertions.assertNotNull(branchSession);
+            RemoveBranchSessionExecute execute = new RemoveBranchSessionExecute();
+            boolean success = execute.execute(convertToBranchSessionMsg(branchSession));
+            Assertions.assertTrue(success);
 
-        RemoveBranchSessionExecute execute = new RemoveBranchSessionExecute();
-        boolean success = execute.execute(convertToBranchSessionMsg(branchSession));
-        Assertions.assertTrue(success);
-
-        branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
-        Assertions.assertNull(branchSession);
+            branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
+            Assertions.assertNull(branchSession);
+        }
     }
 
     @Test
     public void testUpdate() throws Throwable {
-        GLOBAL_SESSION.add(mockBranchSession());
+        BranchSession branchSession = mockBranchSession(GLOBAL_SESSION.getXid(), GLOBAL_SESSION.getTransactionId());
+        GLOBAL_SESSION.add(branchSession);
 
-        BranchSession branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
+        branchSession = GLOBAL_SESSION.getBranch(branchSession.getBranchId());
         Assertions.assertNotNull(branchSession);
 
-        BranchSession expected = mockBranchSession();
-        expected.setStatus(BranchStatus.PhaseTwo_Committed);
+        branchSession.setStatus(BranchStatus.PhaseTwo_Committed);
         UpdateBranchSessionExecute execute = new UpdateBranchSessionExecute();
-        boolean success = execute.execute(convertToBranchSessionMsg(expected));
+        boolean success = execute.execute(convertToBranchSessionMsg(branchSession));
         Assertions.assertTrue(success);
 
-        branchSession = GLOBAL_SESSION.getBranch(BRANCH_ID);
-        assertBranchSessionValid(expected, branchSession);
+        branchSession = GLOBAL_SESSION.getBranch(branchSession.getBranchId());
+        assertBranchSessionValid(branchSession, branchSession);
     }
 
     private static GlobalSession mockGlobalSession() {
+        long txId = UUIDGenerator.generateUUID();
         GlobalSession session = new GlobalSession("test", "test", "test", 5000);
-        session.setXid(XID);
+        session.setXid(XID.generateXID(txId));
         session.setApplicationData("hello, world");
-        session.setTransactionId(123);
+        session.setTransactionId(txId);
         session.setBeginTime(System.currentTimeMillis());
         return session;
     }
 
-    private static BranchSession mockBranchSession() {
+    private static BranchSession mockBranchSession(String xid,long transactionId) {
         BranchSession session = new BranchSession();
-        session.setXid(XID);
-        session.setTransactionId(123);
-        session.setBranchId(BRANCH_ID);
+        session.setXid(xid);
+        session.setTransactionId(transactionId);
+        session.setBranchId(UUIDGenerator.generateUUID());
         session.setClientId("client");
         session.setResourceGroupId(DEFAULT_TX_GROUP);
         session.setResourceId("resource");

--- a/server/src/test/java/org/apache/seata/server/raft/execute/LockExecuteTest.java
+++ b/server/src/test/java/org/apache/seata/server/raft/execute/LockExecuteTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.seata.server.raft.execute;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.seata.common.util.NetUtil;
+import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchType;
+import org.apache.seata.server.cluster.raft.execute.branch.RemoveBranchSessionExecute;
 import org.apache.seata.server.cluster.raft.execute.lock.BranchReleaseLockExecute;
 import org.apache.seata.server.cluster.raft.execute.lock.GlobalReleaseLockExecute;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftBranchSessionSyncMsg;
@@ -83,14 +87,29 @@ class LockExecuteTest {
     }
 
     @AfterEach
-    public void removeTestSession() throws TransactionException {
+    public void removeTestSession() throws Throwable {
+        testRemove();
         SessionHolder.getRootSessionManager().removeGlobalSession(GLOBAL_SESSION);
+    }
+
+    public void testRemove() throws Throwable {
+        List<BranchSession> list = new ArrayList<>(GLOBAL_SESSION.getBranchSessions());
+        for (BranchSession branchSession : list) {
+            Assertions.assertNotNull(branchSession);
+
+            RemoveBranchSessionExecute execute = new RemoveBranchSessionExecute();
+            boolean success = execute.execute(convertToBranchSessionMsg(branchSession));
+            Assertions.assertTrue(success);
+
+            branchSession = GLOBAL_SESSION.getBranch(branchSession.getBranchId());
+            Assertions.assertNull(branchSession);
+        }
     }
 
     @Test
     public void testGlobalRelease() throws Throwable {
-        BranchSession branchSession1 = mockBranchSession("test:0");
-        BranchSession branchSession2 = mockBranchSession("test:1");
+        BranchSession branchSession1 = mockBranchSession(GLOBAL_SESSION.getXid(),GLOBAL_SESSION.getTransactionId(),"t1:53");
+        BranchSession branchSession2 =  mockBranchSession(GLOBAL_SESSION.getXid(),GLOBAL_SESSION.getTransactionId(),"t1:54");
         GLOBAL_SESSION.add(branchSession1);
         GLOBAL_SESSION.add(branchSession2);
 
@@ -109,7 +128,7 @@ class LockExecuteTest {
 
     @Test
     public void testBranchRelease() throws Throwable {
-        BranchSession branchSession = mockBranchSession("test:0");
+        BranchSession branchSession =  mockBranchSession(GLOBAL_SESSION.getXid(),GLOBAL_SESSION.getTransactionId(),"t1:55");
         GLOBAL_SESSION.add(branchSession);
 
         LockManager lockerManager = LockerManagerFactory.getLockManager();
@@ -131,14 +150,14 @@ class LockExecuteTest {
         return session;
     }
 
-    private static BranchSession mockBranchSession(String lockKey) {
+    private static BranchSession mockBranchSession(String xid,long transactionId,String lockKey) {
         BranchSession session = new BranchSession();
-        session.setXid(XID);
-        session.setTransactionId(123);
-        session.setBranchId(BRANCH_ID);
+        session.setXid(xid);
+        session.setTransactionId(transactionId);
+        session.setBranchId(UUIDGenerator.generateUUID());
         session.setClientId("client");
         session.setResourceGroupId(DEFAULT_TX_GROUP);
-        session.setResourceId("db");
+        session.setResourceId("resource");
         session.setLockKey(lockKey);
         session.setBranchType(BranchType.AT);
         session.setApplicationData("hello, world");


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
存在于file一样的缺点，reload后会删除failed状态的事务及涉及的分支事务和锁
以及reload时机于file有区别，file是在重启时，而raft是在leader选举后进行reload（一般leader重选举就是leader挂了）

It has the same drawbacks as in the file: after reload, failed transactions, associated branch transactions, and locks will be deleted. Additionally, the timing of the reload differs from that of the file; the file reload occurs during a restart, while the RAFT reload happens after a leader election (usually, the leader re-election occurs when the leader has failed).

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

