### PR TITLE
optimize:  use the ip of the peerId as the host of the raft node

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -13,6 +13,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7114](https://github.com/apache/incubator-seata/pull/7114)] support raft mode registry to namingserver
 - [[#7133](https://github.com/apache/incubator-seata/pull/7133)] Implement scheduled handling for end status transaction
 - [[#7171](https://github.com/apache/incubator-seata/pull/7171)] support EpollEventLoopGroup in client
+- [[#7182](https://github.com/apache/incubator-seata/pull/7182)] use the ip of the peerId as the host of the raft node
 
 
 ### bugfix:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -13,6 +13,7 @@
 - [[#7114](https://github.com/apache/incubator-seata/pull/7114)] 支持raft集群注册至namingserver
 - [[#7133](https://github.com/apache/incubator-seata/pull/7133)] 实现对残留的end状态事务定时处理
 - [[#7171](https://github.com/apache/incubator-seata/pull/7171)] 客户端支持 EpollEventLoopGroup
+- [[#7182](https://github.com/apache/incubator-seata/pull/7182)] 采用peerId的ip作为raft节点的host
 
 
 ### bugfix:

--- a/server/src/main/java/org/apache/seata/server/cluster/raft/RaftStateMachine.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/raft/RaftStateMachine.java
@@ -370,7 +370,7 @@ public class RaftStateMachine extends StateMachineAdapter {
         if (leaderNode == null || (leaderNode.getInternal() != null
             && !cureentPeerId.equals(new PeerId(leaderNode.getInternal().getHost(), leaderNode.getInternal().getPort())))) {
             Node leader =
-                raftClusterMetadata.createNode(XID.getIpAddress(), XID.getPort(), raftServer.getServerId().getPort(),
+                raftClusterMetadata.createNode(cureentPeerId.getIp(), XID.getPort(), raftServer.getServerId().getPort(),
                     Integer.parseInt(
                         ((Environment)ObjectHolder.INSTANCE.getObject(OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT))
                             .getProperty("server.port", String.valueOf(7091))),
@@ -413,7 +413,7 @@ public class RaftStateMachine extends StateMachineAdapter {
             if (leader != null && StringUtils.isNotBlank(leader.getVersion())) {
                 RaftServer raftServer = RaftServerManager.getRaftServer(group);
                 PeerId cureentPeerId = raftServer.getServerId();
-                Node node = raftClusterMetadata.createNode(XID.getIpAddress(), XID.getPort(), cureentPeerId.getPort(),
+                Node node = raftClusterMetadata.createNode(cureentPeerId.getIp(), XID.getPort(), cureentPeerId.getPort(),
                     Integer.parseInt(
                         ((Environment)ObjectHolder.INSTANCE.getObject(OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT))
                             .getProperty("server.port", String.valueOf(7091))),


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
raft创建node时，采用peerId作为host，而不是xid的ip，因为当不设置SEATA_IP时，xid的ip为podIp，podIp会变动，这会导致在集群扩缩容时，节点只增不减，不是唯一的，而peerId的ip是一个svc域名

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

