### PR TITLE
optimize: use retry logic to end global trx

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -84,7 +84,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7242](https://github.com/apache/incubator-seata/pull/7242)] optimize ratelimit bucketTokenNumPerSecond config
 - [[#7232](https://github.com/apache/incubator-seata/pull/7232)] add license header
 - [[#7260](https://github.com/apache/incubator-seata/pull/7260)] upgrade npmjs dependencies
-
+- [[#7283](https://github.com/apache/incubator-seata/pull/7283)] optimize: use retry logic to end global trx
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -82,6 +82,7 @@
 - [[#7250](https://github.com/apache/incubator-seata/pull/7250)] 适配 client_protocol_version > server_protocol_version场景
 - [[#7232](https://github.com/apache/incubator-seata/pull/7232)] 增加 license header
 - [[#7260](https://github.com/apache/incubator-seata/pull/7260)] 升级 npmjs 依赖版本
+- [[#7283](https://github.com/apache/incubator-seata/pull/7283)] 使用重试逻辑优化事务的结束
 
 ### security:
 - [[#6069](https://github.com/apache/incubator-seata/pull/6069)] 升级Guava依赖版本，修复安全漏洞

--- a/server/src/main/java/org/apache/seata/server/console/impl/AbstractGlobalService.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/AbstractGlobalService.java
@@ -20,10 +20,8 @@ import org.apache.seata.common.result.SingleResult;
 import org.apache.seata.core.model.GlobalStatus;
 import org.apache.seata.server.console.exception.ConsoleException;
 import org.apache.seata.server.console.service.GlobalSessionService;
-import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
-import org.apache.seata.server.session.SessionHolder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/server/src/main/java/org/apache/seata/server/console/impl/AbstractGlobalService.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/AbstractGlobalService.java
@@ -121,21 +121,10 @@ public abstract class AbstractGlobalService extends AbstractService implements G
             boolean res;
             if (RETRY_COMMIT_STATUS.contains(globalStatus) || GlobalStatus.Committing.equals(globalStatus)
                     || GlobalStatus.StopCommitOrCommitRetry.equals(globalStatus)) {
-                res = DefaultCoordinator.getInstance().doGlobalCommit(globalSession, false);
-                if (res && globalSession.hasBranch() && globalSession.hasATBranch()) {
-                    globalSession.clean();
-                    globalSession.asyncCommit();
-                } else if (res && SessionHolder.findGlobalSession(xid) != null) {
-                    globalSession.end();
-                }
+                res = doRetryCommitGlobal(globalSession);
             } else if (RETRY_ROLLBACK_STATUS.contains(globalStatus) || GlobalStatus.Rollbacking.equals(globalStatus)
                     || GlobalStatus.StopRollbackOrRollbackRetry.equals(globalStatus)) {
-                res = DefaultCoordinator.getInstance().doGlobalRollback(globalSession, false);
-                // the record is not deleted
-                if (res && SessionHolder.findGlobalSession(xid) != null) {
-                    globalSession.changeGlobalStatus(GlobalStatus.Rollbacked);
-                    globalSession.end();
-                }
+                res = doRetryRollbackGlobal(globalSession);
             } else {
                 throw new IllegalArgumentException("current global transaction status is not support to do");
             }
@@ -152,11 +141,11 @@ public abstract class AbstractGlobalService extends AbstractService implements G
         GlobalStatus globalStatus = globalSession.getStatus();
         try {
             if (FAIL_COMMIT_STATUS.contains(globalStatus)) {
-                boolean committed = doCommitGlobal(globalSession);
+                boolean committed = doRetryCommitGlobal(globalSession);
                 return committed ? SingleResult.success() : SingleResult.failure("Commit fail, please try again");
             }
             if (FAIL_ROLLBACK_STATUS.contains(globalStatus)) {
-                boolean rollbacked = doRollbackGlobal(globalSession);
+                boolean rollbacked = doRetryRollbackGlobal(globalSession);
                 return rollbacked ? SingleResult.success() : SingleResult.failure("Rollback fail, please try again");
             }
         } catch (Exception e) {

--- a/server/src/main/java/org/apache/seata/server/console/impl/AbstractService.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/AbstractService.java
@@ -147,12 +147,12 @@ public abstract class AbstractService {
         return true;
     }
 
-    protected boolean doCommitGlobal(GlobalSession globalSession) throws TransactionException {
-        return DefaultCoordinator.getInstance().doGlobalCommit(globalSession, false);
+    protected boolean doRetryCommitGlobal(GlobalSession globalSession) throws TransactionException {
+        return DefaultCoordinator.getInstance().doGlobalCommit(globalSession, true);
     }
 
-    protected boolean doRollbackGlobal(GlobalSession globalSession) throws TransactionException {
-        return DefaultCoordinator.getInstance().doGlobalRollback(globalSession, false);
+    protected boolean doRetryRollbackGlobal(GlobalSession globalSession) throws TransactionException {
+        return DefaultCoordinator.getInstance().doGlobalRollback(globalSession, true);
     }
 
     protected static class CheckResult {


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Use retry logic to end global trx. Previously, there were some interfaces that did not have the end logic or were implemented in some other way

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

