### PR TITLE
test: Refactored tests in LowerCaseLinkHashMapTest to use parameterized unit testing

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -72,5 +72,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [wxrqforever](https://github.com/wxrqforever)
 - [xingfudeshi](https://github.com/xingfudeshi)
 - [YongGoose](https://github.com/YongGoose)
+- [Monilnarang](https://github.com/Monilnarang)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -49,6 +49,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 - [[#7092](https://github.com/apache/incubator-seata/pull/7092)] fix the issue of NacosMockTest failing to run
 - [[#7098](https://github.com/apache/incubator-seata/pull/7098)] Add unit tests for the `seata-common` module
+- [[#7160](https://github.com/apache/incubator-seata/pull/7160)] Refactored tests in `LowerCaseLinkHashMapTest` to use parameterized unit testing
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,6 +49,7 @@
 
 - [[#7092](https://github.com/apache/incubator-seata/pull/7092)] 修复NacosMockTest测试方法并行导致测试结果被干扰失败的问题
 - [[#7098](https://github.com/apache/incubator-seata/pull/7098)] 增加 `seata-common` 模块的测试用例
+- [[#7160](https://github.com/apache/incubator-seata/pull/7160)] 在 LowerCaseLinkHashMapTest 中重构测试，以使用参数化单元测试
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -72,5 +72,6 @@
 - [wxrqforever](https://github.com/wxrqforever)
 - [xingfudeshi](https://github.com/xingfudeshi)
 - [YongGoose](https://github.com/YongGoose)
+- [Monilnarang](https://github.com/Monilnarang)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/common/src/test/java/org/apache/seata/common/util/LowerCaseLinkHashMapTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/LowerCaseLinkHashMapTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 
 public class LowerCaseLinkHashMapTest {
@@ -122,11 +124,14 @@ public class LowerCaseLinkHashMapTest {
         Assertions.assertArrayEquals(values.toArray(), lowerCaseLinkHashMap.values().toArray());
     }
 
-    @Test
-    void getOrDefault() {
-        Assertions.assertEquals("Value", lowerCaseLinkHashMap.getOrDefault("Key", "abc"));
-        Assertions.assertEquals("Value", lowerCaseLinkHashMap.getOrDefault("key", "abc"));
-        Assertions.assertEquals("abc", lowerCaseLinkHashMap.getOrDefault("default", "abc"));
+    @ParameterizedTest
+    @CsvSource(value = {
+            "Value, Key, abc",
+            "Value, key, abc",
+            "abc, default, abc"
+    })
+    void getOrDefault1(String expected, String key, String defaultValue) {
+        Assertions.assertEquals(expected, lowerCaseLinkHashMap.getOrDefault(key, defaultValue));
     }
 
     @Test


### PR DESCRIPTION

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Aim:
Improve the test code by avoiding code duplication, improving maintainability, and enhancing readability. By converting the test into a parameterized unit test, we reduce boilerplate code, make it easier to extend by simply adding new input values, and improve debugging by clearly identifying which test case fails instead of searching through individual assertions.


```
    @Test
    void getOrDefault() {
        Assertions.assertEquals("Value", lowerCaseLinkHashMap.getOrDefault("Key", "abc"));
        Assertions.assertEquals("Value", lowerCaseLinkHashMap.getOrDefault("key", "abc"));
        Assertions.assertEquals("abc", lowerCaseLinkHashMap.getOrDefault("default", "abc"));
    }
```
    
In the above in tests from LowerCaseLinkHashMapTest.java:

* The same method call (lowerCaseLinkHashMap.getOrDefault) is repeated multiple times with different inputs, making the test harder to maintain and extend.
* When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
* Adding new test cases requires copying and pasting another Assertions.assertEquals(...) statement instead of simply adding new data.

To accomplish this, I have retrofitted the test into a parameterized unit test. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Successful tests run

### Ⅴ. Special notes for reviews

