### PR TITLE
test: Refactored testSetCodeAndMsgUpdatesValuesCorrectly to use parameterized unit testing

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -40,19 +40,6 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### test:
 
-- [[#7092](https://github.com/apache/incubator-seata/pull/7092)] fix the issue of NacosMockTest failing to run
-- [[#7098](https://github.com/apache/incubator-seata/pull/7098)] Add unit tests for the `seata-common` module
-- [[#7160](https://github.com/apache/incubator-seata/pull/7160)] Refactored tests in `LowerCaseLinkHashMapTest` to use parameterized unit testing
-- [[#7167](https://github.com/apache/incubator-seata/pull/7167)] Refactored tests in `DurationUtilTest` to simplify and use parameterized unit testing
-- [[#7189](https://github.com/apache/incubator-seata/pull/7189)] fix the runtime exception in the saga test case
-- [[#7197](https://github.com/apache/incubator-seata/pull/7197)] add some UT cases for config module
-- [[#7199](https://github.com/apache/incubator-seata/pull/7199)] add some UT cases for client processor
-- [[#7203](https://github.com/apache/incubator-seata/pull/7203)] Refactored tests in rm.datasource.sql.Druid and seata-sqlparser-druid module
-- [[#7221](https://github.com/apache/incubator-seata/pull/7221)] add UT for gRPC Encoder/Decode
-- [[#7227](https://github.com/apache/incubator-seata/pull/7227)] add mock test for seata-discovery-consul module
-- [[#7233][https://github.com/apache/incubator-seata/pull/7233]] add mock test for seata-discovery-etcd3
-- [[#7243](https://github.com/apache/incubator-seata/pull/7243)] add unit test for seata-discovery-eureka
-- [[#7255](https://github.com/apache/incubator-seata/pull/7255)] more unit tests for Discovery-Eureka
 - [[#7286](https://github.com/apache/incubator-seata/pull/7286)] Simplified complex test testMsgSerialize in RaftSyncMessageTest by separating it into two tests
 - [[#7287](https://github.com/apache/incubator-seata/pull/7287)] Refactored testGetErrorMsgWithValidCodeReturnsExpectedMsg to use parameterized unit testing
 - [[#7288](https://github.com/apache/incubator-seata/pull/7288)] Refactored testSetCodeAndMsgUpdatesValuesCorrectly to use parameterized unit testing

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -114,6 +114,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7233][https://github.com/apache/incubator-seata/pull/7233]] add mock test for seata-discovery-etcd3
 - [[#7243](https://github.com/apache/incubator-seata/pull/7243)] add unit test for seata-discovery-eureka
 - [[#7255](https://github.com/apache/incubator-seata/pull/7255)] more unit tests for Discovery-Eureka
+- [[#7288](https://github.com/apache/incubator-seata/pull/7288)] Refactored testSetCodeAndMsgUpdatesValuesCorrectly to use parameterized unit testing
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -41,19 +41,6 @@
 
 ### test:
 
-- [[#7092](https://github.com/apache/incubator-seata/pull/7092)] 修复NacosMockTest测试方法并行导致测试结果被干扰失败的问题
-- [[#7098](https://github.com/apache/incubator-seata/pull/7098)] 增加 `seata-common` 模块的测试用例
-- [[#7160](https://github.com/apache/incubator-seata/pull/7160)] 在 LowerCaseLinkHashMapTest 中重构测试，以使用参数化单元测试
-- [[#7167](https://github.com/apache/incubator-seata/pull/7167)] 重构了 DurationUtilTest 中的测试，以简化并使用参数化单元测试
-- [[#7189](https://github.com/apache/incubator-seata/pull/7189)] 修复saga测试用例运行异常
-- [[#7197](https://github.com/apache/incubator-seata/pull/7197)] 为 config 模块添加 UT 测试用例
-- [[#7199](https://github.com/apache/incubator-seata/pull/7199)] 增加 client processor 单测用例
-- [[#7203](https://github.com/apache/incubator-seata/pull/7203)] 重构了 rm.datasource.sql.Druid 和 seata-sqlparser-druid 模块中的测试
-- [[#7221](https://github.com/apache/incubator-seata/pull/7221)] 增加 gRPC Encoder/Decoder的测试用例
-- [[#7227](https://github.com/apache/incubator-seata/pull/7227)] 为 seata-discovery-consul 增加mock测试
-- [[#7233][https://github.com/apache/incubator-seata/pull/7233]] 增加对 seata-discovery-etcd3 的mock测试
-- [[#7243](https://github.com/apache/incubator-seata/pull/7243)] 增加对 seata-discovery-eureka的单测
-- [[#7255](https://github.com/apache/incubator-seata/pull/7255)] 补充更多seata-discovery-eureka模块的单测提高覆盖率
 - [[#7286](https://github.com/apache/incubator-seata/pull/7286)] 重构了 RaftSyncMessageTest 中的 testMsgSerialize 测试，通过拆分为两个独立测试以简化逻辑
 - [[#7287](https://github.com/apache/incubator-seata/pull/7287)] 重构了 CodeTest 中的 testGetErrorMsgWithValidCodeReturnsExpectedMsg 测试，以简化并使用参数化单元测试。
 - [[#7288](https://github.com/apache/incubator-seata/pull/7288)] 重构了 CodeTest 中的 testSetCodeAndMsgUpdatesValuesCorrectly 测试，以简化并使用参数化单元测试。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -112,6 +112,8 @@
 - [[#7233][https://github.com/apache/incubator-seata/pull/7233]] 增加对 seata-discovery-etcd3 的mock测试
 - [[#7243](https://github.com/apache/incubator-seata/pull/7243)] 增加对 seata-discovery-eureka的单测
 - [[#7255](https://github.com/apache/incubator-seata/pull/7255)] 补充更多seata-discovery-eureka模块的单测提高覆盖率
+- [[#7288](https://github.com/apache/incubator-seata/pull/7288)] 重构了 CodeTest 中的 testSetCodeAndMsgUpdatesValuesCorrectly 测试，以简化并使用参数化单元测试。
+
 ### refactor:
 
 - [[#7145](https://github.com/apache/incubator-seata/pull/7145)] 重构不满足 license 要求的代码

--- a/common/src/test/java/org/apache/seata/common/code/CodeTest.java
+++ b/common/src/test/java/org/apache/seata/common/code/CodeTest.java
@@ -51,8 +51,7 @@ public class CodeTest {
 
     static Stream<Arguments> codeSetterProvider() {
         return Stream.of(
-                Arguments.of(Code.SUCCESS, "201", "Created"),
-                Arguments.of(Code.ERROR, "500", "Something went wrong")
+                Arguments.of(Code.SUCCESS, "201", "Created")
         );
     }
 

--- a/common/src/test/java/org/apache/seata/common/code/CodeTest.java
+++ b/common/src/test/java/org/apache/seata/common/code/CodeTest.java
@@ -48,8 +48,7 @@ public class CodeTest {
     static Stream<Arguments> codeSetterProvider() {
         return Stream.of(
                 Arguments.of(Code.SUCCESS, "201", "Created"),
-                Arguments.of(Code.ERROR, "500", "Something went wrong"),
-                Arguments.of(Code.LOGIN_FAILED, "403", "Unauthorized")
+                Arguments.of(Code.ERROR, "500", "Something went wrong")
         );
     }
 

--- a/common/src/test/java/org/apache/seata/common/code/CodeTest.java
+++ b/common/src/test/java/org/apache/seata/common/code/CodeTest.java
@@ -18,6 +18,11 @@ package org.apache.seata.common.code;
 
 import org.apache.seata.common.result.Code;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -40,12 +45,20 @@ public class CodeTest {
         assertNull(Code.getErrorMsg("404"));
     }
 
-    @Test
-    public void testSetCodeAndMsgUpdatesValuesCorrectly() {
-        // Test case to check if setCode and setMsg are working as expected
-        Code.SUCCESS.setCode("201");
-        Code.SUCCESS.setMsg("Created");
-        assertEquals("201", Code.SUCCESS.getCode());
-        assertEquals("Created", Code.SUCCESS.getMsg());
+    static Stream<Arguments> codeSetterProvider() {
+        return Stream.of(
+                Arguments.of(Code.SUCCESS, "201", "Created"),
+                Arguments.of(Code.ERROR, "500", "Something went wrong"),
+                Arguments.of(Code.LOGIN_FAILED, "403", "Unauthorized")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("codeSetterProvider")
+    public void testSetCodeAndMsgUpdatesValuesCorrectly(Code code, String newCode, String newMsg) {
+        code.setCode(newCode);
+        code.setMsg(newMsg);
+        assertEquals(newCode, code.getCode());
+        assertEquals(newMsg, code.getMsg());
     }
 }


### PR DESCRIPTION
- [x] I have registered the PR [changes](../changes).


### Ⅰ. Describe what this PR did
**Summary**: 
- Parameterized `testSetCodeAndMsgUpdatesValuesCorrectly` and added more test cases. 

**Elaboration**: 
- The same method calls (`getCode` & `getMsg()`) would be repeated multiple times with different inputs, making the test harder to maintain and extend. 
- When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting another Assertions.assertEquals(...) statement instead of simply adding new data.

To accomplish this, I have retrofitted the test into a parameterized unit test. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

**Test execution results after changes:**
<img width="516" alt="Screenshot 2025-04-13 at 11 32 37 AM" src="https://github.com/user-attachments/assets/9b4935df-2024-45eb-af0f-e2322df47398" />

 



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Successful tests run

### Ⅴ. Special notes for reviews

