### PR TITLE
feature:Transfer global timeout and branch transaction begin time

### DIFF
--- a/core/src/main/java/org/apache/seata/core/context/RootContext.java
+++ b/core/src/main/java/org/apache/seata/core/context/RootContext.java
@@ -59,6 +59,11 @@ public class RootContext {
      * The constant KEY_TIMEOUT.
      */
     public static final String KEY_TIMEOUT = "TX_TIMEOUT";
+    
+    /**
+     * The constant KEY_BRANCH_BEIGN_TIME.
+     */
+    public static final String KEY_BRANCH_BEIGN_TIME = "TX_BRANCH_BEIGN_TIME";
 
     /**
      * The constant MDC_KEY_XID for logback
@@ -140,6 +145,14 @@ public class RootContext {
 
     public static void setTimeout(Integer timeout) {
         CONTEXT_HOLDER.put(KEY_TIMEOUT,timeout);
+    }
+    
+    public static Long getBranchBeignTime() {
+    	return (Long) CONTEXT_HOLDER.get(KEY_BRANCH_BEIGN_TIME);
+    }
+    
+    public static void setBranchBeignTime(Long branchBeignTime) {
+    	CONTEXT_HOLDER.put(KEY_BRANCH_BEIGN_TIME,branchBeignTime);
     }
 
     /**

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXA.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXA.java
@@ -27,6 +27,7 @@ import org.apache.seata.common.DefaultValues;
 import org.apache.seata.common.lock.ResourceLock;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.config.ConfigurationFactory;
+import org.apache.seata.core.context.RootContext;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.core.model.BranchType;
@@ -62,11 +63,11 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
 
     private volatile boolean rollBacked = false;
 
-    private volatile Long branchRegisterTime = null;
+    private volatile Long branchBeginTime = null;
 
     private volatile Long prepareTime = null;
 
-    private static final Integer TIMEOUT = Math.max(BRANCH_EXECUTION_TIMEOUT, DefaultValues.DEFAULT_GLOBAL_TRANSACTION_TIMEOUT);
+    private volatile Integer timeout = null;
 
     private boolean shouldBeHeld = false;
 
@@ -92,6 +93,15 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
             this.currentAutoCommitStatus = this.originalConnection.getAutoCommit();
             if (!currentAutoCommitStatus) {
                 throw new IllegalStateException("Connection[autocommit=false] as default is NOT supported");
+            }
+            Integer transactionTimeout = RootContext.getTimeout();
+            if (transactionTimeout == null) {
+                transactionTimeout = DefaultValues.DEFAULT_GLOBAL_TRANSACTION_TIMEOUT;
+            }
+            timeout = Math.max(BRANCH_EXECUTION_TIMEOUT, transactionTimeout);
+            branchBeginTime = RootContext.getBranchBeignTime();
+            if(branchBeginTime == null) {
+            	branchBeginTime = System.currentTimeMillis();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -190,7 +200,6 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
             long branchId;
             try {
                 // 1. register branch to TC then get the branch message
-                branchRegisterTime = System.currentTimeMillis();
                 branchId = DefaultResourceManager.get().branchRegister(BranchType.XA, resource.getResourceId(), null, xid, null,
                         null);
             } catch (TransactionException te) {
@@ -318,7 +327,6 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
 
     private void cleanXABranchContext() {
         xaEnded = false;
-        branchRegisterTime = null;
         prepareTime = null;
         xaActive = false;
         if (!isHeld()) {
@@ -327,7 +335,7 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
     }
 
     private void checkTimeout(Long now) throws XAException {
-        if (now - branchRegisterTime > TIMEOUT) {
+        if (now - branchBeginTime > timeout) {
             xaRollback(xaBranchXid);
             throw new XAException("XA branch timeout error");
         }

--- a/tm/src/main/java/org/apache/seata/tm/api/DefaultGlobalTransaction.java
+++ b/tm/src/main/java/org/apache/seata/tm/api/DefaultGlobalTransaction.java
@@ -113,6 +113,8 @@ public class DefaultGlobalTransaction implements GlobalTransaction {
         xid = transactionManager.begin(null, null, name, timeout);
         status = GlobalStatus.Begin;
         RootContext.bind(xid);
+        RootContext.setTimeout(timeout);
+        RootContext.setBranchBeignTime(createTime);
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Begin new global transaction [{}]", xid);
         }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

XA模式用到的全局超时时间没有使用单独配置，需要传递全局超时时间和分支事务开始时间
The global timeout time used in the XA Mode is not configured separately, and the global timeout time and branch transaction start time need to be passed.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

