### PR TITLE
optimize: fast fail when channel is null

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -14,6 +14,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 - [[#6828](https://github.com/apache/incubator-seata/pull/6828)] spring boot compatible with file.conf and registry.conf
 - [[#7012](https://github.com/apache/incubator-seata/pull/7012)] When the number of primary keys exceeds 1000, use union to concatenate the SQL
+- [[#7075](https://github.com/apache/incubator-seata/pull/7075)] fast fail when channel is null
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -14,6 +14,7 @@
 
 - [[#6828](https://github.com/apache/incubator-seata/pull/6828)] seata-spring-boot-starter兼容file.conf和registry.conf
 - [[#7012](https://github.com/apache/incubator-seata/pull/7012)] 当主键超过1000个时，使用union拼接sql，可以使用索引
+- [[#7075](https://github.com/apache/incubator-seata/pull/7075)] 当channel为空时，快速失败，以便于减少不必要的等待
 
 ### security:
 

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -200,7 +200,7 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
     public void sendAsyncRequest(Channel channel, Object msg) {
         if (channel == null) {
             LOGGER.warn("sendAsyncRequest nothing, caused by null channel.");
-            return;
+            throw new FrameworkException(new Throwable("throw"), "frameworkException", FrameworkErrorCode.ChannelIsNotWritable);
         }
         RpcMessage rpcMessage = buildRequestMessage(msg, msg instanceof HeartbeatMessage
             ? ProtocolConstants.MSGTYPE_HEARTBEAT_REQUEST

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
@@ -26,6 +26,7 @@ import org.apache.seata.common.exception.FrameworkException;
 import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.core.model.Resource;
 import org.apache.seata.core.model.ResourceManager;
+import org.apache.seata.core.protocol.HeartbeatMessage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Rm RPC client test.
@@ -95,5 +97,14 @@ class RmNettyClientTest {
         } catch (Exception ex) {
             throw new RuntimeException(ex.getMessage());
         }
+    }
+
+    @Test
+    public void testSendAsyncRequestWithNullChannelLogsWarning() {
+        RmNettyRemotingClient remotingClient = RmNettyRemotingClient.getInstance();
+        Object message = HeartbeatMessage.PING;
+        assertThrows(FrameworkException.class, () -> {
+            remotingClient.sendAsyncRequest(null, message);
+        });
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

This PR enhances the `RmNettyRemotingClient#sendRegisterMessage` method by improving its error handling when the `channel` parameter is `null`. 


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

Fixes #7057

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

org.apache.seata.core.rpc.netty.RmNettyClientTest#testSendAsyncRequestWithNullChannelLogsWarning

### Ⅳ. Describe how to verify it

1. **Run Unit Tests**: Execute the test suite to ensure all new and existing tests pass.
   ```bash
   mvn test

* org.apache.seata.core.rpc.netty.RmNettyClientTest#testSendAsyncRequestWithNullChannelLogsWarning
