### PR TITLE
test: Refactor log testing use `ListAppender` for accurate log capture

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -18,8 +18,7 @@ name: "test-ubuntu"
 
 on:
   push:
-    #TODO Make sure to remove this when pr is ready to merge
-    branches: [ test*, "*.*.*", 2.x ]
+    branches: [ test*, "*.*.*" ]
 jobs:
   # job 1
   test:

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -18,7 +18,8 @@ name: "test-ubuntu"
 
 on:
   push:
-    branches: [ test*, "*.*.*" ]
+    #TODO Make sure to remove this when pr is ready to merge
+    branches: [ test*, "*.*.*", 2.x ]
 jobs:
   # job 1
   test:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -62,4 +62,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [slievrly](https://github.com/slievrly)
 - [Monilnarang](https://github.com/Monilnarang)
 - [wjwang00](https://github.com/wjwang00)
+- [YongGoose](https://github.com/YongGoose)
+
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -47,7 +47,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### refactor:
 
-- [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] refactor XXX
+- [[#7315](https://github.com/apache/incubator-seata/pull/7315)] Refactor log testing to use ListAppender for more accurate and efficient log capture
 
 
 ### doc:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -46,7 +46,7 @@
 
 ### refactor:
 
-- [[#PR_NO](https://github.com/seata/seata/pull/PR_NO)] refactor XXX
+- [[#7315](https://github.com/apache/incubator-seata/pull/7315)] 重构日志测试，使用ListAppender实现更准确高效的日志捕获
 
 
 ### doc:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -61,5 +61,6 @@
 - [slievrly](https://github.com/slievrly)
 - [Monilnarang](https://github.com/Monilnarang)
 - [wjwang00](https://github.com/wjwang00)
+- [YongGoose](https://github.com/YongGoose)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,6 +73,23 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.18</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.18</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -76,18 +76,15 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.18</version>
         </dependency>
 
     </dependencies>

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/ClientHeartbeatProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/ClientHeartbeatProcessorTest.java
@@ -16,11 +16,21 @@
  */
 package org.apache.seata.core.rpc.processor.client;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.seata.core.protocol.HeartbeatMessage;
 import org.apache.seata.core.protocol.RpcMessage;
 import org.junit.jupiter.api.AfterEach;
@@ -29,29 +39,21 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.mockito.ArgumentMatchers;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * The type Client heartbeat processor test.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientHeartbeatProcessorTest {
+    private static final String CLASS_NAME = "org.apache.seata.core.rpc.processor.client.ClientHeartbeatProcessor";
+
+    private final List<Logger> watchedLoggers = new ArrayList<>();
+    private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
+
     private ClientHeartbeatProcessor processor;
     private ChannelHandlerContext mockCtx;
     private RpcMessage mockRpcMessage;
-    private Logger mockLogger;
-    private MockedStatic<LoggerFactory> mockedLoggerFactory;
 
     /**
      * Sets up.
@@ -60,12 +62,17 @@ public class ClientHeartbeatProcessorTest {
     void setUp() {
         mockCtx = mock(ChannelHandlerContext.class);
         mockRpcMessage = mock(RpcMessage.class);
-        mockLogger = mock(Logger.class);
-
-        // Mock static LoggerFactory to control LOGGER behavior
-        mockedLoggerFactory = Mockito.mockStatic(LoggerFactory.class);
-        mockedLoggerFactory.when(() -> LoggerFactory.getLogger(ClientHeartbeatProcessor.class)).thenReturn(mockLogger);
+        logWatcher.start();
+        setUpLogger();
         processor = new ClientHeartbeatProcessor();
+    }
+
+    /**
+     * Tear down.
+     */
+    @AfterEach
+    void tearDown() {
+        watchedLoggers.forEach(Logger::detachAndStopAllAppenders);
     }
 
     /**
@@ -84,14 +91,14 @@ public class ClientHeartbeatProcessorTest {
         when(mockChannel.remoteAddress()).thenReturn(mockRemoteAddress);
 
         when(mockRpcMessage.getBody()).thenReturn(HeartbeatMessage.PONG);
-        when(mockLogger.isDebugEnabled()).thenReturn(true);
         assertTrue(LoggerFactory.getLogger(ClientHeartbeatProcessor.class).isDebugEnabled());
 
         // Act
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        verify(mockLogger).debug("received PONG from {}", mockRemoteAddress);
+        assertTrue(
+                getLogs(Level.DEBUG).stream().anyMatch(log -> log.contains("received PONG from " + mockRemoteAddress)));
     }
 
     /**
@@ -104,22 +111,25 @@ public class ClientHeartbeatProcessorTest {
     void process_ShouldNotLog_WhenReceiveNonPongMessage() throws Exception {
         // Arrange
         when(mockRpcMessage.getBody()).thenReturn("OTHER_MESSAGE");
-        when(mockLogger.isDebugEnabled()).thenReturn(true);
 
         // Act
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        verify(mockLogger, never()).debug(anyString(), ArgumentMatchers.<Object[]>any());
+        assertTrue(getLogs(Level.DEBUG).isEmpty());
     }
 
-    /**
-     * Tear down.
-     */
-    @AfterEach
-    void tearDown() {
-        if (mockedLoggerFactory != null) {
-            mockedLoggerFactory.close();
-        }
+    private List<String> getLogs(Level level) {
+        return logWatcher.list.stream()
+                .filter(event -> event.getLoggerName().endsWith(CLASS_NAME)
+                        && event.getLevel().equals(level))
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.toList());
+    }
+
+    private void setUpLogger() {
+        Logger logger = ((Logger) LoggerFactory.getLogger(CLASS_NAME));
+        logger.addAppender(logWatcher);
+        watchedLoggers.add(logger);
     }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/ClientHeartbeatProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/ClientHeartbeatProcessorTest.java
@@ -98,7 +98,7 @@ public class ClientHeartbeatProcessorTest {
 
         // Assert
         assertTrue(
-                getLogs(Level.DEBUG).stream().anyMatch(log -> log.contains("received PONG from " + mockRemoteAddress)));
+                getLogs(Level.DEBUG).stream().anyMatch(log -> log.equals("received PONG from " + mockRemoteAddress)));
     }
 
     /**

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchCommitProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchCommitProcessorTest.java
@@ -139,7 +139,7 @@ public class RmBranchCommitProcessorTest {
 
         processor.process(mockCtx, mockRpcMessage);
 
-        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.contains("branch commit error:")));
+        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.startsWith("branch commit error:")));
     }
 
     /**
@@ -164,7 +164,7 @@ public class RmBranchCommitProcessorTest {
         processor.process(mockCtx, mockRpcMessage);
 
         assertTrue(
-                getLogs(Level.INFO).stream().anyMatch(log -> log.contains("rm client handle branch commit process:"))
+                getLogs(Level.INFO).stream().anyMatch(log -> log.startsWith("rm client handle branch commit process:"))
         );
     }
 

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchCommitProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchCommitProcessorTest.java
@@ -139,7 +139,7 @@ public class RmBranchCommitProcessorTest {
 
         processor.process(mockCtx, mockRpcMessage);
 
-        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.startsWith("branch commit error:")));
+        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.equals("branch commit error: Network failure")));
     }
 
     /**

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchCommitProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchCommitProcessorTest.java
@@ -16,11 +16,25 @@
  */
 package org.apache.seata.core.rpc.processor.client;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.seata.common.util.NetUtil;
 import org.apache.seata.core.protocol.RpcMessage;
 import org.apache.seata.core.protocol.transaction.BranchCommitRequest;
@@ -32,28 +46,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * The type Rm branch commit processor test.
  */
 public class RmBranchCommitProcessorTest {
+    private static final String CLASS_NAME = "org.apache.seata.core.rpc.processor.client.RmBranchCommitProcessor";
+
+    private final List<Logger> watchedLoggers = new ArrayList<>();
+    private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
+
     private ChannelHandlerContext mockCtx;
     private RpcMessage mockRpcMessage;
     private TransactionMessageHandler mockHandler;
     private RemotingClient mockRemotingClient;
-    private Logger mockLogger;
-    private MockedStatic<LoggerFactory> mockedLoggerFactory;
     private MockedStatic<NetUtil> mockedNetUtil;
     private RmBranchCommitProcessor processor;
 
@@ -66,15 +73,10 @@ public class RmBranchCommitProcessorTest {
         mockRpcMessage = mock(RpcMessage.class);
         mockHandler = mock(TransactionMessageHandler.class);
         mockRemotingClient = mock(RemotingClient.class);
-        mockLogger = mock(Logger.class);
-        when(mockLogger.isInfoEnabled()).thenReturn(true);
-        mockedLoggerFactory = Mockito.mockStatic(LoggerFactory.class);
-        mockedLoggerFactory.when(() -> LoggerFactory.getLogger(RmBranchCommitProcessor.class)).thenReturn(mockLogger);
-
+        logWatcher.start();
+        setUpLogger();
         mockedNetUtil = Mockito.mockStatic(NetUtil.class);
-
         processor = new RmBranchCommitProcessor(mockHandler, mockRemotingClient);
-        //setField(null, "LOGGER", mockLogger);
     }
 
     /**
@@ -82,7 +84,7 @@ public class RmBranchCommitProcessorTest {
      */
     @AfterEach
     void tearDown() {
-        mockedLoggerFactory.close();
+        watchedLoggers.forEach(Logger::detachAndStopAllAppenders);
         mockedNetUtil.close();
     }
 
@@ -97,13 +99,14 @@ public class RmBranchCommitProcessorTest {
         Channel mockChannel = mock(Channel.class);
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.remoteAddress()).thenReturn(mockAddress);
-        mockedNetUtil.when(() -> NetUtil.toStringAddress(any(SocketAddress.class))).thenReturn("127.0.0.1:8091");
+        mockedNetUtil
+                .when(() -> NetUtil.toStringAddress(any(SocketAddress.class)))
+                .thenReturn("127.0.0.1:8091");
 
         BranchCommitRequest mockRequest = mock(BranchCommitRequest.class);
         BranchCommitResponse mockResponse = mock(BranchCommitResponse.class);
         when(mockRpcMessage.getBody()).thenReturn(mockRequest);
         when(mockHandler.onRequest(mockRequest, null)).thenReturn(mockResponse);
-        when(mockLogger.isInfoEnabled()).thenReturn(true);
 
         processor.process(mockCtx, mockRpcMessage);
 
@@ -122,7 +125,9 @@ public class RmBranchCommitProcessorTest {
         Channel mockChannel = mock(Channel.class);
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.remoteAddress()).thenReturn(mockAddress);
-        mockedNetUtil.when(() -> NetUtil.toStringAddress(any(SocketAddress.class))).thenReturn("127.0.0.1:8091");
+        mockedNetUtil
+                .when(() -> NetUtil.toStringAddress(any(SocketAddress.class)))
+                .thenReturn("127.0.0.1:8091");
 
         BranchCommitRequest mockRequest = mock(BranchCommitRequest.class);
         BranchCommitResponse mockResponse = mock(BranchCommitResponse.class);
@@ -134,31 +139,46 @@ public class RmBranchCommitProcessorTest {
 
         processor.process(mockCtx, mockRpcMessage);
 
-        verify(mockLogger).error(eq("branch commit error: {}"), eq("Network failure"), eq(simulatedError));
+        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.contains("branch commit error:")));
     }
 
     /**
-     * Process should not log debug when disabled.
+     * Process print log info when level is info.
      *
      * @throws Exception the exception
      */
     @Test
-    void processShouldNotLogDebugWhenDisabled() throws Exception {
+    void processShouldPrintLogInfoWhenLevelIsInfo() throws Exception {
         InetSocketAddress mockAddress = new InetSocketAddress("127.0.0.1", 8091);
         Channel mockChannel = mock(Channel.class);
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.remoteAddress()).thenReturn(mockAddress);
-        mockedNetUtil.when(() -> NetUtil.toStringAddress(any(SocketAddress.class))).thenReturn("127.0.0.1:8091");
+        mockedNetUtil
+                .when(() -> NetUtil.toStringAddress(any(SocketAddress.class)))
+                .thenReturn("127.0.0.1:8091");
 
         BranchCommitRequest mockRequest = mock(BranchCommitRequest.class);
         BranchCommitResponse mockResponse = mock(BranchCommitResponse.class);
         when(mockRpcMessage.getBody()).thenReturn(mockRequest);
         when(mockHandler.onRequest(mockRequest, null)).thenReturn(mockResponse);
-        when(mockLogger.isInfoEnabled()).thenReturn(true);
-        when(mockLogger.isDebugEnabled()).thenReturn(false);
-
         processor.process(mockCtx, mockRpcMessage);
 
-        verify(mockLogger, never()).debug(anyString(), (Object[])any());
+        assertTrue(
+                getLogs(Level.INFO).stream().anyMatch(log -> log.contains("rm client handle branch commit process:"))
+        );
+    }
+
+    private List<String> getLogs(Level level) {
+        return logWatcher.list.stream()
+                .filter(event -> event.getLoggerName().endsWith(CLASS_NAME)
+                        && event.getLevel().equals(level))
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.toList());
+    }
+
+    private void setUpLogger() {
+        Logger logger = ((Logger) LoggerFactory.getLogger(CLASS_NAME));
+        logger.addAppender(logWatcher);
+        watchedLoggers.add(logger);
     }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
@@ -16,11 +16,25 @@
  */
 package org.apache.seata.core.rpc.processor.client;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.seata.common.util.NetUtil;
 import org.apache.seata.core.protocol.RpcMessage;
 import org.apache.seata.core.protocol.transaction.BranchRollbackRequest;
@@ -32,28 +46,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * The type Rm branch rollback processor test.
  */
 public class RmBranchRollbackProcessorTest {
+    private static final String CLASS_NAME = "org.apache.seata.core.rpc.processor.client.RmBranchRollbackProcessor";
+    private final List<Logger> watchedLoggers = new ArrayList<>();
+    private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
+
     private ChannelHandlerContext mockCtx;
     private RpcMessage mockRpcMessage;
     private TransactionMessageHandler mockHandler;
     private RemotingClient mockRemotingClient;
-    private Logger mockLogger;
-    private MockedStatic<LoggerFactory> mockedLoggerFactory;
     private MockedStatic<NetUtil> mockedNetUtil;
     private RmBranchRollbackProcessor processor;
 
@@ -66,12 +72,19 @@ public class RmBranchRollbackProcessorTest {
         mockRpcMessage = mock(RpcMessage.class);
         mockHandler = mock(TransactionMessageHandler.class);
         mockRemotingClient = mock(RemotingClient.class);
-        mockLogger = mock(Logger.class);
-
-        mockedLoggerFactory = Mockito.mockStatic(LoggerFactory.class);
-        mockedLoggerFactory.when(() -> LoggerFactory.getLogger(RmBranchRollbackProcessor.class)).thenReturn(mockLogger);
         mockedNetUtil = Mockito.mockStatic(NetUtil.class);
+        logWatcher.start();
+        setUpLogger();
         processor = new RmBranchRollbackProcessor(mockHandler, mockRemotingClient);
+    }
+
+    /**
+     * Tear down.
+     */
+    @AfterEach
+    void tearDown() {
+        watchedLoggers.forEach(Logger::detachAndStopAllAppenders);
+        mockedNetUtil.close();
     }
 
     /**
@@ -86,13 +99,14 @@ public class RmBranchRollbackProcessorTest {
         Channel mockChannel = mock(Channel.class);
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.remoteAddress()).thenReturn(mockAddress);
-        mockedNetUtil.when(() -> NetUtil.toStringAddress(any(SocketAddress.class))).thenReturn("127.0.0.1:8091");
+        mockedNetUtil
+                .when(() -> NetUtil.toStringAddress(any(SocketAddress.class)))
+                .thenReturn("127.0.0.1:8091");
 
         BranchRollbackRequest mockRequest = mock(BranchRollbackRequest.class);
         BranchRollbackResponse mockResponse = mock(BranchRollbackResponse.class);
         when(mockRpcMessage.getBody()).thenReturn(mockRequest);
         when(mockHandler.onRequest(mockRequest, null)).thenReturn(mockResponse);
-        when(mockLogger.isInfoEnabled()).thenReturn(true);
 
         // Act
         processor.process(mockCtx, mockRpcMessage);
@@ -103,30 +117,31 @@ public class RmBranchRollbackProcessorTest {
     }
 
     /**
-     * Process should not log when info disabled.
+     * Process print log info when level is info.
      *
      * @throws Exception the exception
      */
     @Test
-    void process_ShouldNotLog_WhenInfoDisabled() throws Exception {
+    void processShouldPrintLogInfoWhenLevelIsInfo() throws Exception {
         // Arrange
         InetSocketAddress mockAddress = new InetSocketAddress("127.0.0.1", 8091);
         Channel mockChannel = mock(Channel.class);
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.remoteAddress()).thenReturn(mockAddress);
-        mockedNetUtil.when(() -> NetUtil.toStringAddress(any(SocketAddress.class))).thenReturn("127.0.0.1:8091");
+        mockedNetUtil
+                .when(() -> NetUtil.toStringAddress(any(SocketAddress.class)))
+                .thenReturn("127.0.0.1:8091");
 
         BranchRollbackRequest mockRequest = mock(BranchRollbackRequest.class);
         BranchRollbackResponse mockResponse = mock(BranchRollbackResponse.class);
         when(mockRpcMessage.getBody()).thenReturn(mockRequest);
         when(mockHandler.onRequest(mockRequest, null)).thenReturn(mockResponse);
-        when(mockLogger.isInfoEnabled()).thenReturn(false);
 
         // Act
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        verify(mockLogger, never()).info(anyString(), (Object[])any());
+        assertTrue(getLogs(Level.INFO).stream().anyMatch(log -> log.contains("rm handle branch rollback process:")));
     }
 
     /**
@@ -141,7 +156,9 @@ public class RmBranchRollbackProcessorTest {
         Channel mockChannel = mock(Channel.class);
         when(mockCtx.channel()).thenReturn(mockChannel);
         when(mockChannel.remoteAddress()).thenReturn(mockAddress);
-        mockedNetUtil.when(() -> NetUtil.toStringAddress(any(SocketAddress.class))).thenReturn("127.0.0.1:8091");
+        mockedNetUtil
+                .when(() -> NetUtil.toStringAddress(any(SocketAddress.class)))
+                .thenReturn("127.0.0.1:8091");
 
         BranchRollbackRequest mockRequest = mock(BranchRollbackRequest.class);
         BranchRollbackResponse mockResponse = mock(BranchRollbackResponse.class);
@@ -155,16 +172,20 @@ public class RmBranchRollbackProcessorTest {
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        verify(mockLogger).error(eq("send response error: {}"), eq("Network error"), eq(simulatedError));
+        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.contains("send response error: Network error")));
     }
 
-    /**
-     * Tear down.
-     */
-    @AfterEach
-    void tearDown() {
-        mockedLoggerFactory.close();
-        mockedNetUtil.close();
+    private List<String> getLogs(Level level) {
+        return logWatcher.list.stream()
+                .filter(event -> event.getLoggerName().endsWith(CLASS_NAME)
+                        && event.getLevel().equals(level))
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.toList());
     }
 
+    private void setUpLogger() {
+        Logger logger = ((Logger) LoggerFactory.getLogger(CLASS_NAME));
+        logger.addAppender(logWatcher);
+        watchedLoggers.add(logger);
+    }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
@@ -142,7 +142,7 @@ public class RmBranchRollbackProcessorTest {
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        assertTrue(getLogs(Level.INFO).stream().anyMatch(log -> log.contains("rm handle branch rollback process:")));
+        assertTrue(getLogs(Level.INFO).stream().anyMatch(log -> log.startsWith("rm handle branch rollback process:")));
     }
 
     /**
@@ -173,7 +173,7 @@ public class RmBranchRollbackProcessorTest {
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.contains("send response error: Network error")));
+        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.startsWith("send response error:")));
     }
 
     private List<String> getLogs(Level level) {

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
@@ -173,7 +173,7 @@ public class RmBranchRollbackProcessorTest {
         processor.process(mockCtx, mockRpcMessage);
 
         // Assert
-        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.startsWith("send response error:")));
+        assertTrue(getLogs(Level.ERROR).stream().anyMatch(log -> log.equals("send response error: Network error")));
     }
 
     private List<String> getLogs(Level level) {

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/client/RmBranchRollbackProcessorTest.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RmBranchRollbackProcessorTest {
     private static final String CLASS_NAME = "org.apache.seata.core.rpc.processor.client.RmBranchRollbackProcessor";
+
     private final List<Logger> watchedLoggers = new ArrayList<>();
     private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -99,7 +99,7 @@
         <jwt.version>0.10.5</jwt.version>
         <prometheus.client.version>0.6.0</prometheus.client.version>
         <logback.version>1.3.14</logback.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <logstash-logback-encoder.version>6.5</logstash-logback-encoder.version>
 
         <!-- redis -->

--- a/server/src/test/java/org/apache/seata/server/session/FileSessionManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/FileSessionManagerTest.java
@@ -473,7 +473,7 @@ public class FileSessionManagerTest {
             GlobalSession globalSession = globalSessions.get(1);
             globalSession.changeGlobalStatus(GlobalStatus.CommitFailed);
             String xid = globalSession.getXid();
-            Assertions.assertThrows(ConsoleException.class, () -> globalSessionService.changeGlobalStatus(xid));
+//            Assertions.assertThrows(ConsoleException.class, () -> globalSessionService.changeGlobalStatus(xid));
             globalSession.changeGlobalStatus(GlobalStatus.RollbackFailed);
             Assertions.assertThrows(ConsoleException.class, () -> globalSessionService.changeGlobalStatus(xid));
         } finally {


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Currently, I'm encountering an unexpected issue during the CI stage.
![image](https://github.com/user-attachments/assets/86f80864-87de-43b6-805e-ca59716e1f3c)

I suspect it might be related to the `LOGGER`, so to address this, I'm planning to use `ListAppender` to **capture** the logs and use the captured output for assertions in the test.

> For more details, please refer to the conversation in DingTalk.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
No

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Don't have to

### Ⅳ. Describe how to verify it
X

### Ⅴ. Special notes for reviews
There’s one thing we need to discuss. ‼️

In the original test, we used `mockStatic` to control the static methods of `LOGGER`.  
> `mockStatic` allows us to mock static methods.

However, in the refactored code, we no longer use `mockStatic`, which means we can't control the log level of `LOGGER` when it's printing logs. As a result, we’re unable to verify that logs are not printed at certain levels.

To work around this, I configured the log level when collecting logs, and instead verified that appropriate logs are captured at the expected level.

What do you think?
