### PR TITLE
optimize: prevent unexpected NullPointerException in lookup method in FileRegistryServiceImpl class

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -50,7 +50,6 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7241](https://github.com/apache/incubator-seata/pull/7241)] upgrade tomcat-embed-core to 9.0.99 to fix CVE-2025-24813
 - [[#7272](https://github.com/apache/incubator-seata/pull/7272)] fix: fix transaction info not display
 - [[#7277](https://github.com/apache/incubator-seata/pull/7277)] Fix MySQL jdbc driver can't be found properly
-- [[#7282](https://github.com/apache/incubator-seata/pull/7282)] fix unexpected NullPointerException in lookup method in FileRegistryServiceImpl class
 
 ### optimize:
 
@@ -85,7 +84,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7242](https://github.com/apache/incubator-seata/pull/7242)] optimize ratelimit bucketTokenNumPerSecond config
 - [[#7232](https://github.com/apache/incubator-seata/pull/7232)] add license header
 - [[#7260](https://github.com/apache/incubator-seata/pull/7260)] upgrade npmjs dependencies
-
+- [[#7282](https://github.com/apache/incubator-seata/pull/7282)] optimize unexpected NullPointerException in lookup method in FileRegistryServiceImpl class
 
 
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -50,6 +50,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7241](https://github.com/apache/incubator-seata/pull/7241)] upgrade tomcat-embed-core to 9.0.99 to fix CVE-2025-24813
 - [[#7272](https://github.com/apache/incubator-seata/pull/7272)] fix: fix transaction info not display
 - [[#7277](https://github.com/apache/incubator-seata/pull/7277)] Fix MySQL jdbc driver can't be found properly
+- [[#7282](https://github.com/apache/incubator-seata/pull/7282)] fix unexpected NullPointerException in lookup method in FileRegistryServiceImpl class
 
 ### optimize:
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -61,5 +61,5 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 - [slievrly](https://github.com/slievrly)
 - [Monilnarang](https://github.com/Monilnarang)
-
+- [wjwang00](https://github.com/wjwang00)
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,6 +49,7 @@
 - [[#7241](https://github.com/apache/incubator-seata/pull/7241)] 升级 tomcat-embed-core 至 9.0.99 版本以解决 CVE-2025-24813 
 - [[#7272](https://github.com/apache/incubator-seata/pull/7272)] 修复全局事务显示问题
 - [[#7277](https://github.com/apache/incubator-seata/pull/7277)] 修复MySQL jdbc驱动无法正常找到的问题
+- [[#7282](https://github.com/apache/incubator-seata/pull/7282)] 修复FileRegistryServiceImpl类lookup的NullPointerException问题
 
 ### optimize:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,7 +49,6 @@
 - [[#7241](https://github.com/apache/incubator-seata/pull/7241)] 升级 tomcat-embed-core 至 9.0.99 版本以解决 CVE-2025-24813 
 - [[#7272](https://github.com/apache/incubator-seata/pull/7272)] 修复全局事务显示问题
 - [[#7277](https://github.com/apache/incubator-seata/pull/7277)] 修复MySQL jdbc驱动无法正常找到的问题
-- [[#7282](https://github.com/apache/incubator-seata/pull/7282)] 修复FileRegistryServiceImpl类lookup的NullPointerException问题
 
 ### optimize:
 
@@ -83,7 +82,7 @@
 - [[#7250](https://github.com/apache/incubator-seata/pull/7250)] 适配 client_protocol_version > server_protocol_version场景
 - [[#7232](https://github.com/apache/incubator-seata/pull/7232)] 增加 license header
 - [[#7260](https://github.com/apache/incubator-seata/pull/7260)] 升级 npmjs 依赖版本
-
+- [[#7282](https://github.com/apache/incubator-seata/pull/7282)] 优化FileRegistryServiceImpl类lookup的NullPointerException问题
 ### security:
 - [[#6069](https://github.com/apache/incubator-seata/pull/6069)] 升级Guava依赖版本，修复安全漏洞
 - [[#6144](https://github.com/apache/incubator-seata/pull/6144)] 升级Nacos依赖版本至1.4.6

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -60,5 +60,6 @@
 
 - [slievrly](https://github.com/slievrly)
 - [Monilnarang](https://github.com/Monilnarang)
+- [wjwang00](https://github.com/wjwang00)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/common/src/main/java/org/apache/seata/common/util/NetUtil.java
+++ b/common/src/main/java/org/apache/seata/common/util/NetUtil.java
@@ -148,6 +148,15 @@ public class NetUtil {
             if (StringUtils.isBlank(hostAddress) || StringUtils.isBlank(portStr)) {
                 throw new IllegalArgumentException("Invalid endpoint format: " + address + ". Endpoint should be in the format ip:port.");
             }
+            try {
+                int port = Integer.parseInt(portStr);
+                if (port < 1 || port > 65535) {
+                    throw new IllegalArgumentException("Invalid endpoint format: " + address + ". Port must be between 1 and 65535.");
+                }
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid endpoint format: " + address + ". Port must be a numeric value.", e);
+            }
+
             return new String[]{hostAddress, portStr};
         } else {
             throw new IllegalArgumentException("Invalid endpoint format: " + address + ". Endpoint should be in the format ip:port.");

--- a/common/src/main/java/org/apache/seata/common/util/NetUtil.java
+++ b/common/src/main/java/org/apache/seata/common/util/NetUtil.java
@@ -138,18 +138,20 @@ public class NetUtil {
         if (address.charAt(0) == '[') {
             address = removeBrackets(address);
         }
-        String[] serverAddArr = null;
         int i = address.lastIndexOf(Constants.IP_PORT_SPLIT_CHAR);
         if (i > -1) {
-            serverAddArr = new String[2];
-            String hostAddress = address.substring(0,i);
+            String hostAddress = address.substring(0, i);
             if (hostAddress.contains("%")) {
                 hostAddress = hostAddress.substring(0, hostAddress.indexOf("%"));
             }
-            serverAddArr[0] = hostAddress;
-            serverAddArr[1] = address.substring(i + 1);
+            String portStr = address.substring(i + 1);
+            if (StringUtils.isBlank(hostAddress) || StringUtils.isBlank(portStr)) {
+                throw new IllegalArgumentException("Invalid endpoint format: " + address + ". Endpoint should be in the format ip:port.");
+            }
+            return new String[]{hostAddress, portStr};
+        } else {
+            throw new IllegalArgumentException("Invalid endpoint format: " + address + ". Endpoint should be in the format ip:port.");
         }
-        return serverAddArr;
     }
 
     /**

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -113,6 +113,39 @@ public class NetUtilTest {
 
     }
 
+    @Test
+    public void testToInetSocketAddressWhenHostOrPortIsEmpty() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress(":");
+        });
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress(":9001");
+        });
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress("127.0.0.1:");
+        });
+    }
+
+    @Test
+    public void testToInetSocketAddressWhenPortIllegalRange() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress("127.0.0.1:-1");
+        });
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress("127.0.0.1:65539");
+        });
+    }
+
+    @Test
+    public void testToInetSocketAddressWhenPortNotNumber() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress("127.0.0.1:hello");
+        });
+    }
+
     /**
      * Test to long.
      */

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -106,7 +107,10 @@ public class NetUtilTest {
      */
     @Test
     public void testToInetSocketAddress1() {
-        assertThat(NetUtil.toInetSocketAddress("kadfskl").getHostName()).isEqualTo("kadfskl");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            NetUtil.toInetSocketAddress("kadfskl").getHostName().equals("kadfskl");
+        });
+
     }
 
     /**
@@ -117,7 +121,7 @@ public class NetUtilTest {
         try {
             NetUtil.toLong("kdskdsfk");
         } catch (Exception e) {
-            assertThat(e).isInstanceOf(NullPointerException.class);
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -126,13 +130,14 @@ public class NetUtilTest {
      */
     @Test
     public void testToLong1() {
-        String[] split = "127.0.0.1".split("\\.");
+        String[] split = "127.0.0.1:8080".split("[.:]");
         long r = 0;
         r = r | (Long.parseLong(split[0]) << 40);
         r = r | (Long.parseLong(split[1]) << 32);
         r = r | (Long.parseLong(split[2]) << 24);
         r = r | (Long.parseLong(split[3]) << 16);
-        assertThat(NetUtil.toLong("127.0.0.1")).isEqualTo(r);
+        r = r | Long.parseLong(split[4]);
+        assertThat(NetUtil.toLong("127.0.0.1:8080")).isEqualTo(r);
 
     }
 

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -98,7 +98,7 @@ public class NetUtilTest {
         try {
             NetUtil.toInetSocketAddress("23939:ks");
         } catch (Exception e) {
-            assertThat(e).isInstanceOf(NumberFormatException.class);
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
 

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/FileRegistryServiceImpl.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/FileRegistryServiceImpl.java
@@ -89,7 +89,7 @@ public class FileRegistryServiceImpl implements RegistryService<ConfigChangeList
         List<InetSocketAddress> inetSocketAddresses = new ArrayList<>();
         for (String endpoint : endpoints) {
             String[] ipAndPort = NetUtil.splitIPPortStr(endpoint);
-            if (ipAndPort.length != 2) {
+            if (ipAndPort == null || ipAndPort[0].isEmpty() || ipAndPort[1].isEmpty() ) {
                 throw new IllegalArgumentException("endpoint format should like ip:port, the invalid endpoint: " + endpoint);
             }
             inetSocketAddresses.add(new InetSocketAddress(ipAndPort[0], Integer.parseInt(ipAndPort[1])));

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/FileRegistryServiceImpl.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/FileRegistryServiceImpl.java
@@ -89,9 +89,6 @@ public class FileRegistryServiceImpl implements RegistryService<ConfigChangeList
         List<InetSocketAddress> inetSocketAddresses = new ArrayList<>();
         for (String endpoint : endpoints) {
             String[] ipAndPort = NetUtil.splitIPPortStr(endpoint);
-            if (ipAndPort == null || ipAndPort[0].isEmpty() || ipAndPort[1].isEmpty() ) {
-                throw new IllegalArgumentException("endpoint format should like ip:port, the invalid endpoint: " + endpoint);
-            }
             inetSocketAddresses.add(new InetSocketAddress(ipAndPort[0], Integer.parseInt(ipAndPort[1])));
         }
         return inetSocketAddresses;


### PR DESCRIPTION
…ileRegistryServiceImpl class.

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
prevent unexpected NullPointerException in lookup method in FileRegistryServiceImpl class

Due to the design characteristics of `NetUtil.splitIPPortStr(endpoint)`:

- If the `endpoint` does not contain a ":", it returns `null`.
- If the `endpoint` contains a ":", it returns an array of fixed length 2 (even if the content is empty, e.g., `":"` → `["", ""]`).

As a result:
1. The condition `if (ipAndPort.length != 2)` will **never be triggered**.
2. A `NullPointerException` will be thrown when the `endpoint` does not contain a ":".

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
just fix bug

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

