### PR TITLE
bugfix: Add scheduled tasks to clean up futures

### DIFF
--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -16,6 +16,16 @@
  */
 package org.apache.seata.core.rpc.netty;
 
+import static org.apache.seata.common.exception.FrameworkErrorCode.NoAvailableService;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.concurrent.EventExecutorGroup;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -29,14 +39,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
-import io.netty.handler.timeout.IdleState;
-import io.netty.handler.timeout.IdleStateEvent;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.seata.common.exception.FrameworkErrorCode;
 import org.apache.seata.common.exception.FrameworkException;
 import org.apache.seata.common.thread.NamedThreadFactory;
@@ -62,8 +64,6 @@ import org.apache.seata.discovery.loadbalance.LoadBalanceFactory;
 import org.apache.seata.discovery.registry.RegistryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.seata.common.exception.FrameworkErrorCode.NoAvailableService;
 
 /**
  * The netty remoting client.
@@ -96,13 +96,18 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
      * Send via asynchronous thread {@link AbstractNettyRemotingClient.MergedSendRunnable}
      * {@link AbstractNettyRemotingClient#isEnableClientBatchSendRequest()}
      */
-    protected final ConcurrentHashMap<String/*serverAddress*/, BlockingQueue<RpcMessage>> basketMap = new ConcurrentHashMap<>();
+    protected final ConcurrentHashMap<String /*serverAddress*/, BlockingQueue<RpcMessage>> basketMap =
+            new ConcurrentHashMap<>();
+
     private final NettyClientBootstrap clientBootstrap;
     private final NettyClientChannelManager clientChannelManager;
     private final NettyPoolKey.TransactionRole transactionRole;
     private ExecutorService mergeSendExecutorService;
     private TransactionMessageHandler transactionMessageHandler;
     protected volatile boolean enableClientBatchSendRequest;
+
+    private volatile long lastCleanTime = System.currentTimeMillis();
+    private static final long CLEAN_INTERVAL_MILLS = 30 * 1000L;
 
     @Override
     public void init() {
@@ -132,11 +137,14 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
         clientBootstrap = new NettyClientBootstrap(nettyClientConfig, eventExecutorGroup, transactionRole);
         clientBootstrap.setChannelHandlers(new ClientHandler());
         clientChannelManager = new NettyClientChannelManager(
-            new NettyPoolableFactory(this, clientBootstrap), getPoolKeyFunction(), nettyClientConfig);
+                new NettyPoolableFactory(this, clientBootstrap), getPoolKeyFunction(), nettyClientConfig);
     }
 
     @Override
     public Object sendSyncRequest(Object msg) throws TimeoutException {
+        // Clean timeout message to prevent memory leak
+        cleanTimeoutMessage();
+
         String serverAddress = loadBalance(getTransactionServiceGroup(), msg);
         long timeoutMillis = this.getRpcRequestTimeout();
         RpcMessage rpcMessage = buildRequestMessage(msg, ProtocolConstants.MSGTYPE_RESQUEST_SYNC);
@@ -183,7 +191,6 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
             Channel channel = clientChannelManager.acquireChannel(serverAddress);
             return super.sendSync(channel, rpcMessage, timeoutMillis);
         }
-
     }
 
     @Override
@@ -203,14 +210,14 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
             throw new FrameworkException(new Throwable("throw"), "frameworkException", FrameworkErrorCode.ChannelIsNotWritable);
         }
         RpcMessage rpcMessage = buildRequestMessage(msg, msg instanceof HeartbeatMessage
-            ? ProtocolConstants.MSGTYPE_HEARTBEAT_REQUEST
-            : ProtocolConstants.MSGTYPE_RESQUEST_ONEWAY);
+                        ? ProtocolConstants.MSGTYPE_HEARTBEAT_REQUEST
+                        : ProtocolConstants.MSGTYPE_RESQUEST_ONEWAY);
         Object body = rpcMessage.getBody();
         if (body instanceof MergeMessage) {
             Integer parentId = rpcMessage.getId();
-            mergeMsgMap.put(parentId, (MergeMessage)rpcMessage.getBody());
+            mergeMsgMap.put(parentId, (MergeMessage) rpcMessage.getBody());
             if (body instanceof MergedWarpMessage) {
-                for (Integer msgId : ((MergedWarpMessage)rpcMessage.getBody()).msgIds) {
+                for (Integer msgId : ((MergedWarpMessage) rpcMessage.getBody()).msgIds) {
                     childToParentMap.put(msgId, parentId);
                 }
             }
@@ -242,6 +249,12 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
         if (mergeSendExecutorService != null) {
             mergeSendExecutorService.shutdown();
         }
+
+        futures.clear();
+        mergeMsgMap.clear();
+        childToParentMap.clear();
+        basketMap.clear();
+
         super.destroy();
     }
 
@@ -262,7 +275,7 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
         try {
             @SuppressWarnings("unchecked")
             List<InetSocketAddress> inetSocketAddressList =
-                RegistryFactory.getInstance().aliveLookup(transactionServiceGroup);
+                    RegistryFactory.getInstance().aliveLookup(transactionServiceGroup);
             address = this.doSelect(inetSocketAddressList, msg);
         } catch (Exception ex) {
             LOGGER.error("Select the address failed: {}", ex.getMessage());
@@ -337,6 +350,38 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
     protected abstract long getRpcRequestTimeout();
 
     /**
+     * This method removes timeout message from futures, mergeMsgMap and childToParentMap
+     */
+    protected void cleanTimeoutMessage() {
+        long current = System.currentTimeMillis();
+        if (current - lastCleanTime < CLEAN_INTERVAL_MILLS) {
+            return;
+        }
+
+        if (futures.isEmpty()) {
+            return;
+        }
+
+        futures.entrySet().removeIf(entry -> {
+            Integer id = entry.getKey();
+            MessageFuture future = entry.getValue();
+            if (future.isTimeout()) {
+                Integer parentId = childToParentMap.remove(id);
+                if (parentId != null) {
+                    mergeMsgMap.remove(parentId);
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("timeout message removed: {}", id);
+                }
+                return true;
+            }
+            return false;
+        });
+
+        lastCleanTime = current;
+    }
+
+    /**
      * The type Merged send runnable.
      */
     private class MergedSendRunnable implements Runnable {
@@ -351,6 +396,10 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
                     }
                 }
                 isSending = true;
+
+                // Clean timeout message
+                cleanTimeoutMessage();
+
                 basketMap.forEach((address, basket) -> {
                     if (basket.isEmpty()) {
                         return;
@@ -385,7 +434,7 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
                             }
                             if (messageFuture != null) {
                                 messageFuture.setResultMessage(
-                                    new RuntimeException(String.format("%s is unreachable", address), e));
+                                        new RuntimeException(String.format("%s is unreachable", address), e));
                             }
                         }
                         LOGGER.error("client merge call failed: {}", e.getMessage(), e);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -249,12 +249,6 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
         if (mergeSendExecutorService != null) {
             mergeSendExecutorService.shutdown();
         }
-
-        futures.clear();
-        mergeMsgMap.clear();
-        childToParentMap.clear();
-        basketMap.clear();
-
         super.destroy();
     }
 


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Use scheduled tasks to detect whether futures have timeout information before sending messages. If there is, clear it to avoid memory leaks

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #5283 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

