### PR TITLE
bugfix: The time difference between the raft node and the follower node cannot synchronize data.

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -18,6 +18,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7107](https://github.com/apache/incubator-seata/pull/7107)] fix the issue of failing to parse annotations in TCC mode when the business object is a proxy object.
 - [[#7124](https://github.com/apache/incubator-seata/pull/7124)] bugfix: GlobalTransactionScanner.afterPropertiesSet need do scanner check
 - [[#7135](https://github.com/apache/incubator-seata/pull/7135)] treating a unique index conflict during rollback as a dirty write
+- [[#7150](https://github.com/apache/incubator-seata/pull/7150)] The time difference between the raft node and the follower node cannot synchronize data
 
 ### optimize:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -18,6 +18,7 @@
 - [[#7107](https://github.com/apache/incubator-seata/pull/7107)] 修复tcc模式下，当业务对象为代理对象时，解析注解失败问题。
 - [[#7124](https://github.com/apache/incubator-seata/pull/7124)] GlobalTransactionScanner.afterPropertiesSet方法需要做扫描检查
 - [[#7135](https://github.com/apache/incubator-seata/pull/7135)] 回滚时遇到唯一索引冲突视为脏写
+- [[#7150](https://github.com/apache/incubator-seata/pull/7150)] raft节点之前时间差，follower节点无法同步数据
 
 ### optimize:
 

--- a/server/src/main/java/org/apache/seata/server/cluster/raft/RaftStateMachine.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/raft/RaftStateMachine.java
@@ -390,8 +390,11 @@ public class RaftStateMachine extends StateMachineAdapter {
                 PeerId peerId = RouteTable.getInstance().selectLeader(group);
                 if (peerId != null) {
                     syncCurrentNodeInfo(peerId);
+                } else {
+                    initSync.compareAndSet(true, false);
                 }
             } catch (Exception e) {
+                initSync.compareAndSet(true, false);
                 LOGGER.error(e.getMessage(), e);
             }
         }
@@ -439,8 +442,11 @@ public class RaftStateMachine extends StateMachineAdapter {
                                 err);
                         }
                     }, 30000);
+            } else {
+                initSync.compareAndSet(true, false);
             }
         } catch (Exception e) {
+            initSync.compareAndSet(true, false);
             LOGGER.error(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
在部署raft集群时，发现有的节点启动慢时间差会导致follwing同步失败，且initSync不会再次同步.
同步时机：
1. 定时器syncMetadata，第一次同步失败initSync设置为true后，会导致同步元数据不会再次发起
2. onFollowing同步，由于leader为null，同步元数据无法成功

以上导致该节点无法加入到raft集群中。
该pr主要是针对以上两个时机出现的异常情况进行设置，保证定时器syncMetadata还会进入同步逻辑。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

