### PR TITLE
test: add UT for DM/kingbase/oscar sqlparser

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -64,6 +64,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7160](https://github.com/apache/incubator-seata/pull/7160)] Refactored tests in `LowerCaseLinkHashMapTest` to use parameterized unit testing
 - [[#7167](https://github.com/apache/incubator-seata/pull/7167)] Refactored tests in `DurationUtilTest` to simplify and use parameterized unit testing
 - [[#7189](https://github.com/apache/incubator-seata/pull/7189)] fix the runtime exception in the saga test case
+- [[#7203](https://github.com/apache/incubator-seata/pull/7203)] Refactored tests in rm.datasource.sql.Druid and seata-sqlparser-druid module
 
 ### refactor:
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -89,5 +89,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [xingfudeshi](https://github.com/xingfudeshi)
 - [YongGoose](https://github.com/YongGoose)
 - [Monilnarang](https://github.com/Monilnarang)
+- [YoWuwuuuw](https://github.com/YoWuwuuuw)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -65,6 +65,7 @@
 - [[#7160](https://github.com/apache/incubator-seata/pull/7160)] 在 LowerCaseLinkHashMapTest 中重构测试，以使用参数化单元测试
 - [[#7167](https://github.com/apache/incubator-seata/pull/7167)] 重构了 DurationUtilTest 中的测试，以简化并使用参数化单元测试
 - [[#7189](https://github.com/apache/incubator-seata/pull/7189)] 修复saga测试用例运行异常
+- [[#7203](https://github.com/apache/incubator-seata/pull/7203)] 重构了 rm.datasource.sql.Druid 和 seata-sqlparser-druid 模块中的测试
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -90,5 +90,6 @@
 - [xingfudeshi](https://github.com/xingfudeshi)
 - [YongGoose](https://github.com/YongGoose)
 - [Monilnarang](https://github.com/Monilnarang)
+- [YoWuwuuuw](https://github.com/YoWuwuuuw)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmDeleteRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oracle;
+package org.apache.seata.sqlparser.druid.dm;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,6 @@ import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleArgumentExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oracle.OracleDeleteRecognizer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,16 +30,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
-public class OracleDeleteRecognizerTest {
+public class DmDeleteRecognizerTest {
 
-    private static final String DB_TYPE = "oracle";
+    private static final String DB_TYPE = "dm";
 
     @Test
     public void testGetSqlType() {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.DELETE);
     }
 
@@ -49,7 +48,7 @@ public class OracleDeleteRecognizerTest {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -58,7 +57,7 @@ public class OracleDeleteRecognizerTest {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -67,10 +66,10 @@ public class OracleDeleteRecognizerTest {
         String sql = "delete from t";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer,ArrayList<Object>> getParameters() {
+            public Map<Integer, ArrayList<Object>> getParameters() {
                 return null;
             }
         }, new ArrayList<>());
@@ -81,10 +80,10 @@ public class OracleDeleteRecognizerTest {
         sql = "delete from t where id = ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer,ArrayList<Object>> getParameters() {
+            public Map<Integer, ArrayList<Object>> getParameters() {
                 ArrayList<Object> idParam = new ArrayList<>();
                 idParam.add(1);
                 Map result = new HashMap();
@@ -98,10 +97,10 @@ public class OracleDeleteRecognizerTest {
 
         sql = "delete from t where id in (?)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer,ArrayList<Object>> getParameters() {
+            public Map<Integer, ArrayList<Object>> getParameters() {
                 ArrayList<Object> idParam = new ArrayList<>();
                 idParam.add(1);
                 Map result = new HashMap();
@@ -115,10 +114,10 @@ public class OracleDeleteRecognizerTest {
 
         sql = "delete from t where id between ? and ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer,ArrayList<Object>> getParameters() {
+            public Map<Integer, ArrayList<Object>> getParameters() {
                 ArrayList<Object> idParam = new ArrayList<>();
                 idParam.add(1);
                 ArrayList<Object> idParam2 = new ArrayList<>();
@@ -138,9 +137,9 @@ public class OracleDeleteRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLDeleteStatement deleteAst = (SQLDeleteStatement) sqlStatements.get(0);
             deleteAst.setWhere(new OracleArgumentExpr());
-            new OracleDeleteRecognizer(s, deleteAst).getWhereCondition(new ParametersHolder() {
+            new DmDeleteRecognizer(s, deleteAst).getWhereCondition(new ParametersHolder() {
                 @Override
-                public Map<Integer,ArrayList<Object>> getParameters() {
+                public Map<Integer, ArrayList<Object>> getParameters() {
                     return new HashMap<>();
                 }
             }, new ArrayList<>());
@@ -153,7 +152,7 @@ public class OracleDeleteRecognizerTest {
         String sql = "delete from t";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         //test for no condition
@@ -162,7 +161,7 @@ public class OracleDeleteRecognizerTest {
         sql = "delete from t where id = 1";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition();
 
         //test for normal sql
@@ -170,7 +169,7 @@ public class OracleDeleteRecognizerTest {
 
         sql = "delete from t where id in (1)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition();
 
         //test for sql with in
@@ -178,7 +177,7 @@ public class OracleDeleteRecognizerTest {
 
         sql = "delete from t where id between 1 and 2";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
+        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition();
         //test for sql with in
         Assertions.assertEquals("id BETWEEN 1 AND 2", whereCondition);
@@ -189,7 +188,7 @@ public class OracleDeleteRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLDeleteStatement deleteAst = (SQLDeleteStatement) sqlStatements.get(0);
             deleteAst.setWhere(new OracleArgumentExpr());
-            new OracleDeleteRecognizer(s, deleteAst).getWhereCondition();
+            new DmDeleteRecognizer(s, deleteAst).getWhereCondition();
         });
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmInsertRecognizerTest.java
@@ -14,32 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oracle;
+package org.apache.seata.sqlparser.druid.dm;
 
-import java.util.Collections;
-import java.util.List;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oracle.OracleInsertRecognizer;
+import org.apache.seata.sqlparser.druid.dm.DmInsertRecognizer;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
-public class OracleInsertRecognizerTest {
+public class DmInsertRecognizerTest {
 
-    private static final String DB_TYPE = "oracle";
+    private static final String DB_TYPE = "dm";
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
+        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
@@ -48,7 +48,7 @@ public class OracleInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
+        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -57,7 +57,7 @@ public class OracleInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
+        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -68,7 +68,7 @@ public class OracleInsertRecognizerTest {
         String sql = "insert into t values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
+        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
@@ -76,7 +76,7 @@ public class OracleInsertRecognizerTest {
         sql = "insert into t(a) values (?)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new OracleInsertRecognizer(sql, asts.get(0));
+        recognizer = new DmInsertRecognizer(sql, asts.get(0));
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
@@ -84,11 +84,11 @@ public class OracleInsertRecognizerTest {
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
+            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
-            OracleInsertRecognizer oracleInsertRecognizer = new OracleInsertRecognizer(s, sqlInsertStatement);
-            oracleInsertRecognizer.getInsertColumns();
+            DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
+            dmInsertRecognizer.getInsertColumns();
         });
     }
 
@@ -99,7 +99,7 @@ public class OracleInsertRecognizerTest {
         String sql = "insert into t(id, no, name, age, time) values (id_seq.nextval, null, 'a', ?, now())";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
+        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
@@ -107,11 +107,11 @@ public class OracleInsertRecognizerTest {
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
+            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
 
-            OracleInsertRecognizer oracleInsertRecognizer = new OracleInsertRecognizer(s, sqlInsertStatement);
-            oracleInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
+            DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
+            dmInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
         });
     }
 
@@ -119,9 +119,10 @@ public class OracleInsertRecognizerTest {
     public void testNotPlaceholder_giveValidPkIndex() {
         String sql = "insert into test(create_time) values(sysdate)";
         List<SQLStatement> sqlStatements = SQLUtils.parseStatements(sql, DB_TYPE);
+        ;
 
-        OracleInsertRecognizer oracle = new OracleInsertRecognizer(sql, sqlStatements.get(0));
-        List<List<Object>> insertRows = oracle.getInsertRows(Collections.singletonList(-1));
+        DmInsertRecognizer dm = new DmInsertRecognizer(sql, sqlStatements.get(0));
+        List<List<Object>> insertRows = dm.getInsertRows(Collections.singletonList(-1));
         Assertions.assertTrue(insertRows.get(0).get(0) instanceof NotPlaceholderExpr);
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmSelectForUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oracle;
+package org.apache.seata.sqlparser.druid.dm;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,38 +22,35 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oracle.OracleSelectForUpdateRecognizer;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
-public class OracleSelectForUpdateRecognizerTest {
+public class DmSelectForUpdateRecognizerTest {
 
-    private static final String DB_TYPE = "oracle";
+    private static final String DB_TYPE = "dm";
 
     @Test
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
+        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
-
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
+        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer,ArrayList<Object>> getParameters() {
+            public Map<Integer, ArrayList<Object>> getParameters() {
                 return null;
             }
         }, new ArrayList<>());
@@ -65,7 +62,7 @@ public class OracleSelectForUpdateRecognizerTest {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
+        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -76,7 +73,7 @@ public class OracleSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.setSelect(null);
-            new OracleSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new DmSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
 
         //test for query was null
@@ -85,7 +82,7 @@ public class OracleSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.getSelect().setQuery(null);
-            new OracleSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new DmSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
     }
 
@@ -94,7 +91,7 @@ public class OracleSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
+        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -103,7 +100,7 @@ public class OracleSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
+        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.dm;
+package org.apache.seata.sqlparser.druid.dm;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -24,7 +24,6 @@ import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleCursorExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.dm.DmUpdateRecognizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseDeleteRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.kingbase;
+package org.apache.seata.sqlparser.druid.kingbase;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseInsertRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oscar;
+package org.apache.seata.sqlparser.druid.kingbase;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,7 @@ import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oscar.OscarInsertRecognizer;
+import org.apache.seata.sqlparser.druid.kingbase.KingbaseInsertRecognizer;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,19 +30,17 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * The type Oscar insert recognizer test.
- */
-public class OscarInsertRecognizerTest {
 
-    private static final String DB_TYPE = "oscar";
+public class KingbaseInsertRecognizerTest {
+
+    private static final String DB_TYPE = "kingbase";
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
@@ -51,7 +49,7 @@ public class OscarInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -60,7 +58,7 @@ public class OscarInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -71,7 +69,7 @@ public class OscarInsertRecognizerTest {
         String sql = "insert into t values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
@@ -79,7 +77,7 @@ public class OscarInsertRecognizerTest {
         sql = "insert into t(a) values (?)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
@@ -90,8 +88,8 @@ public class OscarInsertRecognizerTest {
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
-            OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
-            oscarInsertRecognizer.getInsertColumns();
+            KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
+            kingbaseInsertRecognizer.getInsertColumns();
         });
     }
 
@@ -102,7 +100,7 @@ public class OscarInsertRecognizerTest {
         String sql = "insert into t(id, no, name, age, time) values (id_seq.nextval, null, 'a', ?, now())";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
@@ -113,8 +111,8 @@ public class OscarInsertRecognizerTest {
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
 
-            OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
-            oscarInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
+            KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
+            kingbaseInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
         });
     }
 
@@ -123,8 +121,8 @@ public class OscarInsertRecognizerTest {
         String sql = "insert into test(create_time) values(sysdate)";
         List<SQLStatement> sqlStatements = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarInsertRecognizer oscar = new OscarInsertRecognizer(sql, sqlStatements.get(0));
-        List<List<Object>> insertRows = oscar.getInsertRows(Collections.singletonList(-1));
+        KingbaseInsertRecognizer kingbase = new KingbaseInsertRecognizer(sql, sqlStatements.get(0));
+        List<List<Object>> insertRows = kingbase.getInsertRows(Collections.singletonList(-1));
         Assertions.assertTrue(insertRows.get(0).get(0) instanceof NotPlaceholderExpr);
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseSelectForUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oscar;
+package org.apache.seata.sqlparser.druid.kingbase;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,7 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oscar.OscarSelectForUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.kingbase.KingbaseSelectForUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,19 +30,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * The type Oscar select for update recognizer test.
- */
-public class OscarSelectForUpdateRecognizerTest {
 
-    private static final String DB_TYPE = "oscar";
+public class KingbaseSelectForUpdateRecognizerTest {
+
+    private static final String DB_TYPE = "kingbase";
 
     @Test
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
 
@@ -52,7 +50,7 @@ public class OscarSelectForUpdateRecognizerTest {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer,ArrayList<Object>> getParameters() {
@@ -67,7 +65,7 @@ public class OscarSelectForUpdateRecognizerTest {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -78,7 +76,7 @@ public class OscarSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.setSelect(null);
-            new OscarSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new KingbaseSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
 
         //test for query was null
@@ -87,7 +85,7 @@ public class OscarSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.getSelect().setQuery(null);
-            new OscarSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new KingbaseSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
     }
 
@@ -96,7 +94,7 @@ public class OscarSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -105,7 +103,7 @@ public class OscarSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oscar;
+package org.apache.seata.sqlparser.druid.kingbase;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -24,7 +24,7 @@ import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleCursorExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oscar.OscarUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.kingbase.KingbaseUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,19 +32,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * The Oscar Update Recognizer Test.
- */
-public class OscarUpdateRecognizerTest {
 
-    private static final String DB_TYPE = "oscar";
+public class KingbaseUpdateRecognizerTest {
+
+    private static final String DB_TYPE = "kingbase";
 
     @Test
     public void testGetSqlType() {
         String sql = "update t set n = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.UPDATE);
     }
 
@@ -53,14 +51,14 @@ public class OscarUpdateRecognizerTest {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         List<String> updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         // test with alias
         sql = "update t set a.a = ?, a.b = ?, a.c = ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
@@ -73,8 +71,8 @@ public class OscarUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setColumn(new OracleCursorExpr());
             }
-            OscarUpdateRecognizer oscarUpdateRecognizer = new OscarUpdateRecognizer(s, sqlUpdateStatement);
-            oscarUpdateRecognizer.getUpdateColumns();
+            KingbaseUpdateRecognizer kingbaseUpdateRecognizer = new KingbaseUpdateRecognizer(s, sqlUpdateStatement);
+            kingbaseUpdateRecognizer.getUpdateColumns();
         });
     }
 
@@ -83,14 +81,14 @@ public class OscarUpdateRecognizerTest {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         List<Object> updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with values
         sql = "update t set a = 1, b = 2, c = 3";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
@@ -103,8 +101,8 @@ public class OscarUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setValue(new OracleCursorExpr());
             }
-            OscarUpdateRecognizer oscarUpdateRecognizer = new OscarUpdateRecognizer(s, sqlUpdateStatement);
-            oscarUpdateRecognizer.getUpdateValues();
+            KingbaseUpdateRecognizer kingbaseUpdateRecognizer = new KingbaseUpdateRecognizer(s, sqlUpdateStatement);
+            kingbaseUpdateRecognizer.getUpdateValues();
         });
     }
 
@@ -114,7 +112,7 @@ public class OscarUpdateRecognizerTest {
         String sql = "update t set a = 1";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer,ArrayList<Object>> getParameters() {
@@ -131,7 +129,7 @@ public class OscarUpdateRecognizerTest {
         String sql = "update t set a = 1";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -142,7 +140,7 @@ public class OscarUpdateRecognizerTest {
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -151,7 +149,7 @@ public class OscarUpdateRecognizerTest {
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbDeleteRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mariadb;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,7 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.seata.sqlparser.druid.mariadb.MariadbDeleteRecognizer;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
+import org.apache.seata.sqlparser.druid.BaseRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbInsertRecognizerTest.java
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mariadb;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -27,16 +31,13 @@ import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOrderingExpr;
 
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.mysql.MySQLInsertRecognizer;
 import org.apache.seata.sqlparser.util.JdbcConstants;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 /**
- * The type My sql insert recognizer test.
+ * The type Mariadb insert recognizer test.
  *
  */
-public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
+public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
 
     private final int pkIndex = 0;
 
@@ -50,13 +51,13 @@ public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
 
         SQLStatement statement = getSQLStatement(sql);
 
-        MySQLInsertRecognizer mySQLInsertRecognizer = new MySQLInsertRecognizer(sql, statement);
+        MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(sql, statement);
 
-        Assertions.assertEquals(sql, mySQLInsertRecognizer.getOriginalSQL());
-        Assertions.assertEquals("t1", mySQLInsertRecognizer.getTableName());
-        Assertions.assertEquals(Collections.singletonList("name"), mySQLInsertRecognizer.getInsertColumns());
-        Assertions.assertEquals(1, mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
-        Assertions.assertEquals(Collections.singletonList("name1"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
+        Assertions.assertEquals(sql, insertRecognizer.getOriginalSQL());
+        Assertions.assertEquals("t1", insertRecognizer.getTableName());
+        Assertions.assertEquals(Collections.singletonList("name"), insertRecognizer.getInsertColumns());
+        Assertions.assertEquals(1, insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
+        Assertions.assertEquals(Collections.singletonList("name1"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
     }
 
     /**
@@ -69,13 +70,13 @@ public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
 
         SQLStatement statement = getSQLStatement(sql);
 
-        MySQLInsertRecognizer mySQLInsertRecognizer = new MySQLInsertRecognizer(sql, statement);
+        MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(sql, statement);
 
-        Assertions.assertEquals(sql, mySQLInsertRecognizer.getOriginalSQL());
-        Assertions.assertEquals("t1", mySQLInsertRecognizer.getTableName());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertColumns());
-        Assertions.assertEquals(1, mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
+        Assertions.assertEquals(sql, insertRecognizer.getOriginalSQL());
+        Assertions.assertEquals("t1", insertRecognizer.getTableName());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertColumns());
+        Assertions.assertEquals(1, insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
     }
 
     /**
@@ -88,32 +89,32 @@ public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
 
         SQLStatement statement = getSQLStatement(sql);
 
-        MySQLInsertRecognizer mySQLInsertRecognizer = new MySQLInsertRecognizer(sql, statement);
+        MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(sql, statement);
 
-        Assertions.assertEquals(sql, mySQLInsertRecognizer.getOriginalSQL());
-        Assertions.assertEquals("t1", mySQLInsertRecognizer.getTableName());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertColumns());
-        Assertions.assertEquals(3, mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
-        Assertions.assertEquals(Arrays.asList("name3", "name4"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(1));
-        Assertions.assertEquals(Arrays.asList("name5", "name6"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(2));
+        Assertions.assertEquals(sql, insertRecognizer.getOriginalSQL());
+        Assertions.assertEquals("t1", insertRecognizer.getTableName());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertColumns());
+        Assertions.assertEquals(3, insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
+        Assertions.assertEquals(Arrays.asList("name3", "name4"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(1));
+        Assertions.assertEquals(Arrays.asList("name5", "name6"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(2));
     }
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
 
-        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
+        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
     @Test
     public void testGetTableAlias() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
 
-        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
+        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -122,28 +123,28 @@ public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
 
         //test for no column
         String sql = "insert into t values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
 
-        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
+        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
         //test for normal
         sql = "insert into t(a) values (?)";
-        asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
+        asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
 
-        recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
+        recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
         //test for exception
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MYSQL);
+            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MARIADB);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new MySqlOrderingExpr());
 
-            MySQLInsertRecognizer oracleInsertRecognizer = new MySQLInsertRecognizer(s, sqlInsertStatement);
+            MariadbInsertRecognizer oracleInsertRecognizer = new MariadbInsertRecognizer(s, sqlInsertStatement);
             oracleInsertRecognizer.getInsertColumns();
         });
     }
@@ -152,37 +153,38 @@ public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
     public void testGetInsertRows() {
         //test for null value
         String sql = "insert into t(id, no, name, age, time) values (1, null, 'a', ?, now())";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
 
-        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
+        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
         //test for exception
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MYSQL);
+            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MARIADB);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new MySqlOrderingExpr());
 
-            MySQLInsertRecognizer mysqlInsertRecognizer = new MySQLInsertRecognizer(s, sqlInsertStatement);
-            mysqlInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
+            MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(s, sqlInsertStatement);
+            insertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
         });
     }
 
     @Override
     public String getDbType() {
-        return JdbcConstants.MYSQL;
+        return JdbcConstants.MARIADB;
     }
 
     @Test
     public void testGetInsertColumns_2() {
         String sql = "insert into t(`id`, `no`, `name`, `age`) values (1, 'no001', 'aaa', '20')";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
-        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
+        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         for (String insertColumn : insertColumns) {
             Assertions.assertTrue(insertColumn.contains("`"));
         }
     }
+
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbSelectForUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mariadb;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.seata.sqlparser.druid.mariadb.MariadbSelectForUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mariadb/MariadbUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mariadb;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.seata.sqlparser.druid.mariadb.MariadbUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLDeleteRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mysql;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,8 @@ import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOrderingExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.mysql.MySQLDeleteRecognizer;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
+import org.apache.seata.sqlparser.druid.BaseRecognizer;
 import org.apache.seata.sqlparser.util.JdbcConstants;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLInsertRecognizerTest.java
@@ -14,16 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mysql;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import org.apache.seata.sqlparser.druid.mariadb.MariadbInsertRecognizer;
-import org.apache.seata.sqlparser.druid.mysql.MySQLInsertRecognizer;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -32,13 +27,16 @@ import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOrderingExpr;
 
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
 import org.apache.seata.sqlparser.util.JdbcConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
- * The type Mariadb insert recognizer test.
+ * The type My sql insert recognizer test.
  *
  */
-public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
+public class MySQLInsertRecognizerTest extends AbstractRecognizerTest {
 
     private final int pkIndex = 0;
 
@@ -52,13 +50,13 @@ public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
 
         SQLStatement statement = getSQLStatement(sql);
 
-        MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(sql, statement);
+        MySQLInsertRecognizer mySQLInsertRecognizer = new MySQLInsertRecognizer(sql, statement);
 
-        Assertions.assertEquals(sql, insertRecognizer.getOriginalSQL());
-        Assertions.assertEquals("t1", insertRecognizer.getTableName());
-        Assertions.assertEquals(Collections.singletonList("name"), insertRecognizer.getInsertColumns());
-        Assertions.assertEquals(1, insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
-        Assertions.assertEquals(Collections.singletonList("name1"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
+        Assertions.assertEquals(sql, mySQLInsertRecognizer.getOriginalSQL());
+        Assertions.assertEquals("t1", mySQLInsertRecognizer.getTableName());
+        Assertions.assertEquals(Collections.singletonList("name"), mySQLInsertRecognizer.getInsertColumns());
+        Assertions.assertEquals(1, mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
+        Assertions.assertEquals(Collections.singletonList("name1"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
     }
 
     /**
@@ -71,13 +69,13 @@ public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
 
         SQLStatement statement = getSQLStatement(sql);
 
-        MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(sql, statement);
+        MySQLInsertRecognizer mySQLInsertRecognizer = new MySQLInsertRecognizer(sql, statement);
 
-        Assertions.assertEquals(sql, insertRecognizer.getOriginalSQL());
-        Assertions.assertEquals("t1", insertRecognizer.getTableName());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertColumns());
-        Assertions.assertEquals(1, insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
+        Assertions.assertEquals(sql, mySQLInsertRecognizer.getOriginalSQL());
+        Assertions.assertEquals("t1", mySQLInsertRecognizer.getTableName());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertColumns());
+        Assertions.assertEquals(1, mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
     }
 
     /**
@@ -90,32 +88,32 @@ public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
 
         SQLStatement statement = getSQLStatement(sql);
 
-        MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(sql, statement);
+        MySQLInsertRecognizer mySQLInsertRecognizer = new MySQLInsertRecognizer(sql, statement);
 
-        Assertions.assertEquals(sql, insertRecognizer.getOriginalSQL());
-        Assertions.assertEquals("t1", insertRecognizer.getTableName());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertColumns());
-        Assertions.assertEquals(3, insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
-        Assertions.assertEquals(Arrays.asList("name1", "name2"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
-        Assertions.assertEquals(Arrays.asList("name3", "name4"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(1));
-        Assertions.assertEquals(Arrays.asList("name5", "name6"), insertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(2));
+        Assertions.assertEquals(sql, mySQLInsertRecognizer.getOriginalSQL());
+        Assertions.assertEquals("t1", mySQLInsertRecognizer.getTableName());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertColumns());
+        Assertions.assertEquals(3, mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).size());
+        Assertions.assertEquals(Arrays.asList("name1", "name2"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(0));
+        Assertions.assertEquals(Arrays.asList("name3", "name4"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(1));
+        Assertions.assertEquals(Arrays.asList("name5", "name6"), mySQLInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex)).get(2));
     }
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
 
-        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
+        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
     @Test
     public void testGetTableAlias() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
 
-        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
+        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -124,28 +122,28 @@ public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
 
         //test for no column
         String sql = "insert into t values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
 
-        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
+        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
         //test for normal
         sql = "insert into t(a) values (?)";
-        asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
+        asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
 
-        recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
+        recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
         //test for exception
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MARIADB);
+            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MYSQL);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new MySqlOrderingExpr());
 
-            MariadbInsertRecognizer oracleInsertRecognizer = new MariadbInsertRecognizer(s, sqlInsertStatement);
+            MySQLInsertRecognizer oracleInsertRecognizer = new MySQLInsertRecognizer(s, sqlInsertStatement);
             oracleInsertRecognizer.getInsertColumns();
         });
     }
@@ -154,38 +152,37 @@ public class MariadbInsertRecognizerTest extends AbstractRecognizerTest {
     public void testGetInsertRows() {
         //test for null value
         String sql = "insert into t(id, no, name, age, time) values (1, null, 'a', ?, now())";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
 
-        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
+        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
         //test for exception
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MARIADB);
+            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, JdbcConstants.MYSQL);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new MySqlOrderingExpr());
 
-            MariadbInsertRecognizer insertRecognizer = new MariadbInsertRecognizer(s, sqlInsertStatement);
-            insertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
+            MySQLInsertRecognizer mysqlInsertRecognizer = new MySQLInsertRecognizer(s, sqlInsertStatement);
+            mysqlInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
         });
     }
 
     @Override
     public String getDbType() {
-        return JdbcConstants.MARIADB;
+        return JdbcConstants.MYSQL;
     }
 
     @Test
     public void testGetInsertColumns_2() {
         String sql = "insert into t(`id`, `no`, `name`, `age`) values (1, 'no001', 'aaa', '20')";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MARIADB);
-        MariadbInsertRecognizer recognizer = new MariadbInsertRecognizer(sql, asts.get(0));
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, JdbcConstants.MYSQL);
+        MySQLInsertRecognizer recognizer = new MySQLInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         for (String insertColumn : insertColumns) {
             Assertions.assertTrue(insertColumn.contains("`"));
         }
     }
-
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLSelectForUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mysql;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,7 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.mysql.MySQLSelectForUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
 import org.apache.seata.sqlparser.util.JdbcConstants;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/mysql/MySQLUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.sqlparser.druid;
+package org.apache.seata.sqlparser.druid.mysql;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -25,7 +25,7 @@ import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlOrderingExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.mysql.MySQLUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
 import org.apache.seata.sqlparser.util.JdbcConstants;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleDeleteRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.dm;
+package org.apache.seata.sqlparser.druid.oracle;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,7 @@ import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleArgumentExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.dm.DmDeleteRecognizer;
+import org.apache.seata.sqlparser.druid.oracle.OracleDeleteRecognizer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,16 +31,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
-public class DmDeleteRecognizerTest {
+public class OracleDeleteRecognizerTest {
 
-    private static final String DB_TYPE = "dm";
+    private static final String DB_TYPE = "oracle";
 
     @Test
     public void testGetSqlType() {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.DELETE);
     }
 
@@ -49,7 +49,7 @@ public class DmDeleteRecognizerTest {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -58,7 +58,7 @@ public class DmDeleteRecognizerTest {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -67,10 +67,10 @@ public class DmDeleteRecognizerTest {
         String sql = "delete from t";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer, ArrayList<Object>> getParameters() {
+            public Map<Integer,ArrayList<Object>> getParameters() {
                 return null;
             }
         }, new ArrayList<>());
@@ -81,10 +81,10 @@ public class DmDeleteRecognizerTest {
         sql = "delete from t where id = ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer, ArrayList<Object>> getParameters() {
+            public Map<Integer,ArrayList<Object>> getParameters() {
                 ArrayList<Object> idParam = new ArrayList<>();
                 idParam.add(1);
                 Map result = new HashMap();
@@ -98,10 +98,10 @@ public class DmDeleteRecognizerTest {
 
         sql = "delete from t where id in (?)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer, ArrayList<Object>> getParameters() {
+            public Map<Integer,ArrayList<Object>> getParameters() {
                 ArrayList<Object> idParam = new ArrayList<>();
                 idParam.add(1);
                 Map result = new HashMap();
@@ -115,10 +115,10 @@ public class DmDeleteRecognizerTest {
 
         sql = "delete from t where id between ? and ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer, ArrayList<Object>> getParameters() {
+            public Map<Integer,ArrayList<Object>> getParameters() {
                 ArrayList<Object> idParam = new ArrayList<>();
                 idParam.add(1);
                 ArrayList<Object> idParam2 = new ArrayList<>();
@@ -138,9 +138,9 @@ public class DmDeleteRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLDeleteStatement deleteAst = (SQLDeleteStatement) sqlStatements.get(0);
             deleteAst.setWhere(new OracleArgumentExpr());
-            new DmDeleteRecognizer(s, deleteAst).getWhereCondition(new ParametersHolder() {
+            new OracleDeleteRecognizer(s, deleteAst).getWhereCondition(new ParametersHolder() {
                 @Override
-                public Map<Integer, ArrayList<Object>> getParameters() {
+                public Map<Integer,ArrayList<Object>> getParameters() {
                     return new HashMap<>();
                 }
             }, new ArrayList<>());
@@ -153,7 +153,7 @@ public class DmDeleteRecognizerTest {
         String sql = "delete from t";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmDeleteRecognizer recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        OracleDeleteRecognizer recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         //test for no condition
@@ -162,7 +162,7 @@ public class DmDeleteRecognizerTest {
         sql = "delete from t where id = 1";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition();
 
         //test for normal sql
@@ -170,7 +170,7 @@ public class DmDeleteRecognizerTest {
 
         sql = "delete from t where id in (1)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition();
 
         //test for sql with in
@@ -178,7 +178,7 @@ public class DmDeleteRecognizerTest {
 
         sql = "delete from t where id between 1 and 2";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new DmDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OracleDeleteRecognizer(sql, asts.get(0));
         whereCondition = recognizer.getWhereCondition();
         //test for sql with in
         Assertions.assertEquals("id BETWEEN 1 AND 2", whereCondition);
@@ -189,7 +189,7 @@ public class DmDeleteRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLDeleteStatement deleteAst = (SQLDeleteStatement) sqlStatements.get(0);
             deleteAst.setWhere(new OracleArgumentExpr());
-            new DmDeleteRecognizer(s, deleteAst).getWhereCondition();
+            new OracleDeleteRecognizer(s, deleteAst).getWhereCondition();
         });
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
@@ -14,33 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.kingbase;
+package org.apache.seata.sqlparser.druid.oracle;
 
+import java.util.Collections;
+import java.util.List;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.kingbase.KingbaseInsertRecognizer;
+import org.apache.seata.sqlparser.druid.oracle.OracleInsertRecognizer;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
 
+public class OracleInsertRecognizerTest {
 
-public class KingbaseInsertRecognizerTest {
-
-    private static final String DB_TYPE = "kingbase";
+    private static final String DB_TYPE = "oracle";
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
+        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
@@ -49,7 +48,7 @@ public class KingbaseInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
+        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -58,7 +57,7 @@ public class KingbaseInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
+        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -69,7 +68,7 @@ public class KingbaseInsertRecognizerTest {
         String sql = "insert into t values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
+        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
@@ -77,7 +76,7 @@ public class KingbaseInsertRecognizerTest {
         sql = "insert into t(a) values (?)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
+        recognizer = new OracleInsertRecognizer(sql, asts.get(0));
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
@@ -88,8 +87,8 @@ public class KingbaseInsertRecognizerTest {
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
-            KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
-            kingbaseInsertRecognizer.getInsertColumns();
+            OracleInsertRecognizer oracleInsertRecognizer = new OracleInsertRecognizer(s, sqlInsertStatement);
+            oracleInsertRecognizer.getInsertColumns();
         });
     }
 
@@ -100,7 +99,7 @@ public class KingbaseInsertRecognizerTest {
         String sql = "insert into t(id, no, name, age, time) values (id_seq.nextval, null, 'a', ?, now())";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseInsertRecognizer recognizer = new KingbaseInsertRecognizer(sql, asts.get(0));
+        OracleInsertRecognizer recognizer = new OracleInsertRecognizer(sql, asts.get(0));
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
@@ -111,8 +110,8 @@ public class KingbaseInsertRecognizerTest {
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
 
-            KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
-            kingbaseInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
+            OracleInsertRecognizer oracleInsertRecognizer = new OracleInsertRecognizer(s, sqlInsertStatement);
+            oracleInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
         });
     }
 
@@ -121,8 +120,8 @@ public class KingbaseInsertRecognizerTest {
         String sql = "insert into test(create_time) values(sysdate)";
         List<SQLStatement> sqlStatements = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseInsertRecognizer kingbase = new KingbaseInsertRecognizer(sql, sqlStatements.get(0));
-        List<List<Object>> insertRows = kingbase.getInsertRows(Collections.singletonList(-1));
+        OracleInsertRecognizer oracle = new OracleInsertRecognizer(sql, sqlStatements.get(0));
+        List<List<Object>> insertRows = oracle.getInsertRows(Collections.singletonList(-1));
         Assertions.assertTrue(insertRows.get(0).get(0) instanceof NotPlaceholderExpr);
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleSelectForUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.kingbase;
+package org.apache.seata.sqlparser.druid.oracle;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,7 +22,7 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.kingbase.KingbaseSelectForUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.oracle.OracleSelectForUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,16 +31,16 @@ import java.util.List;
 import java.util.Map;
 
 
-public class KingbaseSelectForUpdateRecognizerTest {
+public class OracleSelectForUpdateRecognizerTest {
 
-    private static final String DB_TYPE = "kingbase";
+    private static final String DB_TYPE = "oracle";
 
     @Test
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
+        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
 
@@ -50,7 +50,7 @@ public class KingbaseSelectForUpdateRecognizerTest {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
+        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer,ArrayList<Object>> getParameters() {
@@ -65,7 +65,7 @@ public class KingbaseSelectForUpdateRecognizerTest {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
+        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -76,7 +76,7 @@ public class KingbaseSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.setSelect(null);
-            new KingbaseSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new OracleSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
 
         //test for query was null
@@ -85,7 +85,7 @@ public class KingbaseSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.getSelect().setQuery(null);
-            new KingbaseSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new OracleSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
     }
 
@@ -94,7 +94,7 @@ public class KingbaseSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
+        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -103,7 +103,7 @@ public class KingbaseSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseSelectForUpdateRecognizer recognizer = new KingbaseSelectForUpdateRecognizer(sql, asts.get(0));
+        OracleSelectForUpdateRecognizer recognizer = new OracleSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.kingbase;
+package org.apache.seata.sqlparser.druid.oracle;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -24,7 +24,7 @@ import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleCursorExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.kingbase.KingbaseUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.oracle.OracleUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -33,16 +33,16 @@ import java.util.List;
 import java.util.Map;
 
 
-public class KingbaseUpdateRecognizerTest {
+public class OracleUpdateRecognizerTest {
 
-    private static final String DB_TYPE = "kingbase";
+    private static final String DB_TYPE = "oracle";
 
     @Test
     public void testGetSqlType() {
         String sql = "update t set n = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.UPDATE);
     }
 
@@ -51,14 +51,14 @@ public class KingbaseUpdateRecognizerTest {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         List<String> updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         // test with alias
         sql = "update t set a.a = ?, a.b = ?, a.c = ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
@@ -71,8 +71,8 @@ public class KingbaseUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setColumn(new OracleCursorExpr());
             }
-            KingbaseUpdateRecognizer kingbaseUpdateRecognizer = new KingbaseUpdateRecognizer(s, sqlUpdateStatement);
-            kingbaseUpdateRecognizer.getUpdateColumns();
+            OracleUpdateRecognizer oracleUpdateRecognizer = new OracleUpdateRecognizer(s, sqlUpdateStatement);
+            oracleUpdateRecognizer.getUpdateColumns();
         });
     }
 
@@ -81,14 +81,14 @@ public class KingbaseUpdateRecognizerTest {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         List<Object> updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with values
         sql = "update t set a = 1, b = 2, c = 3";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
@@ -101,8 +101,8 @@ public class KingbaseUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setValue(new OracleCursorExpr());
             }
-            KingbaseUpdateRecognizer kingbaseUpdateRecognizer = new KingbaseUpdateRecognizer(s, sqlUpdateStatement);
-            kingbaseUpdateRecognizer.getUpdateValues();
+            OracleUpdateRecognizer oracleUpdateRecognizer = new OracleUpdateRecognizer(s, sqlUpdateStatement);
+            oracleUpdateRecognizer.getUpdateValues();
         });
     }
 
@@ -112,7 +112,7 @@ public class KingbaseUpdateRecognizerTest {
         String sql = "update t set a = 1";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer,ArrayList<Object>> getParameters() {
@@ -129,7 +129,7 @@ public class KingbaseUpdateRecognizerTest {
         String sql = "update t set a = 1";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -140,7 +140,7 @@ public class KingbaseUpdateRecognizerTest {
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -149,7 +149,7 @@ public class KingbaseUpdateRecognizerTest {
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        KingbaseUpdateRecognizer recognizer = new KingbaseUpdateRecognizer(sql, asts.get(0));
+        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarDeleteRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oscar;
+package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.dm;
+package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,24 +22,27 @@ import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.dm.DmInsertRecognizer;
+import org.apache.seata.sqlparser.druid.oscar.OscarInsertRecognizer;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.List;
 
-public class DmInsertRecognizerTest {
+/**
+ * The type Oscar insert recognizer test.
+ */
+public class OscarInsertRecognizerTest {
 
-    private static final String DB_TYPE = "dm";
+    private static final String DB_TYPE = "oscar";
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
@@ -48,7 +51,7 @@ public class DmInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -57,7 +60,7 @@ public class DmInsertRecognizerTest {
         String sql = "insert into t(id) values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -68,7 +71,7 @@ public class DmInsertRecognizerTest {
         String sql = "insert into t values (?)";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
@@ -76,7 +79,7 @@ public class DmInsertRecognizerTest {
         sql = "insert into t(a) values (?)";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        recognizer = new DmInsertRecognizer(sql, asts.get(0));
+        recognizer = new OscarInsertRecognizer(sql, asts.get(0));
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
@@ -84,11 +87,11 @@ public class DmInsertRecognizerTest {
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
+            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
-            DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
-            dmInsertRecognizer.getInsertColumns();
+            OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
+            oscarInsertRecognizer.getInsertColumns();
         });
     }
 
@@ -99,7 +102,7 @@ public class DmInsertRecognizerTest {
         String sql = "insert into t(id, no, name, age, time) values (id_seq.nextval, null, 'a', ?, now())";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmInsertRecognizer recognizer = new DmInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
@@ -107,11 +110,11 @@ public class DmInsertRecognizerTest {
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
+            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement)sqlStatements.get(0);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
 
-            DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
-            dmInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
+            OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
+            oscarInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));
         });
     }
 
@@ -119,10 +122,9 @@ public class DmInsertRecognizerTest {
     public void testNotPlaceholder_giveValidPkIndex() {
         String sql = "insert into test(create_time) values(sysdate)";
         List<SQLStatement> sqlStatements = SQLUtils.parseStatements(sql, DB_TYPE);
-        ;
 
-        DmInsertRecognizer dm = new DmInsertRecognizer(sql, sqlStatements.get(0));
-        List<List<Object>> insertRows = dm.getInsertRows(Collections.singletonList(-1));
+        OscarInsertRecognizer oscar = new OscarInsertRecognizer(sql, sqlStatements.get(0));
+        List<List<Object>> insertRows = oscar.getInsertRows(Collections.singletonList(-1));
         Assertions.assertTrue(insertRows.get(0).get(0) instanceof NotPlaceholderExpr);
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarSelectForUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.dm;
+package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -22,36 +22,40 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.dm.DmSelectForUpdateRecognizer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import org.apache.seata.sqlparser.druid.oscar.OscarSelectForUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
-public class DmSelectForUpdateRecognizerTest {
+/**
+ * The type Oscar select for update recognizer test.
+ */
+public class OscarSelectForUpdateRecognizerTest {
 
-    private static final String DB_TYPE = "dm";
+    private static final String DB_TYPE = "oscar";
 
     @Test
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
+
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
-            public Map<Integer, ArrayList<Object>> getParameters() {
+            public Map<Integer,ArrayList<Object>> getParameters() {
                 return null;
             }
         }, new ArrayList<>());
@@ -63,7 +67,7 @@ public class DmSelectForUpdateRecognizerTest {
         String sql = "select * from t for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -74,7 +78,7 @@ public class DmSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.setSelect(null);
-            new DmSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new OscarSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
 
         //test for query was null
@@ -83,7 +87,7 @@ public class DmSelectForUpdateRecognizerTest {
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
             selectAst.getSelect().setQuery(null);
-            new DmSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
+            new OscarSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
     }
 
@@ -92,7 +96,7 @@ public class DmSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -101,7 +105,7 @@ public class DmSelectForUpdateRecognizerTest {
         String sql = "select * from t where id = ? for update";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        DmSelectForUpdateRecognizer recognizer = new DmSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.oracle;
+package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
@@ -24,7 +24,7 @@ import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleCursorExpr;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.oracle.OracleUpdateRecognizer;
+import org.apache.seata.sqlparser.druid.oscar.OscarUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,17 +32,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The Oscar Update Recognizer Test.
+ */
+public class OscarUpdateRecognizerTest {
 
-public class OracleUpdateRecognizerTest {
-
-    private static final String DB_TYPE = "oracle";
+    private static final String DB_TYPE = "oscar";
 
     @Test
     public void testGetSqlType() {
         String sql = "update t set n = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.UPDATE);
     }
 
@@ -51,14 +53,14 @@ public class OracleUpdateRecognizerTest {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         List<String> updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         // test with alias
         sql = "update t set a.a = ?, a.b = ?, a.c = ?";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
@@ -71,8 +73,8 @@ public class OracleUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setColumn(new OracleCursorExpr());
             }
-            OracleUpdateRecognizer oracleUpdateRecognizer = new OracleUpdateRecognizer(s, sqlUpdateStatement);
-            oracleUpdateRecognizer.getUpdateColumns();
+            OscarUpdateRecognizer oscarUpdateRecognizer = new OscarUpdateRecognizer(s, sqlUpdateStatement);
+            oscarUpdateRecognizer.getUpdateColumns();
         });
     }
 
@@ -81,14 +83,14 @@ public class OracleUpdateRecognizerTest {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         List<Object> updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with values
         sql = "update t set a = 1, b = 2, c = 3";
         asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
@@ -101,8 +103,8 @@ public class OracleUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setValue(new OracleCursorExpr());
             }
-            OracleUpdateRecognizer oracleUpdateRecognizer = new OracleUpdateRecognizer(s, sqlUpdateStatement);
-            oracleUpdateRecognizer.getUpdateValues();
+            OscarUpdateRecognizer oscarUpdateRecognizer = new OscarUpdateRecognizer(s, sqlUpdateStatement);
+            oscarUpdateRecognizer.getUpdateValues();
         });
     }
 
@@ -112,7 +114,7 @@ public class OracleUpdateRecognizerTest {
         String sql = "update t set a = 1";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer,ArrayList<Object>> getParameters() {
@@ -129,7 +131,7 @@ public class OracleUpdateRecognizerTest {
         String sql = "update t set a = 1";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -140,7 +142,7 @@ public class OracleUpdateRecognizerTest {
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -149,7 +151,7 @@ public class OracleUpdateRecognizerTest {
         String sql = "update t set a = ?, b = ?, c = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        OracleUpdateRecognizer recognizer = new OracleUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlDeleteRecognizerTest.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.postgresql;
+package org.apache.seata.sqlparser.druid.postgresql;
 
 import org.apache.seata.sqlparser.ParametersHolder;
-import org.apache.seata.sqlparser.SQLDeleteRecognizer;
-import org.apache.seata.sqlparser.SQLRecognizer;
 import org.apache.seata.sqlparser.SQLType;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,8 +24,6 @@ import java.util.Map;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
-
-import org.apache.seata.rm.datasource.sql.SQLVisitorFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,35 +35,38 @@ public class PostgresqlDeleteRecognizerTest {
     @Test
     public void testGetSqlType() {
         String sql = "delete from t where id = ?";
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) sqlRecognizers.get(0);
-        Assertions.assertEquals(recognizer.getSQLType(), SQLType.DELETE);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        PostgresqlDeleteRecognizer postgresqlDeleteRecognizer = new PostgresqlDeleteRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlDeleteRecognizer.getSQLType(), SQLType.DELETE);
     }
 
     @Test
     public void testGetTableAlias() {
         String sql = "delete from t where id = ?";
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) sqlRecognizers.get(0);
-        Assertions.assertNull(recognizer.getTableAlias());
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        PostgresqlDeleteRecognizer postgresqlDeleteRecognizer = new PostgresqlDeleteRecognizer(sql, asts.get(0));
+        Assertions.assertNull(postgresqlDeleteRecognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) sqlRecognizers.get(0);
-        Assertions.assertEquals(recognizer.getTableName(), "t");
+
+        PostgresqlDeleteRecognizer postgresqlDeleteRecognizer = new PostgresqlDeleteRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlDeleteRecognizer.getTableName(), "t");
     }
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "delete from t";
 
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) sqlRecognizers.get(0);
-        String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        PostgresqlDeleteRecognizer postgresqlDeleteRecognizer = new PostgresqlDeleteRecognizer(sql, asts.get(0));
+        String whereCondition = postgresqlDeleteRecognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer,ArrayList<Object>> getParameters() {
                 return null;
@@ -82,9 +81,9 @@ public class PostgresqlDeleteRecognizerTest {
     public void testGetWhereCondition_1() {
         String sql = "delete from t";
 
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) sqlRecognizers.get(0);
-        String whereCondition = recognizer.getWhereCondition();
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlDeleteRecognizer postgresqlDeleteRecognizer = new PostgresqlDeleteRecognizer(sql, asts.get(0));
+        String whereCondition = postgresqlDeleteRecognizer.getWhereCondition();
 
         //test for no condition
         Assertions.assertEquals("", whereCondition);

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlInsertRecognizerTest.java
@@ -14,13 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.postgresql;
+package org.apache.seata.sqlparser.druid.postgresql;
 
-import org.apache.seata.sqlparser.SQLInsertRecognizer;
 import org.apache.seata.sqlparser.SQLParsingException;
-import org.apache.seata.sqlparser.SQLRecognizer;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.druid.postgresql.PostgresqlInsertRecognizer;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +26,6 @@ import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.expr.SQLBetweenExpr;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import org.apache.seata.rm.datasource.sql.SQLVisitorFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -42,27 +38,26 @@ public class PostgresqlInsertRecognizerTest {
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
 
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) sqlRecognizers.get(0);
-        Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlInsertRecognizer postgresqlInsertRecognizer = new PostgresqlInsertRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlInsertRecognizer.getSQLType(), SQLType.INSERT);
     }
 
     @Test
     public void testGetTableAlias() {
         String sql = "insert into t(id) values (?)";
 
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) sqlRecognizers.get(0);
-        Assertions.assertNull(recognizer.getTableAlias());
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlInsertRecognizer postgresqlInsertRecognizer = new PostgresqlInsertRecognizer(sql, asts.get(0));
+        Assertions.assertNull(postgresqlInsertRecognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "insert into t(id) values (?)";
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-
-        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) sqlRecognizers.get(0);
-        Assertions.assertEquals(recognizer.getTableName(), "t");
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlInsertRecognizer postgresqlInsertRecognizer = new PostgresqlInsertRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlInsertRecognizer.getTableName(), "t");
     }
 
     @Test
@@ -71,16 +66,17 @@ public class PostgresqlInsertRecognizerTest {
         //test for no column
         String sql = "insert into t values (?)";
 
-        List<SQLRecognizer> sqlRecognizers = SQLVisitorFactory.get(sql, DB_TYPE);
-        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) sqlRecognizers.get(0);
-        List<String> insertColumns = recognizer.getInsertColumns();
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlInsertRecognizer postgresqlInsertRecognizer = new PostgresqlInsertRecognizer(sql, asts.get(0));
+        List<String> insertColumns = postgresqlInsertRecognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
         //test for normal
         sql = "insert into t(a) values (?)";
 
-        recognizer = (SQLInsertRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        insertColumns = recognizer.getInsertColumns();
+        asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        postgresqlInsertRecognizer = new PostgresqlInsertRecognizer(sql, asts.get(0));
+        insertColumns = postgresqlInsertRecognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
         //test for exception
@@ -90,8 +86,8 @@ public class PostgresqlInsertRecognizerTest {
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
             sqlInsertStatement.getColumns().add(new SQLBetweenExpr());
 
-            PostgresqlInsertRecognizer postgresqlInsertRecognizer = new PostgresqlInsertRecognizer(s, sqlInsertStatement);
-            postgresqlInsertRecognizer.getInsertColumns();
+            PostgresqlInsertRecognizer postgresqlInsertRecognizer1 = new PostgresqlInsertRecognizer(s, sqlInsertStatement);
+            postgresqlInsertRecognizer1.getInsertColumns();
         });
     }
 
@@ -101,8 +97,9 @@ public class PostgresqlInsertRecognizerTest {
         //test for null value
         String sql = "insert into t(id, no, name, age, time) values (nextval('id_seq'), null, 'a', ?, now())";
 
-        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlInsertRecognizer postgresqlInsertRecognizer1 = new PostgresqlInsertRecognizer(sql, asts.get(0));
+        List<List<Object>> insertRows = postgresqlInsertRecognizer1.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
         //test for exception

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlSelectForUpdateRecognizerTest.java
@@ -14,14 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.postgresql;
+package org.apache.seata.sqlparser.druid.postgresql;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-import org.apache.seata.rm.datasource.sql.SQLVisitorFactory;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
-import org.apache.seata.sqlparser.SQLSelectRecognizer;
 import org.apache.seata.sqlparser.SQLType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -35,16 +36,18 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
 
-        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlSelectForUpdateRecognizer postgresqlSelectForUpdateRecognizer = new PostgresqlSelectForUpdateRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlSelectForUpdateRecognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "select * from t for update";
 
-        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlSelectForUpdateRecognizer postgresqlSelectForUpdateRecognizer = new PostgresqlSelectForUpdateRecognizer(sql, asts.get(0));
+        String whereCondition = postgresqlSelectForUpdateRecognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer, ArrayList<Object>> getParameters() {
                 return null;
@@ -57,8 +60,9 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     public void testGetWhereCondition_1() {
         String sql = "select * from t for update";
 
-        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        String whereCondition = recognizer.getWhereCondition();
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlSelectForUpdateRecognizer postgresqlSelectForUpdateRecognizer = new PostgresqlSelectForUpdateRecognizer(sql, asts.get(0));
+        String whereCondition = postgresqlSelectForUpdateRecognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
     }
@@ -66,14 +70,16 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     @Test
     public void testGetTableAlias() {
         String sql = "select * from t where id = ? for update";
-        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        Assertions.assertNull(recognizer.getTableAlias());
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlSelectForUpdateRecognizer postgresqlSelectForUpdateRecognizer = new PostgresqlSelectForUpdateRecognizer(sql, asts.get(0));
+        Assertions.assertNull(postgresqlSelectForUpdateRecognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "select * from t where id = ? for update";
-        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        Assertions.assertEquals(recognizer.getTableName(), "t");
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlSelectForUpdateRecognizer postgresqlSelectForUpdateRecognizer = new PostgresqlSelectForUpdateRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlSelectForUpdateRecognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/postgresql/PostgresqlUpdateRecognizerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.rm.datasource.sql.druid.postgresql;
+package org.apache.seata.sqlparser.druid.postgresql;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,12 +25,9 @@ import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.expr.SQLBetweenExpr;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateSetItem;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
-import org.apache.seata.rm.datasource.sql.SQLVisitorFactory;
 import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
-import org.apache.seata.sqlparser.SQLUpdateRecognizer;
-import org.apache.seata.sqlparser.druid.postgresql.PostgresqlUpdateRecognizer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,22 +40,27 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetSqlType() {
         String sql = "update t set n = ?";
 
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        Assertions.assertEquals(recognizer.getSQLType(), SQLType.UPDATE);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlUpdateRecognizer.getSQLType(), SQLType.UPDATE);
     }
 
     @Test
     public void testGetUpdateColumns() {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        List<String> updateColumns = recognizer.getUpdateColumns();
+//        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        List<String> updateColumns = postgresqlUpdateRecognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         // test with alias
         sql = "update t set a.a = ?, a.b = ?, a.c = ?";
-        recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        updateColumns = recognizer.getUpdateColumns();
+//        recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
+        asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        updateColumns = postgresqlUpdateRecognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         //test with error
@@ -70,8 +72,8 @@ public class PostgresqlUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setColumn(new SQLBetweenExpr());
             }
-            PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(s, sqlUpdateStatement);
-            postgresqlUpdateRecognizer.getUpdateColumns();
+            PostgresqlUpdateRecognizer postgresqlUpdateRecognizer1 = new PostgresqlUpdateRecognizer(s, sqlUpdateStatement);
+            postgresqlUpdateRecognizer1.getUpdateColumns();
         });
     }
 
@@ -79,14 +81,16 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetUpdateValues() {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        List<Object> updateValues = recognizer.getUpdateValues();
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        List<Object> updateValues = postgresqlUpdateRecognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with values
         sql = "update t set a = 1, b = 2, c = 3";
-        recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        updateValues = recognizer.getUpdateValues();
+        asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        updateValues = postgresqlUpdateRecognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with error
@@ -98,16 +102,17 @@ public class PostgresqlUpdateRecognizerTest {
             for (SQLUpdateSetItem updateSetItem : updateSetItems) {
                 updateSetItem.setValue(new SQLBetweenExpr());
             }
-            PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(s, sqlUpdateStatement);
-            postgresqlUpdateRecognizer.getUpdateValues();
+            PostgresqlUpdateRecognizer postgresqlUpdateRecognizer1 = new PostgresqlUpdateRecognizer(s, sqlUpdateStatement);
+            postgresqlUpdateRecognizer1.getUpdateValues();
         });
     }
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "update t set a = 1";
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        String whereCondition = postgresqlUpdateRecognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public Map<Integer, ArrayList<Object>> getParameters() {
                 return null;
@@ -121,8 +126,9 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetWhereCondition_1() {
 
         String sql = "update t set a = 1";
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        String whereCondition = recognizer.getWhereCondition();
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        String whereCondition = postgresqlUpdateRecognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
     }
@@ -130,15 +136,17 @@ public class PostgresqlUpdateRecognizerTest {
     @Test
     public void testGetTableAlias() {
         String sql = "update t set a = ?, b = ?, c = ?";
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        Assertions.assertNull(recognizer.getTableAlias());
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        Assertions.assertNull(postgresqlUpdateRecognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "update t set a = ?, b = ?, c = ?";
-        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE).get(0);
-        Assertions.assertEquals(recognizer.getTableName(), "t");
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        PostgresqlUpdateRecognizer postgresqlUpdateRecognizer = new PostgresqlUpdateRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(postgresqlUpdateRecognizer.getTableName(), "t");
     }
 
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

1. Organized the mariadb and mysql test classes, and moved them to the corresponding folder 
2. dm, kingbase, oracle, oscar test classes already exist and are located in 【org.apache.seata. rm.datasource.sql.druid】 , move them to the seata-sqlparser-druid module (Codecov test coverage is usually based on the module) 
3. Modify the postgresql test class (at 【org.apache.seata. rm.datasource.sql.druid】 ), the original generation method of the postgresql test class based on SQLVisitorFactory was changed to use the construction method, decoupled from the rm module and moved to the seata-sqlparser-druid module

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7198

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
output：
![image](https://github.com/user-attachments/assets/9947e184-115c-46bc-a9c5-482ba35b83b2)

This is a simple refactoring but now the coverage is not high, if we need to add the test code
