### PR TITLE
feature: support redis config center

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -20,22 +20,9 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### feature:
 
-- [[#7073](https://github.com/apache/incubator-seata/pull/7073)] support virtual thread,replace the usages of synchronized with ReentrantLock
-- [[#6756](https://github.com/apache/incubator-seata/pull/6756)] feature: add single server rate limit
-- [[#7037](https://github.com/apache/incubator-seata/pull/7037)] support fury undolog parser
-- [[#7069](https://github.com/apache/incubator-seata/pull/7069)] Raft cluster mode supports address translation
-- [[#7038](https://github.com/apache/incubator-seata/pull/7038)] support fury serializer
-- [[#7157](https://github.com/apache/incubator-seata/pull/7157)] migrate the console to the naming server
-- [[#7114](https://github.com/apache/incubator-seata/pull/7114)] support raft mode registry to namingserver
-- [[#7133](https://github.com/apache/incubator-seata/pull/7133)] Implement scheduled handling for end status transaction
-- [[#7171](https://github.com/apache/incubator-seata/pull/7171)] support EpollEventLoopGroup in client
-- [[#7183](https://github.com/apache/incubator-seata/pull/7183)] client discovers raft nodes through the naming server
-- [[#7182](https://github.com/apache/incubator-seata/pull/7182)] use the ip of the peerId as the host of the raft node
-- [[#7181](https://github.com/apache/incubator-seata/pull/7181)] raft implements domain name resolution and selects peerId
-- [[#7213](https://github.com/apache/incubator-seata/pull/7213)] support kingbase xa mode
-- [[#7223](https://github.com/apache/incubator-seata/pull/7223)] apply Spotless with Palantir java format
-- [[#7305](https://github.com/apache/incubator-seata/pull/7305)] support redis config center
 - [[#7261](https://github.com/apache/incubator-seata/pull/7261)] enforce account initialization and disable default credentials
+- [[#7305](https://github.com/apache/incubator-seata/pull/7305)] support redis config center
+
 
 
 ### bugfix:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -34,6 +34,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7181](https://github.com/apache/incubator-seata/pull/7181)] raft implements domain name resolution and selects peerId
 - [[#7213](https://github.com/apache/incubator-seata/pull/7213)] support kingbase xa mode
 - [[#7223](https://github.com/apache/incubator-seata/pull/7223)] apply Spotless with Palantir java format
+- [[#7305](https://github.com/apache/incubator-seata/pull/7305)] support redis config center
 
 
 ### bugfix:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -20,29 +20,16 @@
 
 ### feature:
 
-- [[#6756](https://github.com/apache/incubator-seata/pull/6756)] seata服务单点限流支持
-- [[#7073](https://github.com/apache/incubator-seata/pull/7073)] 支持虚拟线程，用ReentrantLock替换synchronized的用法
-- [[#7037](https://github.com/apache/incubator-seata/pull/7037)] 支持UndoLog的fury序列化方式
-- [[#7069](https://github.com/apache/incubator-seata/pull/7069)] Raft集群模式支持地址转换
-- [[#7038](https://github.com/apache/incubator-seata/pull/7038)] 支持Fury序列化器
-- [[#7157](https://github.com/apache/incubator-seata/pull/7157)] 将console迁移至namingserver中
-- [[#7114](https://github.com/apache/incubator-seata/pull/7114)] 支持raft集群注册至namingserver
-- [[#7133](https://github.com/apache/incubator-seata/pull/7133)] 实现对残留的end状态事务定时处理
-- [[#7171](https://github.com/apache/incubator-seata/pull/7171)] 客户端支持 EpollEventLoopGroup
-- [[#7183](https://github.com/apache/incubator-seata/pull/7183)] 客户端支持通过namingserver发现raft节点
-- [[#7182](https://github.com/apache/incubator-seata/pull/7182)] 采用peerId的ip作为raft节点的host
-- [[#7181](https://github.com/apache/incubator-seata/pull/7181)] raft实现域名解析并选择peerId
-- [[#7213](https://github.com/apache/incubator-seata/pull/7213)] support kingbase xa mode
-- [[#7223](https://github.com/apache/incubator-seata/pull/7223)] 使用 Palantir java 格式应用 Spotless
-- [[#7305](https://github.com/apache/incubator-seata/pull/7305)] 支持 redis 做配置中心
 - [[#7261](https://github.com/apache/incubator-seata/pull/7261)] 强制进行账户初始化并禁用默认凭据
-- [[#7356](https://github.com/apache/incubator-seata/pull/7356)] 修复 codecov 错误
+- [[#7305](https://github.com/apache/incubator-seata/pull/7305)] 支持 redis 做配置中心
+
 
 
 ### bugfix:
 
 - [[#7349](https://github.com/apache/incubator-seata/pull/7349)] 解决 EtcdRegistryServiceImplMockTest 中的空指针异常
 - [[#7354](https://github.com/apache/incubator-seata/pull/7354)] 修复lib文件夹中的驱动程序无法加载
+- [[#7356](https://github.com/apache/incubator-seata/pull/7356)] 修复 codecov 错误
 
 ### optimize:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -34,6 +34,8 @@
 - [[#7181](https://github.com/apache/incubator-seata/pull/7181)] raft实现域名解析并选择peerId
 - [[#7213](https://github.com/apache/incubator-seata/pull/7213)] support kingbase xa mode
 - [[#7223](https://github.com/apache/incubator-seata/pull/7223)] 使用 Palantir java 格式应用 Spotless
+- [[#7305](https://github.com/apache/incubator-seata/pull/7305)] 支持 redis 做配置中心
+
 
 ### bugfix:
 

--- a/config/seata-config-core/src/main/java/org/apache/seata/config/ConfigType.java
+++ b/config/seata-config-core/src/main/java/org/apache/seata/config/ConfigType.java
@@ -52,7 +52,11 @@ public enum ConfigType {
     /**
      * Custom config type
      */
-    Custom;
+    Custom,
+    /**
+     * Redis config type
+     */
+    Redis;
 
     /**
      * Gets type.

--- a/config/seata-config-redis/pom.xml
+++ b/config/seata-config-redis/pom.xml
@@ -35,9 +35,16 @@
             <artifactId>seata-config-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/config/seata-config-redis/pom.xml
+++ b/config/seata-config-redis/pom.xml
@@ -17,30 +17,28 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.seata</groupId>
-        <artifactId>seata-parent</artifactId>
+        <artifactId>seata-config</artifactId>
         <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>seata-config</artifactId>
-    <packaging>pom</packaging>
-    <name>seata-config ${project.version}</name>
-    <description>config top parent for Seata built with Maven</description>
+    <artifactId>seata-config-redis</artifactId>
+    <name>seata-config-redis ${project.version}</name>
+    <description>config-redis for Seata built with Maven</description>
 
-    <modules>
-        <module>seata-config-core</module>
-        <module>seata-config-custom</module>
-        <module>seata-config-apollo</module>
-        <module>seata-config-nacos</module>
-        <module>seata-config-zk</module>
-        <module>seata-config-all</module>
-        <module>seata-config-etcd3</module>
-        <module>seata-config-consul</module>
-        <module>seata-config-spring-cloud</module>
-        <module>seata-config-redis</module>
-    </modules>
-</project>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seata</groupId>
+            <artifactId>seata-config-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+        </dependency>
+    </dependencies>
+
+</project> 

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/ConfigOperation.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/ConfigOperation.java
@@ -21,6 +21,12 @@ package org.apache.seata.config.redis;
  *
  */
 public enum ConfigOperation {
+    /**
+     * PUT
+     */
     PUT,
+    /**
+     * REMOVE
+     */
     REMOVE
 }

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/ConfigOperation.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/ConfigOperation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.config.redis;
+
+/**
+ * The enum config change Type for redis pub/sub
+ *
+ */
+public enum ConfigOperation {
+    PUT,
+    REMOVE
+}

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/ConfigOperation.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/ConfigOperation.java
@@ -18,7 +18,6 @@ package org.apache.seata.config.redis;
 
 /**
  * The enum config change Type for redis pub/sub
- *
  */
 public enum ConfigOperation {
     /**

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Transaction;
 
@@ -115,7 +116,7 @@ public class RedisConfiguration extends AbstractConfiguration {
         redisConfig.setTestOnReturn(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-return", false));
         redisConfig.setTestWhileIdle(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-while-idle", false));
 
-        String serverAddr = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "serverAddr");
+        String serverAddr = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "server-addr");
         String[] serverArr = NetUtil.splitIPPortStr(serverAddr);
         String host = serverArr[0];
         int port = Integer.parseInt(serverArr[1]);
@@ -139,7 +140,8 @@ public class RedisConfiguration extends AbstractConfiguration {
         if (maxTotal > 0) {
             redisConfig.setMaxTotal(maxTotal);
         }
-        int maxWait = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-wait", fileConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
+        int maxWait = fileConfig.getInt(
+                REDIS_FILEKEY_PREFIX + "max-wait", fileConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
         if (maxWait > 0) {
             redisConfig.setMaxWaitMillis(maxWait);
         }
@@ -147,7 +149,8 @@ public class RedisConfiguration extends AbstractConfiguration {
         if (numTestsPerEvictionRun > 0) {
             redisConfig.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
         }
-        int timeBetweenEvictionRunsMillis = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "time-between-eviction-runs-millis", 0);
+        int timeBetweenEvictionRunsMillis =
+                fileConfig.getInt(REDIS_FILEKEY_PREFIX + "time-between-eviction-runs-millis", 0);
         if (timeBetweenEvictionRunsMillis > 0) {
             redisConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
         }
@@ -170,7 +173,6 @@ public class RedisConfiguration extends AbstractConfiguration {
         try (Jedis jedis = jedisPool.getResource()) {
             Map<String, String> configMap = jedis.hgetAll(getConfigKey());
             if (!configMap.isEmpty()) {
-                seataConfig = new Properties();
                 configMap.forEach((key, value) -> seataConfig.setProperty(key, value));
             }
         } catch (Exception e) {
@@ -186,8 +188,8 @@ public class RedisConfiguration extends AbstractConfiguration {
         }
 
         // Time in ConfigFuture, if time out, get() method would return the default value
-        ConfigFuture configFuture = new ConfigFuture(dataId, defaultValue, ConfigFuture.ConfigOperation.GET,
-                timeoutMills);
+        ConfigFuture configFuture =
+                new ConfigFuture(dataId, defaultValue, ConfigFuture.ConfigOperation.GET, timeoutMills);
         configExecutor.execute(() -> {
             try (Jedis jedis = jedisPool.getResource()) {
                 String result = jedis.hget(getConfigKey(), dataId);
@@ -207,9 +209,11 @@ public class RedisConfiguration extends AbstractConfiguration {
                 timeoutMills);
 
         configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource()) {
-                jedis.hset(getConfigKey(), dataId, content);
-                jedis.publish(getConfigChannelKey() + ":" + dataId, buildConfigChangeMessage(dataId, content));
+            try (Jedis jedis = jedisPool.getResource(); Pipeline pipeline = jedis.pipelined()) {
+                pipeline.hset(getConfigKey(), dataId, content);
+                pipeline.publish(getConfigChannelKey() + ":" + dataId,
+                        buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
+                pipeline.sync();
 
                 seataConfig.setProperty(dataId, content);
                 configFuture.setResult(Boolean.TRUE);
@@ -238,12 +242,14 @@ public class RedisConfiguration extends AbstractConfiguration {
         configExecutor.execute(() -> {
             try (Jedis jedis = jedisPool.getResource()) {
                 String configKey = getConfigKey();
-
                 jedis.watch(configKey);
+
+                // Use a transaction to ensure atomicity: check if the key exists and execute the put operation
                 if (!jedis.hexists(configKey, dataId)) {
                     Transaction transaction = jedis.multi();
                     transaction.hset(configKey, dataId, content);
-                    transaction.publish(getConfigChannelKey() + ":" + dataId, buildConfigChangeMessage(dataId, content));
+                    transaction.publish(getConfigChannelKey() + ":" + dataId,
+                            buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
 
                     List<Object> results = transaction.exec();
 
@@ -269,13 +275,14 @@ public class RedisConfiguration extends AbstractConfiguration {
 
     @Override
     public boolean removeConfig(String dataId, long timeoutMills) {
-        ConfigFuture configFuture = new ConfigFuture(dataId, null, ConfigFuture.ConfigOperation.REMOVE,
-                timeoutMills);
+        ConfigFuture configFuture = new ConfigFuture(dataId, null, ConfigFuture.ConfigOperation.REMOVE, timeoutMills);
 
         configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource()) {
-                jedis.hdel(getConfigKey(), dataId);
-                jedis.publish(getConfigChannelKey() + ":" + dataId, buildConfigChangeMessage(dataId, null));
+            try (Jedis jedis = jedisPool.getResource(); Pipeline pipeline = jedis.pipelined()) {
+                pipeline.hdel(getConfigKey(), dataId);
+                pipeline.publish(getConfigChannelKey() + ":" + dataId,
+                        buildConfigChangeMessage(ConfigOperation.REMOVE, dataId, ""));
+                pipeline.sync();
 
                 seataConfig.remove(dataId);
                 configFuture.setResult(Boolean.TRUE);
@@ -302,9 +309,7 @@ public class RedisConfiguration extends AbstractConfiguration {
 
             subscribeExecutor.execute(() -> {
                 try (Jedis jedis = jedisPool.getResource()) {
-
-                    String channel = getConfigChannelKey() + ":" + dataId;
-                    jedis.subscribe(redisListener, channel);
+                    jedis.subscribe(redisListener, getConfigChannelKey() + ":" + dataId);
                 } catch (Exception e) {
                     LOGGER.error("Failed to subscribe Redis channel: {}", e.getMessage());
                 }
@@ -370,13 +375,33 @@ public class RedisConfiguration extends AbstractConfiguration {
                 return;
             }
 
-            String[] parts = message.split("-", 2);
-            if (parts.length == 2 && parts[0].equals(dataId)) {
-                ConfigurationChangeEvent event = new ConfigurationChangeEvent()
-                        .setDataId(dataId)
-                        .setNewValue(parts[1])
-                        .setNamespace(DEFAULT_GROUP);
-                listener.onProcessEvent(event);
+            String[] parts = message.split("-", 3);
+            if (parts.length >= 2) {
+                try {
+                    ConfigOperation operation = ConfigOperation.valueOf(parts[0].toUpperCase());
+                    String dataId = parts[1];
+                    String content = parts.length > 2 ? parts[2] : null;
+
+                    switch (operation) {
+                        case PUT:
+                            if (content != null) {
+                                seataConfig.setProperty(dataId, content);
+                            }
+                            break;
+                        case REMOVE:
+                            seataConfig.remove(dataId);
+                            content = null;
+                            break;
+                    }
+
+                    ConfigurationChangeEvent event = new ConfigurationChangeEvent()
+                            .setDataId(dataId)
+                            .setNewValue(content)
+                            .setNamespace(DEFAULT_GROUP);
+                    listener.onProcessEvent(event);
+                } catch (IllegalArgumentException e) {
+                    LOGGER.error("Invalid operation in Redis message: {}", parts[0]);
+                }
             }
         }
 
@@ -393,9 +418,9 @@ public class RedisConfiguration extends AbstractConfiguration {
     /**
      * Build configuration change message for Redis pub/sub
      */
-    private String buildConfigChangeMessage(String dataId, String content) {
-        // like: dataId-content
-        return String.format("%s-%s", dataId, content);
+    private String buildConfigChangeMessage(ConfigOperation operation, String dataId, String content) {
+        // like: put-dataId-content
+        return String.format("%s-%s-%s", operation.name().toLowerCase(), dataId, content);
     }
 
     private String getConfigKey() {

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
@@ -16,14 +16,13 @@
  */
 package org.apache.seata.config.redis;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -45,7 +44,6 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Transaction;
 
 /**
  * The type Redis configuration
@@ -57,7 +55,6 @@ public class RedisConfiguration extends AbstractConfiguration {
     private static final String DEFAULT_GROUP = "SEATA_GROUP";
     private static final String CONFIG_TYPE = "redis";
     private static final String REDIS_FILEKEY_PREFIX = "config.redis.";
-    private static final int THREAD_POOL_NUM = 1;
 
     private final Configuration fileConfig = ConfigurationFactory.CURRENT_FILE_INSTANCE;
     private static volatile Properties seataConfig = new Properties();
@@ -65,7 +62,6 @@ public class RedisConfiguration extends AbstractConfiguration {
 
     private static final ConcurrentMap<String, Set<RedisListener>> CONFIG_LISTENERS_MAP = new ConcurrentHashMap<>();
 
-    private final ExecutorService configExecutor;
     private final ExecutorService subscribeExecutor;
 
     /**
@@ -91,26 +87,19 @@ public class RedisConfiguration extends AbstractConfiguration {
         initRedisPool();
         initSeataConfig();
 
-        this.configExecutor = new ThreadPoolExecutor(
-                THREAD_POOL_NUM,
-                THREAD_POOL_NUM,
-                Integer.MAX_VALUE,
-                TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(),
-                new NamedThreadFactory("redis-config-executor", THREAD_POOL_NUM));
+        int threadPoolNum = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "thread-pool-num", 50);
 
         this.subscribeExecutor = new ThreadPoolExecutor(
-                THREAD_POOL_NUM,
-                THREAD_POOL_NUM,
+                threadPoolNum,
+                threadPoolNum,
                 Integer.MAX_VALUE,
                 TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(),
-                new NamedThreadFactory("redis-subscribe-executor", THREAD_POOL_NUM));
+                new SynchronousQueue<>(),
+                new NamedThreadFactory("redis-subscribe-executor", threadPoolNum));
 
         // Register the JVM shutdown hook to release resources
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
-                shutdownExecutorService(configExecutor);
                 shutdownExecutorService(subscribeExecutor);
 
                 if (jedisPool != null && !jedisPool.isClosed()) {
@@ -123,7 +112,7 @@ public class RedisConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * get latest config with timeout and default value
+     * Get latest config with timeout and default value
      */
     @Override
     public String getLatestConfig(String dataId, String defaultValue, long timeoutMills) {
@@ -136,16 +125,13 @@ public class RedisConfiguration extends AbstractConfiguration {
         ConfigFuture configFuture =
                 new ConfigFuture(dataId, defaultValue, ConfigFuture.ConfigOperation.GET, timeoutMills);
 
-        // The configuration executor is used to asynchronously retrieve from Redis
-        configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource()) {
-                String result = jedis.hget(getConfigKey(), dataId);
-                configFuture.setResult(result != null ? result : defaultValue);
-            } catch (Exception e) {
-                LOGGER.error("Failed to get config from Redis: {}", e.getMessage());
-                configFuture.setResult(defaultValue);
-            }
-        });
+        try (Jedis jedis = jedisPool.getResource()) {
+            String result = jedis.hget(getConfigKey(), dataId);
+            configFuture.setResult(result != null ? result : defaultValue);
+        } catch (Exception e) {
+            LOGGER.error("Failed to get config from Redis: {}", e.getMessage());
+            configFuture.setResult(defaultValue);
+        }
 
         return (String) configFuture.get();
     }
@@ -157,100 +143,79 @@ public class RedisConfiguration extends AbstractConfiguration {
     public boolean putConfig(String dataId, String content, long timeoutMills) {
         ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUT, timeoutMills);
 
-        configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource();
-                 Pipeline pipeline = jedis.pipelined()) {
-                pipeline.hset(getConfigKey(), dataId, content);
-                pipeline.publish(
-                        getConfigChannelKey() + ":" + dataId,
-                        buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
-                pipeline.sync();
+        try (Jedis jedis = jedisPool.getResource(); Pipeline pipeline = jedis.pipelined()) {
+            pipeline.hset(getConfigKey(), dataId, content);
+            pipeline.publish(
+                    getConfigChannelKey() + ":" + dataId,
+                    buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
+            pipeline.sync();
 
-                seataConfig.setProperty(dataId, content);
-                configFuture.setResult(Boolean.TRUE);
-            } catch (Exception e) {
-                LOGGER.error("Failed to put config to Redis: {}", e.getMessage());
-                configFuture.setResult(Boolean.FALSE);
-            }
-        });
+            seataConfig.setProperty(dataId, content);
+            configFuture.setResult(Boolean.TRUE);
+        } catch (Exception e) {
+            LOGGER.error("Failed to put config to Redis: {}", e.getMessage());
+            configFuture.setResult(Boolean.FALSE);
+        }
 
         return (Boolean) configFuture.get();
     }
 
     /**
-     * write config only when the configuration does not exist
+     * Write config only when the configuration does not exist
      */
     @Override
     public boolean putConfigIfAbsent(String dataId, String content, long timeoutMills) {
-        if (!seataConfig.isEmpty()) {
-            if (seataConfig.containsKey(dataId)) {
-                return true;
-            } else {
-                return putConfig(dataId, content, timeoutMills);
-            }
+        if (!seataConfig.isEmpty() && seataConfig.containsKey(dataId)) {
+            return true;
         }
 
-        ConfigFuture configFuture =
-                new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUTIFABSENT, timeoutMills);
+        ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUTIFABSENT, timeoutMills);
 
-        configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource()) {
-                String configKey = getConfigKey();
-                jedis.watch(configKey);
+        try (Jedis jedis = jedisPool.getResource()) {
+            String configKey = getConfigKey();
+            Long result = jedis.hsetnx(configKey, dataId, content);
 
-                // Use a transaction to ensure atomicity: check if the key exists and execute the put operation
-                if (!jedis.hexists(configKey, dataId)) {
-                    Transaction transaction = jedis.multi();
-                    transaction.hset(configKey, dataId, content);
-                    transaction.publish(
-                            getConfigChannelKey() + ":" + dataId,
-                            buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
-
-                    List<Object> results = transaction.exec();
-
-                    if (results != null && !results.isEmpty()) {
-                        seataConfig.setProperty(dataId, content);
-                        configFuture.setResult(Boolean.TRUE);
-                    } else {
-                        configFuture.setResult(Boolean.FALSE);
-                    }
-                } else {
-                    configFuture.setResult(Boolean.FALSE);
-                }
-
-                jedis.unwatch();
-            } catch (Exception e) {
-                LOGGER.error("Failed to put config if absent to Redis: {}", e.getMessage());
-                configFuture.setResult(Boolean.FALSE);
+            if (result == 1) {
+                jedis.publish(
+                        getConfigChannelKey() + ":" + dataId,
+                        buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
+                seataConfig.setProperty(dataId, content);
+                configFuture.setResult(Boolean.TRUE);
+            } else {
+                // If HSETNX returns 0, the key-field already exists in the Redis
+                String existingContent = jedis.hget(configKey, dataId);
+                seataConfig.setProperty(dataId, existingContent);
+                configFuture.setResult(Boolean.TRUE);
             }
-        });
+        } catch (Exception e) {
+            LOGGER.error("Failed to put config if absent to Redis: {}", e.getMessage());
+            configFuture.setResult(Boolean.FALSE);
+        }
 
         return (Boolean) configFuture.get();
     }
 
     /**
-     * remove config with timeout
+     * Remove config with timeout
      */
     @Override
     public boolean removeConfig(String dataId, long timeoutMills) {
         ConfigFuture configFuture = new ConfigFuture(dataId, null, ConfigFuture.ConfigOperation.REMOVE, timeoutMills);
 
-        configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource();
-                 Pipeline pipeline = jedis.pipelined()) {
-                pipeline.hdel(getConfigKey(), dataId);
-                pipeline.publish(
-                        getConfigChannelKey() + ":" + dataId,
-                        buildConfigChangeMessage(ConfigOperation.REMOVE, dataId, ""));
-                pipeline.sync();
+        try (Jedis jedis = jedisPool.getResource();
+             Pipeline pipeline = jedis.pipelined()) {
+            pipeline.hdel(getConfigKey(), dataId);
+            pipeline.publish(
+                    getConfigChannelKey() + ":" + dataId,
+                    buildConfigChangeMessage(ConfigOperation.REMOVE, dataId, ""));
+            pipeline.sync();
 
-                seataConfig.remove(dataId);
-                configFuture.setResult(Boolean.TRUE);
-            } catch (Exception e) {
-                LOGGER.error("Failed to remove config from Redis: {}", e.getMessage());
-                configFuture.setResult(Boolean.FALSE);
-            }
-        });
+            seataConfig.remove(dataId);
+            configFuture.setResult(Boolean.TRUE);
+        } catch (Exception e) {
+            LOGGER.error("Failed to remove config from Redis: {}", e.getMessage());
+            configFuture.setResult(Boolean.FALSE);
+        }
 
         return (Boolean) configFuture.get();
     }
@@ -263,9 +228,6 @@ public class RedisConfiguration extends AbstractConfiguration {
 
         try {
             RedisListener redisListener = new RedisListener(dataId, listener);
-            CONFIG_LISTENERS_MAP
-                    .computeIfAbsent(dataId, key -> ConcurrentHashMap.newKeySet())
-                    .add(redisListener);
 
             subscribeExecutor.execute(() -> {
                 try (Jedis jedis = jedisPool.getResource()) {
@@ -365,6 +327,13 @@ public class RedisConfiguration extends AbstractConfiguration {
                     LOGGER.error("Invalid operation in Redis message: {}", parts[0]);
                 }
             }
+        }
+
+        @Override
+        public void onSubscribe(String channel, int subscribedChannels) {
+            CONFIG_LISTENERS_MAP
+                    .computeIfAbsent(dataId, key -> ConcurrentHashMap.newKeySet())
+                    .add(this);
         }
 
         public ConfigurationChangeListener getTargetListener() {

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
@@ -27,6 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.seata.common.thread.NamedThreadFactory;
 import org.apache.seata.common.util.NetUtil;
@@ -53,34 +54,19 @@ public class RedisConfiguration extends AbstractConfiguration {
     private static volatile RedisConfiguration instance;
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisConfiguration.class);
 
-    private final Configuration fileConfig = ConfigurationFactory.CURRENT_FILE_INSTANCE;
-    private static volatile Properties seataConfig = new Properties();
-
     private static final String DEFAULT_GROUP = "SEATA_GROUP";
     private static final String CONFIG_TYPE = "redis";
-
     private static final String REDIS_FILEKEY_PREFIX = "config.redis.";
     private static final int THREAD_POOL_NUM = 1;
 
+    private final Configuration fileConfig = ConfigurationFactory.CURRENT_FILE_INSTANCE;
+    private static volatile Properties seataConfig = new Properties();
     private static volatile JedisPool jedisPool;
 
     private static final ConcurrentMap<String, Set<RedisListener>> CONFIG_LISTENERS_MAP = new ConcurrentHashMap<>();
 
-    private final ExecutorService configExecutor = new ThreadPoolExecutor(
-            THREAD_POOL_NUM,
-            THREAD_POOL_NUM,
-            Integer.MAX_VALUE,
-            TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(),
-            new NamedThreadFactory("redis-config-executor", THREAD_POOL_NUM));
-
-    private final ExecutorService subscribeExecutor = new ThreadPoolExecutor(
-            THREAD_POOL_NUM,
-            THREAD_POOL_NUM,
-            Integer.MAX_VALUE,
-            TimeUnit.MILLISECONDS,
-            new LinkedBlockingQueue<>(),
-            new NamedThreadFactory("redis-subscribe-executor", THREAD_POOL_NUM));
+    private final ExecutorService configExecutor;
+    private final ExecutorService subscribeExecutor;
 
     /**
      * Get instance of RedisConfiguration
@@ -99,86 +85,46 @@ public class RedisConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Instantiates a new Redis configuration
+     * Instantiates Redis configuration
      */
     private RedisConfiguration() {
         initRedisPool();
         initSeataConfig();
-    }
 
-    /**
-     * Initialize Redis connection pool with configuration parameters
-     */
-    private void initRedisPool() {
-        GenericObjectPoolConfig redisConfig = new GenericObjectPoolConfig();
-        redisConfig.setTestOnBorrow(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-borrow", true));
-        redisConfig.setTestOnReturn(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-return", false));
-        redisConfig.setTestWhileIdle(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-while-idle", false));
+        this.configExecutor = new ThreadPoolExecutor(
+                THREAD_POOL_NUM,
+                THREAD_POOL_NUM,
+                Integer.MAX_VALUE,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                new NamedThreadFactory("redis-config-executor", THREAD_POOL_NUM));
 
-        String serverAddr = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "server-addr");
-        String[] serverArr = NetUtil.splitIPPortStr(serverAddr);
-        String host = serverArr[0];
-        int port = Integer.parseInt(serverArr[1]);
+        this.subscribeExecutor = new ThreadPoolExecutor(
+                THREAD_POOL_NUM,
+                THREAD_POOL_NUM,
+                Integer.MAX_VALUE,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                new NamedThreadFactory("redis-subscribe-executor", THREAD_POOL_NUM));
 
-        String password = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "password");
-        int database = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "db", 0);
+        // Register the JVM shutdown hook to release resources
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                shutdownExecutorService(configExecutor);
+                shutdownExecutorService(subscribeExecutor);
 
-        int maxIdle = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-idle", 0);
-        if (maxIdle > 0) {
-            redisConfig.setMaxIdle(maxIdle);
-        }
-        int minIdle = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "min-idle", 0);
-        if (minIdle > 0) {
-            redisConfig.setMinIdle(minIdle);
-        }
-        int maxActive = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-active", 0);
-        if (maxActive > 0) {
-            redisConfig.setMaxTotal(maxActive);
-        }
-        int maxTotal = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-total", 0);
-        if (maxTotal > 0) {
-            redisConfig.setMaxTotal(maxTotal);
-        }
-        int maxWait = fileConfig.getInt(
-                REDIS_FILEKEY_PREFIX + "max-wait", fileConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
-        if (maxWait > 0) {
-            redisConfig.setMaxWaitMillis(maxWait);
-        }
-        int numTestsPerEvictionRun = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "num-tests-per-eviction-run", 0);
-        if (numTestsPerEvictionRun > 0) {
-            redisConfig.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
-        }
-        int timeBetweenEvictionRunsMillis =
-                fileConfig.getInt(REDIS_FILEKEY_PREFIX + "time-between-eviction-runs-millis", 0);
-        if (timeBetweenEvictionRunsMillis > 0) {
-            redisConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
-        }
-        int minEvictableIdleTimeMillis = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "min-evictable-idle-time-millis", 0);
-        if (minEvictableIdleTimeMillis > 0) {
-            redisConfig.setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis);
-        }
-
-        if (StringUtils.isNullOrEmpty(password)) {
-            jedisPool = new JedisPool(redisConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, database);
-        } else {
-            jedisPool = new JedisPool(redisConfig, host, port, Protocol.DEFAULT_TIMEOUT, password, database);
-        }
-    }
-
-    /**
-     * Initialize Seata configuration from Redis, loads all configurations into local cache
-     */
-    private void initSeataConfig() {
-        try (Jedis jedis = jedisPool.getResource()) {
-            Map<String, String> configMap = jedis.hgetAll(getConfigKey());
-            if (!configMap.isEmpty()) {
-                configMap.forEach((key, value) -> seataConfig.setProperty(key, value));
+                if (jedisPool != null && !jedisPool.isClosed()) {
+                    jedisPool.close();
+                }
+            } catch (Exception e) {
+                LOGGER.error("Error while shutting down Redis configuration: {}", e.getMessage());
             }
-        } catch (Exception e) {
-            LOGGER.error("Failed to init Redis config: {}", e.getMessage());
-        }
+        }));
     }
 
+    /**
+     * get latest config with timeout and default value
+     */
     @Override
     public String getLatestConfig(String dataId, String defaultValue, long timeoutMills) {
         String value = seataConfig.getProperty(dataId);
@@ -186,9 +132,11 @@ public class RedisConfiguration extends AbstractConfiguration {
             return value;
         }
 
-        // Time in ConfigFuture, if time out, get() method would return the default value
+        // Time in ConfigFuture, if time out, get() would return the default value
         ConfigFuture configFuture =
                 new ConfigFuture(dataId, defaultValue, ConfigFuture.ConfigOperation.GET, timeoutMills);
+
+        // The configuration executor is used to asynchronously retrieve from Redis
         configExecutor.execute(() -> {
             try (Jedis jedis = jedisPool.getResource()) {
                 String result = jedis.hget(getConfigKey(), dataId);
@@ -202,13 +150,16 @@ public class RedisConfiguration extends AbstractConfiguration {
         return (String) configFuture.get();
     }
 
+    /**
+     * Write config regardless of whether the configuration already exists
+     */
     @Override
     public boolean putConfig(String dataId, String content, long timeoutMills) {
         ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUT, timeoutMills);
 
         configExecutor.execute(() -> {
             try (Jedis jedis = jedisPool.getResource();
-                    Pipeline pipeline = jedis.pipelined()) {
+                 Pipeline pipeline = jedis.pipelined()) {
                 pipeline.hset(getConfigKey(), dataId, content);
                 pipeline.publish(
                         getConfigChannelKey() + ":" + dataId,
@@ -226,6 +177,9 @@ public class RedisConfiguration extends AbstractConfiguration {
         return (Boolean) configFuture.get();
     }
 
+    /**
+     * write config only when the configuration does not exist
+     */
     @Override
     public boolean putConfigIfAbsent(String dataId, String content, long timeoutMills) {
         if (!seataConfig.isEmpty()) {
@@ -274,13 +228,16 @@ public class RedisConfiguration extends AbstractConfiguration {
         return (Boolean) configFuture.get();
     }
 
+    /**
+     * remove config with timeout
+     */
     @Override
     public boolean removeConfig(String dataId, long timeoutMills) {
         ConfigFuture configFuture = new ConfigFuture(dataId, null, ConfigFuture.ConfigOperation.REMOVE, timeoutMills);
 
         configExecutor.execute(() -> {
             try (Jedis jedis = jedisPool.getResource();
-                    Pipeline pipeline = jedis.pipelined()) {
+                 Pipeline pipeline = jedis.pipelined()) {
                 pipeline.hdel(getConfigKey(), dataId);
                 pipeline.publish(
                         getConfigChannelKey() + ":" + dataId,
@@ -417,6 +374,93 @@ public class RedisConfiguration extends AbstractConfiguration {
         public void unsubscribe() {
             running = false;
             super.unsubscribe();
+        }
+    }
+
+    private void shutdownExecutorService(ExecutorService executorService) {
+        if (executorService != null && !executorService.isShutdown()) {
+            executorService.shutdown();
+            try {
+                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    executorService.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Initialize Redis connection pool with configuration parameters
+     */
+    private void initRedisPool() {
+        GenericObjectPoolConfig redisConfig = new GenericObjectPoolConfig();
+        redisConfig.setTestOnBorrow(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-borrow", true));
+        redisConfig.setTestOnReturn(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-return", false));
+        redisConfig.setTestWhileIdle(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-while-idle", false));
+
+        String serverAddr = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "server-addr");
+        String[] serverArr = NetUtil.splitIPPortStr(serverAddr);
+        String host = serverArr[0];
+        int port = Integer.parseInt(serverArr[1]);
+
+        String password = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "password");
+        int database = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "db", 0);
+
+        int maxIdle = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-idle", 0);
+        if (maxIdle > 0) {
+            redisConfig.setMaxIdle(maxIdle);
+        }
+        int minIdle = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "min-idle", 0);
+        if (minIdle > 0) {
+            redisConfig.setMinIdle(minIdle);
+        }
+        int maxActive = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-active", 0);
+        if (maxActive > 0) {
+            redisConfig.setMaxTotal(maxActive);
+        }
+        int maxTotal = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-total", 0);
+        if (maxTotal > 0) {
+            redisConfig.setMaxTotal(maxTotal);
+        }
+        int maxWait = fileConfig.getInt(
+                REDIS_FILEKEY_PREFIX + "max-wait", fileConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
+        if (maxWait > 0) {
+            redisConfig.setMaxWaitMillis(maxWait);
+        }
+        int numTestsPerEvictionRun = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "num-tests-per-eviction-run", 0);
+        if (numTestsPerEvictionRun > 0) {
+            redisConfig.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
+        }
+        int timeBetweenEvictionRunsMillis =
+                fileConfig.getInt(REDIS_FILEKEY_PREFIX + "time-between-eviction-runs-millis", 0);
+        if (timeBetweenEvictionRunsMillis > 0) {
+            redisConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
+        }
+        int minEvictableIdleTimeMillis = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "min-evictable-idle-time-millis", 0);
+        if (minEvictableIdleTimeMillis > 0) {
+            redisConfig.setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis);
+        }
+
+        if (StringUtils.isNullOrEmpty(password)) {
+            jedisPool = new JedisPool(redisConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, database);
+        } else {
+            jedisPool = new JedisPool(redisConfig, host, port, Protocol.DEFAULT_TIMEOUT, password, database);
+        }
+    }
+
+    /**
+     * Initialize Seata configuration from Redis, loads all configurations into local cache
+     */
+    private void initSeataConfig() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Map<String, String> configMap = jedis.hgetAll(getConfigKey());
+            if (!configMap.isEmpty()) {
+                configMap.forEach((key, value) -> seataConfig.setProperty(key, value));
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to init Redis config: {}", e.getMessage());
         }
     }
 

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
@@ -1,0 +1,410 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.config.redis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.seata.common.thread.NamedThreadFactory;
+import org.apache.seata.common.util.NetUtil;
+import org.apache.seata.common.util.StringUtils;
+import org.apache.seata.config.AbstractConfiguration;
+import org.apache.seata.config.ConfigFuture;
+import org.apache.seata.config.Configuration;
+import org.apache.seata.config.ConfigurationChangeEvent;
+import org.apache.seata.config.ConfigurationChangeListener;
+import org.apache.seata.config.ConfigurationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Transaction;
+
+/**
+ * The type Redis configuration
+ */
+public class RedisConfiguration extends AbstractConfiguration {
+    private static volatile RedisConfiguration instance;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisConfiguration.class);
+
+    private final Configuration fileConfig = ConfigurationFactory.CURRENT_FILE_INSTANCE;
+    private static volatile Properties seataConfig = new Properties();
+
+    private static final String DEFAULT_GROUP = "SEATA_GROUP";
+    private static final String CONFIG_TYPE = "redis";
+
+    private static final String REDIS_FILEKEY_PREFIX = "config.redis.";
+    private static final int THREAD_POOL_NUM = 1;
+
+    private static volatile JedisPool jedisPool;
+
+    private static final ConcurrentMap<String, Set<RedisListener>> CONFIG_LISTENERS_MAP = new ConcurrentHashMap<>();
+
+    private final ExecutorService configExecutor = new ThreadPoolExecutor(
+            THREAD_POOL_NUM,
+            THREAD_POOL_NUM,
+            Integer.MAX_VALUE,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(),
+            new NamedThreadFactory("redis-config-executor", THREAD_POOL_NUM));
+
+    private final ExecutorService subscribeExecutor = new ThreadPoolExecutor(
+            THREAD_POOL_NUM,
+            THREAD_POOL_NUM,
+            Integer.MAX_VALUE,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(),
+            new NamedThreadFactory("redis-subscribe-executor", THREAD_POOL_NUM));
+
+    /**
+     * Get instance of RedisConfiguration
+     *
+     * @return instance
+     */
+    public static RedisConfiguration getInstance() {
+        if (instance == null) {
+            synchronized (RedisConfiguration.class) {
+                if (instance == null) {
+                    instance = new RedisConfiguration();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Instantiates a new Redis configuration
+     */
+    private RedisConfiguration() {
+        initRedisPool();
+        initSeataConfig();
+    }
+
+    /**
+     * Initialize Redis connection pool with configuration parameters
+     */
+    private void initRedisPool() {
+        GenericObjectPoolConfig redisConfig = new GenericObjectPoolConfig();
+        redisConfig.setTestOnBorrow(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-borrow", true));
+        redisConfig.setTestOnReturn(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-return", false));
+        redisConfig.setTestWhileIdle(fileConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-while-idle", false));
+
+        String serverAddr = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "serverAddr");
+        String[] serverArr = NetUtil.splitIPPortStr(serverAddr);
+        String host = serverArr[0];
+        int port = Integer.parseInt(serverArr[1]);
+
+        String password = fileConfig.getConfig(REDIS_FILEKEY_PREFIX + "password");
+        int database = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "db", 0);
+
+        int maxIdle = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-idle", 0);
+        if (maxIdle > 0) {
+            redisConfig.setMaxIdle(maxIdle);
+        }
+        int minIdle = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "min-idle", 0);
+        if (minIdle > 0) {
+            redisConfig.setMinIdle(minIdle);
+        }
+        int maxActive = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-active", 0);
+        if (maxActive > 0) {
+            redisConfig.setMaxTotal(maxActive);
+        }
+        int maxTotal = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-total", 0);
+        if (maxTotal > 0) {
+            redisConfig.setMaxTotal(maxTotal);
+        }
+        int maxWait = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "max-wait", fileConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
+        if (maxWait > 0) {
+            redisConfig.setMaxWaitMillis(maxWait);
+        }
+        int numTestsPerEvictionRun = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "num-tests-per-eviction-run", 0);
+        if (numTestsPerEvictionRun > 0) {
+            redisConfig.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
+        }
+        int timeBetweenEvictionRunsMillis = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "time-between-eviction-runs-millis", 0);
+        if (timeBetweenEvictionRunsMillis > 0) {
+            redisConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
+        }
+        int minEvictableIdleTimeMillis = fileConfig.getInt(REDIS_FILEKEY_PREFIX + "min-evictable-idle-time-millis", 0);
+        if (minEvictableIdleTimeMillis > 0) {
+            redisConfig.setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis);
+        }
+
+        if (StringUtils.isNullOrEmpty(password)) {
+            jedisPool = new JedisPool(redisConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, database);
+        } else {
+            jedisPool = new JedisPool(redisConfig, host, port, Protocol.DEFAULT_TIMEOUT, password, database);
+        }
+    }
+
+    /**
+     * Initialize Seata configuration from Redis, loads all configurations into local cache
+     */
+    private void initSeataConfig() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Map<String, String> configMap = jedis.hgetAll(getConfigKey());
+            if (!configMap.isEmpty()) {
+                seataConfig = new Properties();
+                configMap.forEach((key, value) -> seataConfig.setProperty(key, value));
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to init Redis config: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public String getLatestConfig(String dataId, String defaultValue, long timeoutMills) {
+        String value = seataConfig.getProperty(dataId);
+        if (value != null) {
+            return value;
+        }
+
+        // Time in ConfigFuture, if time out, get() method would return the default value
+        ConfigFuture configFuture = new ConfigFuture(dataId, defaultValue, ConfigFuture.ConfigOperation.GET,
+                timeoutMills);
+        configExecutor.execute(() -> {
+            try (Jedis jedis = jedisPool.getResource()) {
+                String result = jedis.hget(getConfigKey(), dataId);
+                configFuture.setResult(result != null ? result : defaultValue);
+            } catch (Exception e) {
+                LOGGER.error("Failed to get config from Redis: {}", e.getMessage());
+                configFuture.setResult(defaultValue);
+            }
+        });
+
+        return (String) configFuture.get();
+    }
+
+    @Override
+    public boolean putConfig(String dataId, String content, long timeoutMills) {
+        ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUT,
+                timeoutMills);
+
+        configExecutor.execute(() -> {
+            try (Jedis jedis = jedisPool.getResource()) {
+                jedis.hset(getConfigKey(), dataId, content);
+                jedis.publish(getConfigChannelKey() + ":" + dataId, buildConfigChangeMessage(dataId, content));
+
+                seataConfig.setProperty(dataId, content);
+                configFuture.setResult(Boolean.TRUE);
+            } catch (Exception e) {
+                LOGGER.error("Failed to put config to Redis: {}", e.getMessage());
+                configFuture.setResult(Boolean.FALSE);
+            }
+        });
+
+        return (Boolean) configFuture.get();
+    }
+
+    @Override
+    public boolean putConfigIfAbsent(String dataId, String content, long timeoutMills) {
+        if (!seataConfig.isEmpty()) {
+            if (seataConfig.containsKey(dataId)) {
+                return true;
+            } else {
+                return putConfig(dataId, content, timeoutMills);
+            }
+        }
+
+        ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUTIFABSENT,
+                timeoutMills);
+
+        configExecutor.execute(() -> {
+            try (Jedis jedis = jedisPool.getResource()) {
+                String configKey = getConfigKey();
+
+                jedis.watch(configKey);
+                if (!jedis.hexists(configKey, dataId)) {
+                    Transaction transaction = jedis.multi();
+                    transaction.hset(configKey, dataId, content);
+                    transaction.publish(getConfigChannelKey() + ":" + dataId, buildConfigChangeMessage(dataId, content));
+
+                    List<Object> results = transaction.exec();
+
+                    if (results != null && !results.isEmpty()) {
+                        seataConfig.setProperty(dataId, content);
+                        configFuture.setResult(Boolean.TRUE);
+                    } else {
+                        configFuture.setResult(Boolean.FALSE);
+                    }
+                } else {
+                    configFuture.setResult(Boolean.FALSE);
+                }
+
+                jedis.unwatch();
+            } catch (Exception e) {
+                LOGGER.error("Failed to put config if absent to Redis: {}", e.getMessage());
+                configFuture.setResult(Boolean.FALSE);
+            }
+        });
+
+        return (Boolean) configFuture.get();
+    }
+
+    @Override
+    public boolean removeConfig(String dataId, long timeoutMills) {
+        ConfigFuture configFuture = new ConfigFuture(dataId, null, ConfigFuture.ConfigOperation.REMOVE,
+                timeoutMills);
+
+        configExecutor.execute(() -> {
+            try (Jedis jedis = jedisPool.getResource()) {
+                jedis.hdel(getConfigKey(), dataId);
+                jedis.publish(getConfigChannelKey() + ":" + dataId, buildConfigChangeMessage(dataId, null));
+
+                seataConfig.remove(dataId);
+                configFuture.setResult(Boolean.TRUE);
+            } catch (Exception e) {
+                LOGGER.error("Failed to remove config from Redis: {}", e.getMessage());
+                configFuture.setResult(Boolean.FALSE);
+            }
+        });
+
+        return (Boolean) configFuture.get();
+    }
+
+    @Override
+    public void addConfigListener(String dataId, ConfigurationChangeListener listener) {
+        if (StringUtils.isBlank(dataId) || listener == null) {
+            return;
+        }
+
+        try {
+            RedisListener redisListener = new RedisListener(dataId, listener);
+            CONFIG_LISTENERS_MAP
+                    .computeIfAbsent(dataId, key -> ConcurrentHashMap.newKeySet())
+                    .add(redisListener);
+
+            subscribeExecutor.execute(() -> {
+                try (Jedis jedis = jedisPool.getResource()) {
+
+                    String channel = getConfigChannelKey() + ":" + dataId;
+                    jedis.subscribe(redisListener, channel);
+                } catch (Exception e) {
+                    LOGGER.error("Failed to subscribe Redis channel: {}", e.getMessage());
+                }
+            });
+        } catch (Exception e) {
+            LOGGER.error("Failed to add Redis listener: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void removeConfigListener(String dataId, ConfigurationChangeListener listener) {
+        if (StringUtils.isBlank(dataId) || listener == null) {
+            return;
+        }
+
+        Set<RedisListener> redisListeners = CONFIG_LISTENERS_MAP.get(dataId);
+        if (redisListeners != null) {
+            redisListeners.removeIf(redisListener -> {
+                if (redisListener.getTargetListener().equals(listener)) {
+                    redisListener.unsubscribe();
+                    return true;
+                }
+                return false;
+            });
+
+            if (redisListeners.isEmpty()) {
+                CONFIG_LISTENERS_MAP.remove(dataId);
+            }
+        }
+    }
+
+    @Override
+    public Set<ConfigurationChangeListener> getConfigListeners(String dataId) {
+        Set<RedisListener> redisListeners = CONFIG_LISTENERS_MAP.get(dataId);
+        if (redisListeners != null) {
+            return redisListeners.stream().map(RedisListener::getTargetListener).collect(Collectors.toSet());
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getTypeName() {
+        return CONFIG_TYPE;
+    }
+
+    /**
+     * RedisListener, handles Redis publish events for configuration changes
+     */
+    public static class RedisListener extends JedisPubSub {
+        private final String dataId;
+        private final ConfigurationChangeListener listener;
+        private volatile boolean running = true;
+
+        public RedisListener(String dataId, ConfigurationChangeListener listener) {
+            this.dataId = dataId;
+            this.listener = listener;
+        }
+
+        @Override
+        public void onMessage(String channel, String message) {
+            if (!running) {
+                return;
+            }
+
+            String[] parts = message.split("-", 2);
+            if (parts.length == 2 && parts[0].equals(dataId)) {
+                ConfigurationChangeEvent event = new ConfigurationChangeEvent()
+                        .setDataId(dataId)
+                        .setNewValue(parts[1])
+                        .setNamespace(DEFAULT_GROUP);
+                listener.onProcessEvent(event);
+            }
+        }
+
+        public ConfigurationChangeListener getTargetListener() {
+            return this.listener;
+        }
+
+        public void unsubscribe() {
+            running = false;
+            super.unsubscribe();
+        }
+    }
+
+    /**
+     * Build configuration change message for Redis pub/sub
+     */
+    private String buildConfigChangeMessage(String dataId, String content) {
+        // like: dataId-content
+        return String.format("%s-%s", dataId, content);
+    }
+
+    private String getConfigKey() {
+        // like: seata:config:SEATA_GROUP
+        return "seata:config:" + DEFAULT_GROUP;
+    }
+
+    private String getConfigChannelKey() {
+        // like: seata:config:channel:SEATA_GROUP
+        return "seata:config:channel:" + DEFAULT_GROUP;
+    }
+}

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfiguration.java
@@ -27,7 +27,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.seata.common.thread.NamedThreadFactory;
 import org.apache.seata.common.util.NetUtil;
@@ -205,13 +204,14 @@ public class RedisConfiguration extends AbstractConfiguration {
 
     @Override
     public boolean putConfig(String dataId, String content, long timeoutMills) {
-        ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUT,
-                timeoutMills);
+        ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUT, timeoutMills);
 
         configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource(); Pipeline pipeline = jedis.pipelined()) {
+            try (Jedis jedis = jedisPool.getResource();
+                    Pipeline pipeline = jedis.pipelined()) {
                 pipeline.hset(getConfigKey(), dataId, content);
-                pipeline.publish(getConfigChannelKey() + ":" + dataId,
+                pipeline.publish(
+                        getConfigChannelKey() + ":" + dataId,
                         buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
                 pipeline.sync();
 
@@ -236,8 +236,8 @@ public class RedisConfiguration extends AbstractConfiguration {
             }
         }
 
-        ConfigFuture configFuture = new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUTIFABSENT,
-                timeoutMills);
+        ConfigFuture configFuture =
+                new ConfigFuture(dataId, content, ConfigFuture.ConfigOperation.PUTIFABSENT, timeoutMills);
 
         configExecutor.execute(() -> {
             try (Jedis jedis = jedisPool.getResource()) {
@@ -248,7 +248,8 @@ public class RedisConfiguration extends AbstractConfiguration {
                 if (!jedis.hexists(configKey, dataId)) {
                     Transaction transaction = jedis.multi();
                     transaction.hset(configKey, dataId, content);
-                    transaction.publish(getConfigChannelKey() + ":" + dataId,
+                    transaction.publish(
+                            getConfigChannelKey() + ":" + dataId,
                             buildConfigChangeMessage(ConfigOperation.PUT, dataId, content));
 
                     List<Object> results = transaction.exec();
@@ -278,9 +279,11 @@ public class RedisConfiguration extends AbstractConfiguration {
         ConfigFuture configFuture = new ConfigFuture(dataId, null, ConfigFuture.ConfigOperation.REMOVE, timeoutMills);
 
         configExecutor.execute(() -> {
-            try (Jedis jedis = jedisPool.getResource(); Pipeline pipeline = jedis.pipelined()) {
+            try (Jedis jedis = jedisPool.getResource();
+                    Pipeline pipeline = jedis.pipelined()) {
                 pipeline.hdel(getConfigKey(), dataId);
-                pipeline.publish(getConfigChannelKey() + ":" + dataId,
+                pipeline.publish(
+                        getConfigChannelKey() + ":" + dataId,
                         buildConfigChangeMessage(ConfigOperation.REMOVE, dataId, ""));
                 pipeline.sync();
 
@@ -391,6 +394,8 @@ public class RedisConfiguration extends AbstractConfiguration {
                         case REMOVE:
                             seataConfig.remove(dataId);
                             content = null;
+                            break;
+                        default:
                             break;
                     }
 

--- a/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfigurationProvider.java
+++ b/config/seata-config-redis/src/main/java/org/apache/seata/config/redis/RedisConfigurationProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.config.redis;
+
+import org.apache.seata.common.loader.LoadLevel;
+import org.apache.seata.config.Configuration;
+import org.apache.seata.config.ConfigurationProvider;
+
+@LoadLevel(name = "Redis", order = 1)
+public class RedisConfigurationProvider implements ConfigurationProvider {
+    @Override
+    public Configuration provide() {
+        return RedisConfiguration.getInstance();
+    }
+}

--- a/config/seata-config-redis/src/main/resources/META-INF/services/org.apache.seata.config.ConfigurationProvider
+++ b/config/seata-config-redis/src/main/resources/META-INF/services/org.apache.seata.config.ConfigurationProvider
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.seata.config.redis.RedisConfigurationProvider

--- a/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
+++ b/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.config.redis;
+
+import java.lang.reflect.Field;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.seata.config.Configuration;
+import org.apache.seata.config.ConfigurationChangeEvent;
+import org.apache.seata.config.ConfigurationChangeListener;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+@EnabledIfSystemProperty(named = "redisCaseEnabled", matches = "true")
+public class RedisConfigurationTest {
+
+    private static final String TEST_DATA_ID = "testDataId";
+    private static final String TEST_CONTENT = "testContent";
+    private static final String CONFIGKEY = "seata:config:SEATA_GROUP";
+
+    private static final long TIMEOUT_MILLIS = 5000;
+
+    private static Configuration configuration;
+    private static JedisPool jedisPool;
+
+    @BeforeAll
+    public static void setUp() {
+        System.setProperty("config.type", "redis");
+        System.setProperty("config.redis.server-addr", "127.0.0.1:6379");
+        configuration = RedisConfiguration.getInstance();
+
+        jedisPool = new JedisPool("127.0.0.1", 6379);
+
+        // refresh data
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.del(CONFIGKEY);
+        }
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        // clean up all test data
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.del(CONFIGKEY);
+        }
+        jedisPool.close();
+    }
+
+    @Test
+    public void testPutConfig() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch);
+
+        boolean putResult = configuration.putConfig(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
+        Assertions.assertTrue(putResult);
+
+        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
+        Assertions.assertTrue(isMessageReceived, "onMessage() method is not triggered");
+
+        cleanupAfterTest(TEST_DATA_ID, listener);
+    }
+
+    @Test
+    public void testGetLatestConfig() throws InterruptedException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.hset(CONFIGKEY, TEST_DATA_ID, TEST_CONTENT);
+        }
+
+        String result = configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS);
+        Assertions.assertEquals(TEST_CONTENT, result);
+
+        cleanupAfterTest(TEST_DATA_ID, null);
+    }
+
+    @Test
+    public void testRemoveConfig() throws InterruptedException {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.hset(CONFIGKEY, TEST_DATA_ID, TEST_CONTENT);
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, null, latch);
+
+        boolean success = configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS);
+        Assertions.assertTrue(success);
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            String value = jedis.hget(CONFIGKEY, TEST_DATA_ID);
+            Assertions.assertNull(value);
+        }
+
+        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
+        Assertions.assertTrue(isMessageReceived, "onMessage() method is not triggered");
+
+        cleanupAfterTest(TEST_DATA_ID, listener);
+    }
+
+    @Test
+    public void testPutConfigIfAbsent() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch);
+
+        // When seataConfig is empty, execute redis transactions -> set and publish
+        boolean success = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
+        Assertions.assertTrue(success);
+
+        // When local cache is available, return true directly
+        boolean secondTry = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
+        Assertions.assertTrue(secondTry);
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            String value = jedis.hget(CONFIGKEY, TEST_DATA_ID);
+            Assertions.assertEquals(TEST_CONTENT, value);
+        }
+
+        // When dataId is new and seataConfig is not empty, -> .putConfig()
+        String newDataId = "newTestDataId";
+        boolean thirdTry = configuration.putConfigIfAbsent(newDataId, "newTestContent", TIMEOUT_MILLIS);
+        Assertions.assertTrue(thirdTry);
+
+        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
+        Assertions.assertTrue(isMessageReceived, "onMessage() method is not triggered");
+
+        cleanupAfterTest(TEST_DATA_ID, listener);
+        cleanupAfterTest(newDataId, null);
+    }
+
+    @Test
+    public void testGetConfigListeners() throws InterruptedException {
+        Set<ConfigurationChangeListener> initialListeners = configuration.getConfigListeners(TEST_DATA_ID);
+        Assertions.assertNull(initialListeners);
+
+        CountDownLatch latch1 = new CountDownLatch(1);
+        ConfigurationChangeListener listener1 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch1);
+
+        CountDownLatch latch2 = new CountDownLatch(1);
+        ConfigurationChangeListener listener2 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch2);
+
+        Set<ConfigurationChangeListener> listeners = configuration.getConfigListeners(TEST_DATA_ID);
+        Assertions.assertNotNull(listeners);
+        Assertions.assertEquals(2, listeners.size());
+        Assertions.assertTrue(listeners.contains(listener1));
+        Assertions.assertTrue(listeners.contains(listener2));
+
+        configuration.removeConfigListener(TEST_DATA_ID, listener1);
+        listeners = configuration.getConfigListeners(TEST_DATA_ID);
+        Assertions.assertNotNull(listeners);
+        Assertions.assertEquals(1, listeners.size());
+        Assertions.assertTrue(listeners.contains(listener2));
+
+        Set<ConfigurationChangeListener> nonExistentListeners = configuration.getConfigListeners("nonExistentDataId");
+        Assertions.assertNull(nonExistentListeners);
+    }
+
+    /**
+     * Create and add a configuration listener, check if publish notifications are successful
+     */
+    private ConfigurationChangeListener addPublishListener(String dataId, String expectedContent, CountDownLatch latch)
+            throws InterruptedException {
+        ConfigurationChangeListener listener = new ConfigurationChangeListener() {
+            @Override
+            public void onChangeEvent(ConfigurationChangeEvent event) {
+            }
+
+            @Override
+            public void onProcessEvent(ConfigurationChangeEvent event) {
+                if (event.getDataId().equals(dataId)) {
+                    String newValue = event.getNewValue();
+                    if ((expectedContent == null && newValue == null)
+                            || (expectedContent != null && expectedContent.equals(newValue))) {
+                        latch.countDown();
+                    }
+                }
+            }
+        };
+
+        configuration.addConfigListener(dataId, listener);
+
+        // add sleep to ensure listener added successfully
+        Thread.sleep(100);
+        return listener;
+    }
+
+    /**
+     * Clean up resources after each test
+     */
+    private void cleanupAfterTest(String dataId, ConfigurationChangeListener listener) throws InterruptedException {
+        // remove the listener
+        if (listener != null) {
+            configuration.removeConfigListener(dataId, listener);
+        }
+
+        // clean redis data
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.hdel(CONFIGKEY, dataId);
+        }
+
+        // clean up the cache in seataConfig
+        try {
+            Field seataConfigField = RedisConfiguration.class.getDeclaredField("seataConfig");
+            seataConfigField.setAccessible(true);
+            Properties seataConfig = (Properties) seataConfigField.get(null);
+            seataConfig.remove(dataId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clean seataConfig cache", e);
+        }
+
+        Thread.sleep(100);
+    }
+}

--- a/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
+++ b/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.seata.config.Configuration;
 import org.apache.seata.config.ConfigurationChangeEvent;
 import org.apache.seata.config.ConfigurationChangeListener;
@@ -181,8 +180,7 @@ public class RedisConfigurationTest {
             throws InterruptedException {
         ConfigurationChangeListener listener = new ConfigurationChangeListener() {
             @Override
-            public void onChangeEvent(ConfigurationChangeEvent event) {
-            }
+            public void onChangeEvent(ConfigurationChangeEvent event) {}
 
             @Override
             public void onProcessEvent(ConfigurationChangeEvent event) {

--- a/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
+++ b/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
@@ -16,19 +16,40 @@
  */
 package org.apache.seata.config.redis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.apache.seata.config.Configuration;
 import org.apache.seata.config.ConfigurationChangeEvent;
 import org.apache.seata.config.ConfigurationChangeListener;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
@@ -37,6 +58,7 @@ public class RedisConfigurationTest {
 
     private static final String TEST_DATA_ID = "testDataId";
     private static final String TEST_CONTENT = "testContent";
+    private static final String TEST_DEFAULT_VALUE = "testDefaultValue";
     private static final String CONFIGKEY = "seata:config:SEATA_GROUP";
 
     private static final long TIMEOUT_MILLIS = 5000;
@@ -44,15 +66,18 @@ public class RedisConfigurationTest {
     private static Configuration configuration;
     private static JedisPool jedisPool;
 
+    private final List<Logger> watchedLoggers = new ArrayList<>();
+    private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
+
     @BeforeAll
     public static void setUp() {
         System.setProperty("config.type", "redis");
         System.setProperty("config.redis.server-addr", "127.0.0.1:6379");
-        configuration = RedisConfiguration.getInstance();
 
+        configuration = RedisConfiguration.getInstance();
         jedisPool = new JedisPool("127.0.0.1", 6379);
 
-        // refresh data
+        // clean up all test data
         try (Jedis jedis = jedisPool.getResource()) {
             jedis.del(CONFIGKEY);
         }
@@ -67,18 +92,25 @@ public class RedisConfigurationTest {
         jedisPool.close();
     }
 
+    @BeforeEach
+    public void startLogWatcher() {
+        logWatcher.start();
+
+        Logger logger = ((Logger) LoggerFactory.getLogger(RedisConfiguration.class.getName()));
+        logger.addAppender(logWatcher);
+
+        watchedLoggers.add(logger);
+    }
+
+    @AfterEach
+    public void cleanLogWatcher() {
+        watchedLoggers.forEach(Logger::detachAndStopAllAppenders);
+    }
+
     @Test
-    public void testPutConfig() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch);
-
-        boolean putResult = configuration.putConfig(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
-        Assertions.assertTrue(putResult);
-
-        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
-        Assertions.assertTrue(isMessageReceived, "onMessage() method is not triggered");
-
-        cleanupAfterTest(TEST_DATA_ID, listener);
+    public void testGetInstance() {
+        assertInstanceOf(RedisConfiguration.class, RedisConfiguration.getInstance());
+        assertEquals(configuration, RedisConfiguration.getInstance());
     }
 
     @Test
@@ -87,31 +119,39 @@ public class RedisConfigurationTest {
             jedis.hset(CONFIGKEY, TEST_DATA_ID, TEST_CONTENT);
         }
 
+        // If there is no cache, asynchronously query redis
         String result = configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS);
-        Assertions.assertEquals(TEST_CONTENT, result);
+        assertEquals(TEST_CONTENT, result);
+
+        // If there is a cache
+        configuration.putConfig(TEST_DATA_ID, "newTestContent");
+        assertEquals("newTestContent", configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
 
         cleanupAfterTest(TEST_DATA_ID, null);
     }
 
     @Test
+    public void testPutConfig() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch);
+
+        assertTrue(configuration.putConfig(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(TEST_CONTENT, configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
+
+        cleanupAfterTest(TEST_DATA_ID, listener);
+    }
+
+    @Test
     public void testRemoveConfig() throws InterruptedException {
-        try (Jedis jedis = jedisPool.getResource()) {
-            jedis.hset(CONFIGKEY, TEST_DATA_ID, TEST_CONTENT);
-        }
+        configuration.putConfig(TEST_DATA_ID, TEST_CONTENT);
 
         CountDownLatch latch = new CountDownLatch(1);
         ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, null, latch);
 
-        boolean success = configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS);
-        Assertions.assertTrue(success);
-
-        try (Jedis jedis = jedisPool.getResource()) {
-            String value = jedis.hget(CONFIGKEY, TEST_DATA_ID);
-            Assertions.assertNull(value);
-        }
-
-        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
-        Assertions.assertTrue(isMessageReceived, "onMessage() method is not triggered");
+        assertTrue(configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS));
+        assertNull(configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
 
         cleanupAfterTest(TEST_DATA_ID, listener);
     }
@@ -123,24 +163,20 @@ public class RedisConfigurationTest {
 
         // When seataConfig is empty, execute redis transactions -> set and publish
         boolean success = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
-        Assertions.assertTrue(success);
+        assertTrue(success);
 
         // When local cache is available, return true directly
         boolean secondTry = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
-        Assertions.assertTrue(secondTry);
-
-        try (Jedis jedis = jedisPool.getResource()) {
-            String value = jedis.hget(CONFIGKEY, TEST_DATA_ID);
-            Assertions.assertEquals(TEST_CONTENT, value);
-        }
+        assertTrue(secondTry);
+        assertEquals(TEST_CONTENT, configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
 
         // When dataId is new and seataConfig is not empty, -> .putConfig()
         String newDataId = "newTestDataId";
         boolean thirdTry = configuration.putConfigIfAbsent(newDataId, "newTestContent", TIMEOUT_MILLIS);
-        Assertions.assertTrue(thirdTry);
+        assertTrue(thirdTry);
 
         boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
-        Assertions.assertTrue(isMessageReceived, "onMessage() method is not triggered");
+        assertTrue(isMessageReceived);
 
         cleanupAfterTest(TEST_DATA_ID, listener);
         cleanupAfterTest(newDataId, null);
@@ -159,18 +195,87 @@ public class RedisConfigurationTest {
 
         Set<ConfigurationChangeListener> listeners = configuration.getConfigListeners(TEST_DATA_ID);
         Assertions.assertNotNull(listeners);
-        Assertions.assertEquals(2, listeners.size());
-        Assertions.assertTrue(listeners.contains(listener1));
-        Assertions.assertTrue(listeners.contains(listener2));
+        assertEquals(2, listeners.size());
+        assertTrue(listeners.contains(listener1));
+        assertTrue(listeners.contains(listener2));
 
         configuration.removeConfigListener(TEST_DATA_ID, listener1);
         listeners = configuration.getConfigListeners(TEST_DATA_ID);
         Assertions.assertNotNull(listeners);
-        Assertions.assertEquals(1, listeners.size());
-        Assertions.assertTrue(listeners.contains(listener2));
+        assertEquals(1, listeners.size());
+        assertTrue(listeners.contains(listener2));
 
         Set<ConfigurationChangeListener> nonExistentListeners = configuration.getConfigListeners("nonExistentDataId");
         Assertions.assertNull(nonExistentListeners);
+    }
+
+    @Test
+    public void testGetTypeName() {
+        RedisConfiguration redisConfiguration = RedisConfiguration.getInstance();
+        assertEquals(redisConfiguration.getTypeName(), "redis");
+    }
+
+    @Test
+    public void testAllConfigMethodsWithRedisException() throws Exception {
+        JedisPool mockJedisPool = mock(JedisPool.class);
+
+        // let mockJedisPool throws a runtime exception when calling getResource()
+        RuntimeException simulatedException = new RuntimeException("Simulated Redis connection failure");
+        when(mockJedisPool.getResource()).thenThrow(simulatedException);
+
+        // Replace the static jedisPool field inside the RedisConfiguration with a mock object by reflection
+        Field jedisPoolField = RedisConfiguration.class.getDeclaredField("jedisPool");
+        jedisPoolField.setAccessible(true);
+        jedisPoolField.set(null, mockJedisPool);
+
+        // 1.test getLatestConfig
+        String getResult = configuration.getLatestConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
+        assertEquals(TEST_DEFAULT_VALUE, getResult);
+        verify(mockJedisPool, times(1)).getResource();
+        Thread.sleep(TIMEOUT_MILLIS + 50);
+        assertEquals("Failed to get config from Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(0));
+
+        // 2.test putConfig
+        boolean putResult = configuration.putConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
+        assertFalse(putResult);
+        verify(mockJedisPool, times(2)).getResource();
+        Thread.sleep(TIMEOUT_MILLIS + 50);
+        assertEquals("Failed to put config to Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(1));
+
+        // 3.test removeConfig
+        boolean removeResult = configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS);
+        assertFalse(removeResult);
+        verify(mockJedisPool, times(3)).getResource();
+        Thread.sleep(TIMEOUT_MILLIS + 50);
+        assertEquals("Failed to remove config from Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(2));
+
+        // 4.test putConfigIfAbsent
+        // Clear the cache and make sure that the putConfigIfAbsent goes to the 'try (Jedis jedis = jedisPool.getResource())' branch
+        clearSeataConfigCache();
+        boolean putIfAbsentResult = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
+        assertFalse(putIfAbsentResult);
+        verify(mockJedisPool, times(4)).getResource();
+        Thread.sleep(TIMEOUT_MILLIS + 50);
+        assertEquals("Failed to put config if absent to Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(3));
+
+        // Restore the jedisPool to its original value to ensure that other tests are not affected
+        jedisPoolField.set(null, new JedisPool("10.21.32.10", 6379));
+    }
+
+    /**
+     * Helper to clear entire seataConfig cache
+     */
+    private void clearSeataConfigCache() {
+        try {
+            Field seataConfigField = RedisConfiguration.class.getDeclaredField("seataConfig");
+            seataConfigField.setAccessible(true);
+            Properties seataConfig = (Properties) seataConfigField.get(null);
+            if (seataConfig != null) {
+                seataConfig.clear();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to clear seataConfig cache", e);
+        }
     }
 
     /**
@@ -180,7 +285,8 @@ public class RedisConfigurationTest {
             throws InterruptedException {
         ConfigurationChangeListener listener = new ConfigurationChangeListener() {
             @Override
-            public void onChangeEvent(ConfigurationChangeEvent event) {}
+            public void onChangeEvent(ConfigurationChangeEvent event) {
+            }
 
             @Override
             public void onProcessEvent(ConfigurationChangeEvent event) {
@@ -198,6 +304,7 @@ public class RedisConfigurationTest {
 
         // add sleep to ensure listener added successfully
         Thread.sleep(100);
+
         return listener;
     }
 
@@ -225,6 +332,15 @@ public class RedisConfigurationTest {
             throw new RuntimeException("Failed to clean seataConfig cache", e);
         }
 
+        // add sleep to ensure the security of test data
         Thread.sleep(100);
+    }
+
+    private List<String> getLogs(Level level) {
+        return logWatcher.list.stream()
+                .filter(event -> event.getLoggerName().endsWith(RedisConfiguration.class.getName())
+                        && event.getLevel().equals(level))
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.toList());
     }
 }

--- a/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
+++ b/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
@@ -108,12 +108,6 @@ public class RedisConfigurationTest {
     }
 
     @Test
-    public void testGetInstance() {
-        assertInstanceOf(RedisConfiguration.class, RedisConfiguration.getInstance());
-        assertEquals(configuration, RedisConfiguration.getInstance());
-    }
-
-    @Test
     public void testGetLatestConfig() throws InterruptedException {
         try (Jedis jedis = jedisPool.getResource()) {
             jedis.hset(CONFIGKEY, TEST_DATA_ID, TEST_CONTENT);
@@ -164,19 +158,17 @@ public class RedisConfigurationTest {
         // When seataConfig is empty, execute redis transactions -> set and publish
         boolean success = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
         assertTrue(success);
+        assertEquals(TEST_CONTENT, configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
 
         // When local cache is available, return true directly
         boolean secondTry = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
         assertTrue(secondTry);
-        assertEquals(TEST_CONTENT, configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
 
         // When dataId is new and seataConfig is not empty, -> .putConfig()
         String newDataId = "newTestDataId";
         boolean thirdTry = configuration.putConfigIfAbsent(newDataId, "newTestContent", TIMEOUT_MILLIS);
         assertTrue(thirdTry);
-
-        boolean isMessageReceived = latch.await(5, TimeUnit.SECONDS);
-        assertTrue(isMessageReceived);
 
         cleanupAfterTest(TEST_DATA_ID, listener);
         cleanupAfterTest(newDataId, null);
@@ -187,32 +179,20 @@ public class RedisConfigurationTest {
         Set<ConfigurationChangeListener> initialListeners = configuration.getConfigListeners(TEST_DATA_ID);
         assertNull(initialListeners);
 
-        CountDownLatch latch1 = new CountDownLatch(1);
-        ConfigurationChangeListener listener1 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch1);
-
-        CountDownLatch latch2 = new CountDownLatch(1);
-        ConfigurationChangeListener listener2 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch2);
+        ConfigurationChangeListener listener1 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, new CountDownLatch(1));
+        ConfigurationChangeListener listener2 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, new CountDownLatch(1));
 
         Set<ConfigurationChangeListener> listeners = configuration.getConfigListeners(TEST_DATA_ID);
-        assertNotNull(listeners);
         assertEquals(2, listeners.size());
-        assertTrue(listeners.contains(listener1));
-        assertTrue(listeners.contains(listener2));
+        assertTrue(listeners.contains(listener1) && listeners.contains(listener2));
 
         configuration.removeConfigListener(TEST_DATA_ID, listener1);
         listeners = configuration.getConfigListeners(TEST_DATA_ID);
-        assertNotNull(listeners);
         assertEquals(1, listeners.size());
         assertTrue(listeners.contains(listener2));
 
         Set<ConfigurationChangeListener> nonExistentListeners = configuration.getConfigListeners("nonExistentDataId");
         assertNull(nonExistentListeners);
-    }
-
-    @Test
-    public void testGetTypeName() {
-        RedisConfiguration redisConfiguration = RedisConfiguration.getInstance();
-        assertEquals(redisConfiguration.getTypeName(), "redis");
     }
 
     @Test
@@ -231,22 +211,16 @@ public class RedisConfigurationTest {
         // 1.test getLatestConfig
         String getResult = configuration.getLatestConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
         assertEquals(TEST_DEFAULT_VALUE, getResult);
-        verify(mockJedisPool, times(1)).getResource();
-        Thread.sleep(TIMEOUT_MILLIS + 50);
         assertEquals("Failed to get config from Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(0));
 
         // 2.test putConfig
         boolean putResult = configuration.putConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
         assertFalse(putResult);
-        verify(mockJedisPool, times(2)).getResource();
-        Thread.sleep(TIMEOUT_MILLIS + 50);
         assertEquals("Failed to put config to Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(1));
 
         // 3.test removeConfig
         boolean removeResult = configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS);
         assertFalse(removeResult);
-        verify(mockJedisPool, times(3)).getResource();
-        Thread.sleep(TIMEOUT_MILLIS + 50);
         assertEquals("Failed to remove config from Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(2));
 
         // 4.test putConfigIfAbsent
@@ -255,11 +229,22 @@ public class RedisConfigurationTest {
         boolean putIfAbsentResult = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
         assertFalse(putIfAbsentResult);
         verify(mockJedisPool, times(4)).getResource();
-        Thread.sleep(TIMEOUT_MILLIS + 50);
         assertEquals("Failed to put config if absent to Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(3));
 
         // Restore the jedisPool to its original value to ensure that other tests are not affected
-        jedisPoolField.set(null, new JedisPool("10.21.32.10", 6379));
+        jedisPoolField.set(null, new JedisPool("127.0.0.1", 6379));
+    }
+
+    @Test
+    public void testGetTypeName() {
+        RedisConfiguration redisConfiguration = RedisConfiguration.getInstance();
+        assertEquals(redisConfiguration.getTypeName(), "redis");
+    }
+
+    @Test
+    public void testGetInstance() {
+        assertInstanceOf(RedisConfiguration.class, RedisConfiguration.getInstance());
+        assertEquals(configuration, RedisConfiguration.getInstance());
     }
 
     /**

--- a/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
+++ b/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
@@ -19,7 +19,6 @@ package org.apache.seata.config.redis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -113,7 +112,7 @@ public class RedisConfigurationTest {
             jedis.hset(CONFIGKEY, TEST_DATA_ID, TEST_CONTENT);
         }
 
-        // If there is no cache, asynchronously query redis
+        // If there is no cache, query redis
         String result = configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS);
         assertEquals(TEST_CONTENT, result);
 
@@ -155,20 +154,25 @@ public class RedisConfigurationTest {
         CountDownLatch latch = new CountDownLatch(1);
         ConfigurationChangeListener listener = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch);
 
-        // When seataConfig is empty, execute redis transactions -> set and publish
+        // 1.When seataConfig and redis is empty, put config to redis
         boolean success = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
         assertTrue(success);
         assertEquals(TEST_CONTENT, configuration.getLatestConfig(TEST_DATA_ID, null, TIMEOUT_MILLIS));
         assertTrue(latch.await(5, TimeUnit.SECONDS));
 
-        // When local cache is available, return true directly
+        // 2.When local cache is available, return true directly
         boolean secondTry = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_CONTENT, TIMEOUT_MILLIS);
         assertTrue(secondTry);
 
-        // When dataId is new and seataConfig is not empty, -> .putConfig()
+        // 3.When seataConfig is empty and redis is not empty, update the value of redis to seataConfig
         String newDataId = "newTestDataId";
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.hset(CONFIGKEY, newDataId, "alreadyExist");
+        }
+
         boolean thirdTry = configuration.putConfigIfAbsent(newDataId, "newTestContent", TIMEOUT_MILLIS);
         assertTrue(thirdTry);
+        assertEquals("alreadyExist", configuration.getLatestConfig(newDataId, null, TIMEOUT_MILLIS));
 
         cleanupAfterTest(TEST_DATA_ID, listener);
         cleanupAfterTest(newDataId, null);
@@ -209,27 +213,27 @@ public class RedisConfigurationTest {
         jedisPoolField.set(null, mockJedisPool);
 
         // 1.test getLatestConfig
-        String getResult = configuration.getLatestConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
-        assertEquals(TEST_DEFAULT_VALUE, getResult);
+        assertEquals(TEST_DEFAULT_VALUE, configuration.getLatestConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS));
         assertEquals("Failed to get config from Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(0));
 
         // 2.test putConfig
-        boolean putResult = configuration.putConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
-        assertFalse(putResult);
+        assertFalse(configuration.putConfig(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS));
         assertEquals("Failed to put config to Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(1));
 
         // 3.test removeConfig
-        boolean removeResult = configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS);
-        assertFalse(removeResult);
+        assertFalse(configuration.removeConfig(TEST_DATA_ID, TIMEOUT_MILLIS));
         assertEquals("Failed to remove config from Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(2));
 
         // 4.test putConfigIfAbsent
-        // Clear the cache and make sure that the putConfigIfAbsent goes to the 'try (Jedis jedis = jedisPool.getResource())' branch
         clearSeataConfigCache();
-        boolean putIfAbsentResult = configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS);
-        assertFalse(putIfAbsentResult);
-        verify(mockJedisPool, times(4)).getResource();
+        assertFalse(configuration.putConfigIfAbsent(TEST_DATA_ID, TEST_DEFAULT_VALUE, TIMEOUT_MILLIS));
         assertEquals("Failed to put config if absent to Redis: Simulated Redis connection failure", getLogs(Level.ERROR).get(3));
+
+        // 5.test addConfigListener
+        addPublishListener(TEST_DATA_ID, TEST_DEFAULT_VALUE, new CountDownLatch(1));
+        assertEquals("Failed to subscribe Redis channel: Simulated Redis connection failure", getLogs(Level.ERROR).get(4));
+
+        verify(mockJedisPool, times(5)).getResource();
 
         // Restore the jedisPool to its original value to ensure that other tests are not affected
         jedisPoolField.set(null, new JedisPool("127.0.0.1", 6379));
@@ -248,7 +252,7 @@ public class RedisConfigurationTest {
     }
 
     /**
-     * Helper to clear entire seataConfig cache
+     * Clear the cache and make sure that the putConfigIfAbsent goes to the 'try (Jedis jedis = jedisPool.getResource())' branch
      */
     private void clearSeataConfigCache() {
         try {

--- a/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
+++ b/config/seata-config-redis/src/test/java/org/apache/seata/config/redis/RedisConfigurationTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.config.redis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -44,7 +45,6 @@ import org.apache.seata.config.ConfigurationChangeEvent;
 import org.apache.seata.config.ConfigurationChangeListener;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -185,7 +185,7 @@ public class RedisConfigurationTest {
     @Test
     public void testGetConfigListeners() throws InterruptedException {
         Set<ConfigurationChangeListener> initialListeners = configuration.getConfigListeners(TEST_DATA_ID);
-        Assertions.assertNull(initialListeners);
+        assertNull(initialListeners);
 
         CountDownLatch latch1 = new CountDownLatch(1);
         ConfigurationChangeListener listener1 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch1);
@@ -194,19 +194,19 @@ public class RedisConfigurationTest {
         ConfigurationChangeListener listener2 = addPublishListener(TEST_DATA_ID, TEST_CONTENT, latch2);
 
         Set<ConfigurationChangeListener> listeners = configuration.getConfigListeners(TEST_DATA_ID);
-        Assertions.assertNotNull(listeners);
+        assertNotNull(listeners);
         assertEquals(2, listeners.size());
         assertTrue(listeners.contains(listener1));
         assertTrue(listeners.contains(listener2));
 
         configuration.removeConfigListener(TEST_DATA_ID, listener1);
         listeners = configuration.getConfigListeners(TEST_DATA_ID);
-        Assertions.assertNotNull(listeners);
+        assertNotNull(listeners);
         assertEquals(1, listeners.size());
         assertTrue(listeners.contains(listener2));
 
         Set<ConfigurationChangeListener> nonExistentListeners = configuration.getConfigListeners("nonExistentDataId");
-        Assertions.assertNull(nonExistentListeners);
+        assertNull(nonExistentListeners);
     }
 
     @Test

--- a/config/seata-config-redis/src/test/resources/META-INF/services/org.apache.seata.config.ConfigurationProvider
+++ b/config/seata-config-redis/src/test/resources/META-INF/services/org.apache.seata.config.ConfigurationProvider
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.seata.config.redis.RedisConfigurationProvider

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -82,6 +82,12 @@ seata:
     etcd3:
       server-addr: http://localhost:2379
       key: seata.properties
+    redis:
+      server-addr: 127.0.0.1:6379
+      db: 0
+      password:
+      cluster: default
+      timeout: 0
   registry:
     # support: nacos 、 eureka 、 redis 、 zk  、 consul 、 etcd3 、 sofa 、 seata
     type: file

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -45,7 +45,7 @@ logging:
       enabled: false
 seata:
   config:
-    # support: nacos 、 consul 、 apollo 、 zk  、 etcd3
+    # support: nacos 、 consul 、 apollo 、 zk  、 etcd3 、 redis
     type: file
     nacos:
       server-addr: 127.0.0.1:8848

--- a/server/src/main/resources/application.raft.example.yml
+++ b/server/src/main/resources/application.raft.example.yml
@@ -79,6 +79,12 @@ seata:
     etcd3:
       server-addr: http://localhost:2379
       key: seata.properties
+    redis:
+      server-addr: 127.0.0.1:6379
+      db: 0
+      password:
+      cluster: default
+      timeout: 0
   registry:
     # support: nacos 、 eureka 、 redis 、 zk  、 consul 、 etcd3 、 sofa
     type: file

--- a/server/src/main/resources/application.raft.example.yml
+++ b/server/src/main/resources/application.raft.example.yml
@@ -45,7 +45,7 @@ logging:
       enabled: false
 seata:
   config:
-    # support: nacos 、 consul 、 apollo 、 zk  、 etcd3
+    # support: nacos 、 consul 、 apollo 、 zk  、 etcd3 、 redis
     type: file
     nacos:
       server-addr: 127.0.0.1:8848

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -46,7 +46,7 @@ logging:
 
 seata:
   config:
-    # support: nacos, consul, apollo, zk, etcd3
+    # support: nacos, consul, apollo, zk, etcd3, redis
     type: file
   registry:
     # support: nacos, eureka, redis, zk, consul, etcd3, sofa


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
#3617

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

#### Architecture(implement 'AbstractConfiguration')
1. **getLatestConfig():** Configuration read
2. **putConfig():** Write config regardless of whether the configuration already exists
3. **putConfigIfAbsent():** Writes only the configuration that does not exist
4. **removeConfig():** Configuration deletion
5. **addConfigListener() / removeConfigListener():** Listener management


#### Redis data structure design
1. Config: use hash structure 
**Hash strucrture key:** `seata: config: SEATA_GROUP`
**ConfigKey:** dataId
**Value:** content
2. Pub/Sub channel:
**Channel name:** `seata: config:channel:SEATA_GROUP:dataId`
**Message format:** `{operation}-{dataId}-{content}`
**Example:** `put-server.port-8080`


#### Monitoring mechanism
1. **Inheritance JedisPubSub:** Use the native Pub/Sub mechanism of Jedis
2. **Message parsing:** Custom message format parsing logic
3. **Condition conversion:** Convert Redis messages to Seata configuration change events


#### ThreadPool
1. **Reason for use:** Since the subscribe() of redis is blocking, a thread pool is created to manage subscription, and the number of threads can be configured
2. **Close logic:** Use the JVM hook to execute the resource destruction logic for process shutdown


#### Details
1. **The logic of adding listener:** The logic of putting listener into `CONFIG_LISTENERS_MAP` is placed in the callback method `RedisListener.onSubscribe()`, and it will only be put in if the subscription is successful
2. **Redis client:** The client dependency and jedis initialization logic are aligned with `seata-discovery-redis` module

### Ⅴ. Special notes for reviews

