### PR TITLE
test: Refactored tests in DurationUtilTest to simplify and use parameterized unit testing

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -51,6 +51,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7092](https://github.com/apache/incubator-seata/pull/7092)] fix the issue of NacosMockTest failing to run
 - [[#7098](https://github.com/apache/incubator-seata/pull/7098)] Add unit tests for the `seata-common` module
 - [[#7160](https://github.com/apache/incubator-seata/pull/7160)] Refactored tests in `LowerCaseLinkHashMapTest` to use parameterized unit testing
+- [[#7167](https://github.com/apache/incubator-seata/pull/7167)] Refactored tests in `DurationUtilTest` to simplify and use parameterized unit testing
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -51,6 +51,7 @@
 - [[#7092](https://github.com/apache/incubator-seata/pull/7092)] 修复NacosMockTest测试方法并行导致测试结果被干扰失败的问题
 - [[#7098](https://github.com/apache/incubator-seata/pull/7098)] 增加 `seata-common` 模块的测试用例
 - [[#7160](https://github.com/apache/incubator-seata/pull/7160)] 在 LowerCaseLinkHashMapTest 中重构测试，以使用参数化单元测试
+- [[#7167](https://github.com/apache/incubator-seata/pull/7167)] 重构了 DurationUtilTest 中的测试，以简化并使用参数化单元测试
 
 ### refactor:
 

--- a/common/src/test/java/org/apache/seata/common/util/DurationUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/DurationUtilTest.java
@@ -17,56 +17,72 @@
 package org.apache.seata.common.util;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class DurationUtilTest {
 
-    @Test
-    public void testParse() {
-        Assertions.assertEquals(-1L, DurationUtil.parse("").getSeconds());
-        Assertions.assertEquals(0L, DurationUtil.parse("8").getSeconds());
-        Assertions.assertEquals(8L, DurationUtil.parse("8").toMillis());
-        Assertions.assertEquals(0L, DurationUtil.parse("8ms").getSeconds());
-        Assertions.assertEquals(8L, DurationUtil.parse("8ms").toMillis());
-        Assertions.assertEquals(8L, DurationUtil.parse("8s").getSeconds());
-        Assertions.assertEquals(480L, DurationUtil.parse("8m").getSeconds());
-        Assertions.assertEquals(28800L, DurationUtil.parse("8h").getSeconds());
-        Assertions.assertEquals(691200L, DurationUtil.parse("8d").getSeconds());
-
-        Assertions.assertEquals(172800L,DurationUtil.parse("P2D").getSeconds());
-        Assertions.assertEquals(20L,DurationUtil.parse("PT20.345S").getSeconds());
-        Assertions.assertEquals(20345L,DurationUtil.parse("PT20.345S").toMillis());
-        Assertions.assertEquals(900L,DurationUtil.parse("PT15M").getSeconds());
-        Assertions.assertEquals(36000L,DurationUtil.parse("PT10H").getSeconds());
-        Assertions.assertEquals(8L,DurationUtil.parse("PT8S").getSeconds());
-        Assertions.assertEquals(86460L,DurationUtil.parse("P1DT1M").getSeconds());
-        Assertions.assertEquals(183840L,DurationUtil.parse("P2DT3H4M").getSeconds());
-        Assertions.assertEquals(-21420L,DurationUtil.parse("PT-6H3M").getSeconds());
-        Assertions.assertEquals(-21780L,DurationUtil.parse("-PT6H3M").getSeconds());
-        Assertions.assertEquals(21420L,DurationUtil.parse("-PT-6H+3M").getSeconds());
+    private static Stream<Arguments> provideValueSetsTestParseGetSeconds() {
+        return Stream.of(
+                Arguments.of(-1L, ""),
+                Arguments.of(0L, "8"),
+                Arguments.of(0L, "8ms"),
+                Arguments.of(8L, "8s"),
+                Arguments.of(480L, "8m"),
+                Arguments.of(28800L, "8h"),
+                Arguments.of(691200L, "8d"),
+                Arguments.of(172800L, "P2D"),
+                Arguments.of(20L, "PT20.345S"),
+                Arguments.of(900L, "PT15M"),
+                Arguments.of(36000L, "PT10H"),
+                Arguments.of(8L, "PT8S"),
+                Arguments.of(86460L, "P1DT1M"),
+                Arguments.of(183840L, "P2DT3H4M"),
+                Arguments.of(-21420L, "PT-6H3M"),
+                Arguments.of(-21780L, "-PT6H3M"),
+                Arguments.of(21420L, "-PT-6H+3M")
+        );
     }
 
-    @Test
-    public void testParseThrowException() {
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("a"));
+    @ParameterizedTest
+    @MethodSource("provideValueSetsTestParseGetSeconds")
+    public void testParseGetSeconds(long expected, String str) {
+        Assertions.assertEquals(expected,DurationUtil.parse(str).getSeconds());
+    }
 
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("as"));
+    private static Stream<Arguments> provideValueSetsTestParseToMillis() {
+        return Stream.of(
+                Arguments.of(8L, "8"),
+                Arguments.of(8L, "8ms"),
+                Arguments.of(20345L, "PT20.345S")
+        );
+    }
 
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("d"));
+    @ParameterizedTest
+    @MethodSource("provideValueSetsTestParseToMillis")
+    public void testParseToMillis(long expected, String str) {
+        Assertions.assertEquals(expected, DurationUtil.parse(str).toMillis());
+    }
 
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("h"));
+    private static Stream<Arguments> provideValueSetsTestParseThrowException() {
+        return Stream.of(
+                Arguments.of("a"),
+                Arguments.of("as"),
+                Arguments.of("d"),
+                Arguments.of("h"),
+                Arguments.of("m"),
+                Arguments.of("s"),
+                Arguments.of("ms")
+        );
+    }
 
+    @ParameterizedTest
+    @MethodSource("provideValueSetsTestParseThrowException")
+    public void testParseThrowException(String str) {
         Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("m"));
-
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("s"));
-
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> DurationUtil.parse("ms"));
+                () -> DurationUtil.parse(str));
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
**Summary**: 
- Created 2 separate parameterized tests for `testParse`
- Parameterized `testParseThrowException`

**Aim**:
Improve the test code by avoiding code duplication, improving maintainability, and enhancing readability. By converting the test into a parameterized unit test, we reduce boilerplate code, make it easier to extend by simply adding new input values, and improve debugging by clearly identifying which test case fails instead of searching through individual assertions.

**Elaboration**: 
Like in the below test from DurationUtilTest.java:
```
@Test
    public void testParse() {
        Assertions.assertEquals(-1L, DurationUtil.parse("").getSeconds());
        Assertions.assertEquals(0L, DurationUtil.parse("8").getSeconds());
        Assertions.assertEquals(8L, DurationUtil.parse("8").toMillis());
        Assertions.assertEquals(0L, DurationUtil.parse("8ms").getSeconds());
        Assertions.assertEquals(8L, DurationUtil.parse("8ms").toMillis());
        Assertions.assertEquals(8L, DurationUtil.parse("8s").getSeconds());
        Assertions.assertEquals(480L, DurationUtil.parse("8m").getSeconds());
        Assertions.assertEquals(28800L, DurationUtil.parse("8h").getSeconds());
        Assertions.assertEquals(691200L, DurationUtil.parse("8d").getSeconds());

        Assertions.assertEquals(172800L,DurationUtil.parse("P2D").getSeconds());
        Assertions.assertEquals(20L,DurationUtil.parse("PT20.345S").getSeconds());
        Assertions.assertEquals(20345L,DurationUtil.parse("PT20.345S").toMillis());
        Assertions.assertEquals(900L,DurationUtil.parse("PT15M").getSeconds());
        Assertions.assertEquals(36000L,DurationUtil.parse("PT10H").getSeconds());
        Assertions.assertEquals(8L,DurationUtil.parse("PT8S").getSeconds());
        Assertions.assertEquals(86460L,DurationUtil.parse("P1DT1M").getSeconds());
        Assertions.assertEquals(183840L,DurationUtil.parse("P2DT3H4M").getSeconds());
        Assertions.assertEquals(-21420L,DurationUtil.parse("PT-6H3M").getSeconds());
        Assertions.assertEquals(-21780L,DurationUtil.parse("-PT6H3M").getSeconds());
        Assertions.assertEquals(21420L,DurationUtil.parse("-PT-6H+3M").getSeconds());
    }
```

- The same method calls (`DurationUtil.parse("someString").getSeconds()`, `DurationUtil.parse("someString").toMillis()`) are repeated multiple times with different inputs, making the test harder to maintain and extend. 
- Both the above method calls are cluttered together in one test, blurring the exact scope of this test. 
- When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting another Assertions.assertEquals(...) statement instead of simply adding new data.

To accomplish this, I have split this test into 2 separate tests (`testParseGetSeconds` and `testParseToMillis`) and retrofitted them into a parameterized unit test. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

**Test execution results before changes:** 
<img width="338" alt="Screenshot 2025-02-17 at 2 38 03 PM" src="https://github.com/user-attachments/assets/4de7c387-b97e-4236-8d3c-d3ab42e1d1c8" />

**Test execution results after changes:** 
<img width="338" alt="Screenshot 2025-02-17 at 2 37 42 PM" src="https://github.com/user-attachments/assets/daf55b1d-e42d-4ff0-9bad-de927ada4340" />



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Successful tests run

### Ⅴ. Special notes for reviews

