### PR TITLE
test: Refactored testGetErrorMsgWithValidCodeReturnsExpectedMsg to use parameterized unit testing

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -114,6 +114,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7233][https://github.com/apache/incubator-seata/pull/7233]] add mock test for seata-discovery-etcd3
 - [[#7243](https://github.com/apache/incubator-seata/pull/7243)] add unit test for seata-discovery-eureka
 - [[#7255](https://github.com/apache/incubator-seata/pull/7255)] more unit tests for Discovery-Eureka
+- [[#7287](https://github.com/apache/incubator-seata/pull/7287)] Refactored testGetErrorMsgWithValidCodeReturnsExpectedMsg to use parameterized unit testing
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -112,6 +112,7 @@
 - [[#7233][https://github.com/apache/incubator-seata/pull/7233]] 增加对 seata-discovery-etcd3 的mock测试
 - [[#7243](https://github.com/apache/incubator-seata/pull/7243)] 增加对 seata-discovery-eureka的单测
 - [[#7255](https://github.com/apache/incubator-seata/pull/7255)] 补充更多seata-discovery-eureka模块的单测提高覆盖率
+- [[#7287](https://github.com/apache/incubator-seata/pull/7287)] 重构了 CodeTest 中的 testGetErrorMsgWithValidCodeReturnsExpectedMsg 测试，以简化并使用参数化单元测试。
 ### refactor:
 
 - [[#7145](https://github.com/apache/incubator-seata/pull/7145)] 重构不满足 license 要求的代码

--- a/common/src/test/java/org/apache/seata/common/code/CodeTest.java
+++ b/common/src/test/java/org/apache/seata/common/code/CodeTest.java
@@ -18,20 +18,29 @@ package org.apache.seata.common.code;
 
 import org.apache.seata.common.result.Code;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CodeTest {
 
-    @Test
-    public void testGetErrorMsgWithValidCodeReturnsExpectedMsg() {
-        // Test case for SUCCESS
-        assertEquals("ok", Code.SUCCESS.getMsg());
-        // Test case for ERROR
-        assertEquals("Server error", Code.ERROR.getMsg());
-        // Test case for LOGIN_FAILED
-        assertEquals("Login failed", Code.LOGIN_FAILED.getMsg());
+    static Stream<Arguments> codeMessageProvider() {
+        return Stream.of(
+                Arguments.of(Code.SUCCESS, "ok"), // Test case for SUCCESS
+                Arguments.of(Code.ERROR, "Server error"), // Test case for ERROR
+                Arguments.of(Code.LOGIN_FAILED, "Login failed") // Test case for LOGIN_FAILED
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("codeMessageProvider")
+    public void testGetErrorMsgWithValidCodeReturnsExpectedMsg(Code code, String expectedMsg) {
+        assertEquals(expectedMsg, code.getMsg());
     }
 
     @Test


### PR DESCRIPTION
- [x] I have registered the PR [changes](../changes).


### Ⅰ. Describe what this PR did
**Summary**: 
- Parameterized `testGetErrorMsgWithValidCodeReturnsExpectedMsg `

**Elaboration**: 
- The same method calls (`getMsg()`) is repeated multiple times with different inputs, making the test harder to maintain and extend. 
- When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting another Assertions.assertEquals(...) statement instead of simply adding new data.

To accomplish this, I have retrofitted the test into a parameterized unit test. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

**Test execution results after changes:**
<img width="532" alt="Screenshot 2025-04-13 at 11 24 21 AM" src="https://github.com/user-attachments/assets/a69e8c5c-7585-48fb-992b-15ef1b30cf98" />
 



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Successful tests run

### Ⅴ. Special notes for reviews

