### PR TITLE
refactor: changed folder name in org.apache.seata.server.storage.raft.sore from sore to store

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -116,5 +116,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [s-ramyalakshmi](https://github.com/s-ramyalakshmi)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
 - [mehedikhan72](https://github.com/mehedikhan72)
+- [AndrewSf](https://github.com/andrewseif)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -86,6 +86,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### refactor:
 
 - [[#7145](https://github.com/apache/incubator-seata/pull/7145)] refactor the code that does not comply with license requirements
+- [[#7236](https://github.com/apache/incubator-seata/pull/7236)] changed folder name in org.apache.seata.server.storage.raft.sore from sore to store
 
 
 ### doc:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -85,6 +85,7 @@
 ### refactor:
 
 - [[#7145](https://github.com/apache/incubator-seata/pull/7145)] 重构不满足 license 要求的代码
+- [[#7236](https://github.com/apache/incubator-seata/pull/7236)] 将 org.apache.seata.server.storage.raft.sore 中的文件夹名称从 sore 更改为 store
 
 非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -109,5 +109,6 @@
 - [iAmClever](https://github.com/iAmClever)
 - [s-ramyalakshmi](https://github.com/s-ramyalakshmi)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
+- [AndrewSf](https://github.com/andrewseif)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/server/src/main/java/org/apache/seata/server/cluster/raft/execute/vgroup/VGroupAddExecute.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/raft/execute/vgroup/VGroupAddExecute.java
@@ -19,7 +19,7 @@ package org.apache.seata.server.cluster.raft.execute.vgroup;
 import org.apache.seata.server.cluster.raft.execute.AbstractRaftMsgExecute;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftBaseMsg;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftVGroupSyncMsg;
-import org.apache.seata.server.storage.raft.sore.RaftVGroupMappingStoreManager;
+import org.apache.seata.server.storage.raft.store.RaftVGroupMappingStoreManager;
 
 /**
  */

--- a/server/src/main/java/org/apache/seata/server/cluster/raft/execute/vgroup/VGroupRemoveExecute.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/raft/execute/vgroup/VGroupRemoveExecute.java
@@ -19,7 +19,7 @@ package org.apache.seata.server.cluster.raft.execute.vgroup;
 import org.apache.seata.server.cluster.raft.execute.AbstractRaftMsgExecute;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftBaseMsg;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftVGroupSyncMsg;
-import org.apache.seata.server.storage.raft.sore.RaftVGroupMappingStoreManager;
+import org.apache.seata.server.storage.raft.store.RaftVGroupMappingStoreManager;
 
 /**
  */

--- a/server/src/main/java/org/apache/seata/server/cluster/raft/snapshot/vgroup/VGroupSnapshotFile.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/raft/snapshot/vgroup/VGroupSnapshotFile.java
@@ -28,7 +28,7 @@ import org.apache.seata.core.store.MappingDO;
 import org.apache.seata.server.cluster.raft.snapshot.RaftSnapshot;
 import org.apache.seata.server.cluster.raft.snapshot.StoreSnapshotFile;
 import org.apache.seata.server.session.SessionHolder;
-import org.apache.seata.server.storage.raft.sore.RaftVGroupMappingStoreManager;
+import org.apache.seata.server.storage.raft.store.RaftVGroupMappingStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/server/src/main/java/org/apache/seata/server/storage/raft/store/RaftVGroupMappingStoreManager.java
+++ b/server/src/main/java/org/apache/seata/server/storage/raft/store/RaftVGroupMappingStoreManager.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.server.storage.raft.sore;
+package org.apache.seata.server.storage.raft.store;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;

--- a/server/src/main/resources/META-INF/services/org.apache.seata.server.store.VGroupMappingStoreManager
+++ b/server/src/main/resources/META-INF/services/org.apache.seata.server.store.VGroupMappingStoreManager
@@ -17,4 +17,4 @@
 org.apache.seata.server.storage.db.store.DataBaseVGroupMappingStoreManager
 org.apache.seata.server.storage.file.store.FileVGroupMappingStoreManager
 org.apache.seata.server.storage.redis.store.RedisVGroupMappingStoreManager
-org.apache.seata.server.storage.raft.sore.RaftVGroupMappingStoreManager
+org.apache.seata.server.storage.raft.store.RaftVGroupMappingStoreManager


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

In package org.apache.seata.server.storage.raft.sore, the folder name sore is refactored to store, since it is holding the RaftVGroupMappingStoreManager Class.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Check the 2.x branch before committing. 

### Ⅴ. Special notes for reviews

