### PR TITLE
test: Simplified complex test testMsgSerialize in RaftSyncMessageTest by separating it into two tests

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -114,6 +114,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7233][https://github.com/apache/incubator-seata/pull/7233]] add mock test for seata-discovery-etcd3
 - [[#7243](https://github.com/apache/incubator-seata/pull/7243)] add unit test for seata-discovery-eureka
 - [[#7255](https://github.com/apache/incubator-seata/pull/7255)] more unit tests for Discovery-Eureka
+- [[#7286](https://github.com/apache/incubator-seata/pull/7286)] Simplified complex test testMsgSerialize in RaftSyncMessageTest by separating it into two tests
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -112,6 +112,8 @@
 - [[#7233][https://github.com/apache/incubator-seata/pull/7233]] 增加对 seata-discovery-etcd3 的mock测试
 - [[#7243](https://github.com/apache/incubator-seata/pull/7243)] 增加对 seata-discovery-eureka的单测
 - [[#7255](https://github.com/apache/incubator-seata/pull/7255)] 补充更多seata-discovery-eureka模块的单测提高覆盖率
+- [[#7286](https://github.com/apache/incubator-seata/pull/7286)] 重构了 RaftSyncMessageTest 中的 testMsgSerialize 测试，通过拆分为两个独立测试以简化逻辑
+
 ### refactor:
 
 - [[#7145](https://github.com/apache/incubator-seata/pull/7145)] 重构不满足 license 要求的代码

--- a/server/src/test/java/org/apache/seata/server/raft/RaftSyncMessageTest.java
+++ b/server/src/test/java/org/apache/seata/server/raft/RaftSyncMessageTest.java
@@ -110,18 +110,22 @@ public class RaftSyncMessageTest {
     public void testMsgSerialize() throws IOException {
         RaftSyncMessage raftSyncMessage = new RaftSyncMessage();
         RaftGlobalSessionSyncMsg raftSessionSyncMsg = new RaftGlobalSessionSyncMsg();
-        RaftBranchSessionSyncMsg raftBranchSessionMsg = new RaftBranchSessionSyncMsg();
-        raftBranchSessionMsg.setBranchSession(new BranchTransactionDTO("123:123", 1234));
         raftSessionSyncMsg.setGlobalSession(new GlobalTransactionDTO("123:123"));
         raftSyncMessage.setBody(raftSessionSyncMsg);
         byte[] msg = RaftSyncMessageSerializer.encode(raftSyncMessage);
         RaftSyncMessage raftSyncMessage1 = RaftSyncMessageSerializer.decode(msg);
+        Assertions.assertEquals("123:123", ((RaftGlobalSessionSyncMsg) raftSyncMessage1.getBody()).getGlobalSession().getXid());
+    }
+
+    @Test
+    public void testMsgSerialize_2() throws IOException {
         RaftSyncMessage raftSyncMessage2 = new RaftSyncMessage();
+        RaftBranchSessionSyncMsg raftBranchSessionMsg = new RaftBranchSessionSyncMsg();
+        raftBranchSessionMsg.setBranchSession(new BranchTransactionDTO("123:123", 1234));
         raftSyncMessage2.setBody(raftBranchSessionMsg);
         byte[] msg2 = RaftSyncMessageSerializer.encode(raftSyncMessage2);
         RaftSyncMessage raftSyncMessageByBranch = RaftSyncMessageSerializer.decode(msg2);
         Assertions.assertEquals("123:123", ((RaftBranchSessionSyncMsg) raftSyncMessageByBranch.getBody()).getBranchSession().getXid());
-        Assertions.assertEquals("123:123", ((RaftGlobalSessionSyncMsg) raftSyncMessage1.getBody()).getGlobalSession().getXid());
         Assertions.assertEquals(1234, ((RaftBranchSessionSyncMsg) raftSyncMessageByBranch.getBody()).getBranchSession().getBranchId());
     }
 

--- a/server/src/test/java/org/apache/seata/server/raft/RaftSyncMessageTest.java
+++ b/server/src/test/java/org/apache/seata/server/raft/RaftSyncMessageTest.java
@@ -107,7 +107,7 @@ public class RaftSyncMessageTest {
     }
 
     @Test
-    public void testMsgSerialize() throws IOException {
+    public void testGlobalSessionMsgSerializationAndDeserialization() throws IOException {
         RaftSyncMessage raftSyncMessage = new RaftSyncMessage();
         RaftGlobalSessionSyncMsg raftSessionSyncMsg = new RaftGlobalSessionSyncMsg();
         raftSessionSyncMsg.setGlobalSession(new GlobalTransactionDTO("123:123"));
@@ -118,7 +118,7 @@ public class RaftSyncMessageTest {
     }
 
     @Test
-    public void testMsgSerialize_2() throws IOException {
+    public void testBranchSessionMsgSerializationAndDeserialization() throws IOException {
         RaftSyncMessage raftSyncMessage2 = new RaftSyncMessage();
         RaftBranchSessionSyncMsg raftBranchSessionMsg = new RaftBranchSessionSyncMsg();
         raftBranchSessionMsg.setBranchSession(new BranchTransactionDTO("123:123", 1234));


### PR DESCRIPTION
- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
**Summary**: 
- Separated the test `testMsgSerialize` into 2 tests: `testGlobalSessionMsgSerializationAndDeserialization` and `testBranchSessionMsgSerializationAndDeserialization`. 

**Elaboration**: 
- The test `testMsgSerialize` is long, complex and have 2 testing flows which are completely independent of each other. 
- In the PR I have separated those different testing logics into different tests making the new tests simplified & easier to understand and maintain. The new tests would also have increased debugging and issue finding capabilities. 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Successful tests run

### Ⅴ. Special notes for reviews

