### PR TITLE
optimize: Add some checks to RegistryFactory

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -35,6 +35,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7282](https://github.com/apache/incubator-seata/pull/7282)] optimize unexpected NullPointerException in lookup method in FileRegistryServiceImpl class
 - [[#7310](https://github.com/seata/seata/pull/7310)] Optimize minor issues in the naming-server
 - [[#7329](https://github.com/apache/incubator-seata/pull/7329)] upgrade tomcat to 9.0.100
+- [[#7345](https://github.com/apache/incubator-seata/pull/7345)] add empty check and duplicate type check to RegistryFactory
 
 
 ### security:
@@ -62,6 +63,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7294](https://github.com/apache/incubator-seata/pull/7294)] improved test testGetInsertParamsValue in SqlServerInsertRecognizerTest by splitting and parameterizing
 - [[#7295](https://github.com/apache/incubator-seata/pull/7295)] updated 3 tests in StringUtilsTest to use parameterized unit testing
 - [[#7205](https://github.com/apache/incubator-seata/issues/7205)] add UT for namingserver module
+- 
 ### refactor:
 
 - [[#7315](https://github.com/apache/incubator-seata/pull/7315)] Refactor log testing to use ListAppender for more accurate and efficient log capture

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -34,7 +34,7 @@
 - [[#7282](https://github.com/apache/incubator-seata/pull/7282)] 优化FileRegistryServiceImpl类lookup的NullPointerException问题
 - [[#7310](https://github.com/seata/seata/pull/7310)] 优化naming-server中的一些小问题
 - [[#7329](https://github.com/apache/incubator-seata/pull/7329)] 将 tomcat 升级到 9.0.100
-
+- [[#7345](https://github.com/apache/incubator-seata/pull/7345)] 为 RegistryFactory 增加空校验与重复类型检查
 
 ### security:
 

--- a/discovery/seata-discovery-core/pom.xml
+++ b/discovery/seata-discovery-core/pom.xml
@@ -35,5 +35,11 @@
             <artifactId>seata-config-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
@@ -49,7 +49,6 @@ public class MultiRegistryFactory {
 
     private static List<RegistryService> buildRegistryServices() {
         List<RegistryService> registryServices = new ArrayList<>();
-        Set<String> processedRegistryTypes = new HashSet<>();
         String registryTypeNamesStr = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(
                 ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
 
@@ -70,15 +69,14 @@ public class MultiRegistryFactory {
                 throw new NotSupportYetException("not support registry type: " + registryTypeName);
             }
 
-            if (processedRegistryTypes.contains(registryType.name())) {
+            RegistryService registryService = EnhancedServiceLoader
+                    .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
+
+            if(registryServices.contains(registryService)) {
                 LOGGER.warn("The duplicate registration center type '{}' was found in the configuration and has been skipped.", registryType.name());
                 continue;
             }
-
-            RegistryService registryService = EnhancedServiceLoader
-                    .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
             registryServices.add(registryService);
-            processedRegistryTypes.add(registryType.name());
         }
         return registryServices;
     }

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
@@ -17,8 +17,10 @@
 package org.apache.seata.discovery.registry;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
@@ -48,6 +50,7 @@ public class MultiRegistryFactory {
 
     private static List<RegistryService> buildRegistryServices() {
         List<RegistryService> registryServices = new ArrayList<>();
+        Set<String> processedRegistryTypes = new HashSet<>();
         String registryTypeNamesStr =
             ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(ConfigurationKeys.FILE_ROOT_REGISTRY
                 + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
@@ -65,9 +68,16 @@ public class MultiRegistryFactory {
             } catch (Exception exx) {
                 throw new NotSupportYetException("not support registry type: " + registryTypeName);
             }
+
+            if(processedRegistryTypes.contains(registryType.name())) {
+                LOGGER.warn("The duplicate registration center type '{}' was found in the configuration and has been skipped.", registryType.name());
+                continue;
+            }
+
             RegistryService registryService = EnhancedServiceLoader
                 .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
             registryServices.add(registryService);
+            processedRegistryTypes.add(registryType.name());
         }
         return registryServices;
     }

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The type multiple Registry factory.
- *
  */
 public class MultiRegistryFactory {
 
@@ -51,16 +50,18 @@ public class MultiRegistryFactory {
     private static List<RegistryService> buildRegistryServices() {
         List<RegistryService> registryServices = new ArrayList<>();
         Set<String> processedRegistryTypes = new HashSet<>();
-        String registryTypeNamesStr =
-            ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(ConfigurationKeys.FILE_ROOT_REGISTRY
-                + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
+        String registryTypeNamesStr = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(
+                ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
+
         if (StringUtils.isBlank(registryTypeNamesStr)) {
             registryTypeNamesStr = RegistryType.File.name();
         }
         String[] registryTypeNames = registryTypeNamesStr.split(Constants.REGISTRY_TYPE_SPLIT_CHAR);
+
         if (registryTypeNames.length > 1) {
             LOGGER.info("use multi registry center type: {}", registryTypeNamesStr);
         }
+
         for (String registryTypeName : registryTypeNames) {
             RegistryType registryType;
             try {
@@ -69,13 +70,13 @@ public class MultiRegistryFactory {
                 throw new NotSupportYetException("not support registry type: " + registryTypeName);
             }
 
-            if(processedRegistryTypes.contains(registryType.name())) {
+            if (processedRegistryTypes.contains(registryType.name())) {
                 LOGGER.warn("The duplicate registration center type '{}' was found in the configuration and has been skipped.", registryType.name());
                 continue;
             }
 
             RegistryService registryService = EnhancedServiceLoader
-                .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
+                    .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
             registryServices.add(registryService);
             processedRegistryTypes.add(registryType.name());
         }

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
@@ -25,7 +25,6 @@ import java.util.TreeSet;
 
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
-import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.config.ConfigurationFactory;
@@ -50,28 +49,24 @@ public class MultiRegistryFactory {
 
     private static List<RegistryService> buildRegistryServices() {
         List<RegistryService> registryServices = new ArrayList<>();
+
         String registryTypeNamesStr = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(
                 ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
 
+        // If blank, use default configuration
         if (StringUtils.isBlank(registryTypeNamesStr)) {
             registryTypeNamesStr = RegistryType.File.name();
         }
 
-        Set<String> registryTypeNames = new TreeSet<>(
-                Arrays.asList(registryTypeNamesStr.split(Constants.REGISTRY_TYPE_SPLIT_CHAR))
-        );
+        Set<String> registryTypeNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        registryTypeNames.addAll(Arrays.asList(registryTypeNamesStr.split(Constants.REGISTRY_TYPE_SPLIT_CHAR)));
 
         if (registryTypeNames.size() > 1) {
             LOGGER.info("use multi registry center type: {}", registryTypeNames);
         }
 
         for (String registryTypeName : registryTypeNames) {
-            RegistryType registryType;
-            try {
-                registryType = RegistryType.getType(registryTypeName);
-            } catch (Exception exx) {
-                throw new NotSupportYetException("not support registry type: " + registryTypeName);
-            }
+            RegistryType registryType = RegistryType.getType(registryTypeName);
 
             RegistryService registryService = EnhancedServiceLoader
                     .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
@@ -17,8 +17,11 @@
 package org.apache.seata.discovery.registry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
@@ -53,10 +56,13 @@ public class MultiRegistryFactory {
         if (StringUtils.isBlank(registryTypeNamesStr)) {
             registryTypeNamesStr = RegistryType.File.name();
         }
-        String[] registryTypeNames = registryTypeNamesStr.split(Constants.REGISTRY_TYPE_SPLIT_CHAR);
 
-        if (registryTypeNames.length > 1) {
-            LOGGER.info("use multi registry center type: {}", registryTypeNamesStr);
+        Set<String> registryTypeNames = new TreeSet<>(
+                Arrays.asList(registryTypeNamesStr.split(Constants.REGISTRY_TYPE_SPLIT_CHAR))
+        );
+
+        if (registryTypeNames.size() > 1) {
+            LOGGER.info("use multi registry center type: {}", registryTypeNames);
         }
 
         for (String registryTypeName : registryTypeNames) {
@@ -69,11 +75,6 @@ public class MultiRegistryFactory {
 
             RegistryService registryService = EnhancedServiceLoader
                     .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
-
-            if (registryServices.contains(registryService)) {
-                LOGGER.warn("The duplicate registration center type '{}' was found in the configuration and has been skipped.", registryType.name());
-                continue;
-            }
             registryServices.add(registryService);
         }
         return registryServices;

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/MultiRegistryFactory.java
@@ -17,10 +17,8 @@
 package org.apache.seata.discovery.registry;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
@@ -72,7 +70,7 @@ public class MultiRegistryFactory {
             RegistryService registryService = EnhancedServiceLoader
                     .load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
 
-            if(registryServices.contains(registryService)) {
+            if (registryServices.contains(registryService)) {
                 LOGGER.warn("The duplicate registration center type '{}' was found in the configuration and has been skipped.", registryType.name());
                 continue;
             }

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The type Registry factory.
- *
  */
 public class RegistryFactory {
 
@@ -46,12 +45,12 @@ public class RegistryFactory {
     private static RegistryService buildRegistryService() {
         RegistryType registryType;
         String registryTypeName = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(
-            ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
-                + ConfigurationKeys.FILE_ROOT_TYPE);
+                ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
 
         if (StringUtils.isBlank(registryTypeName)) {
             registryTypeName = RegistryType.File.name();
         }
+
         LOGGER.info("use registry center type: {}", registryTypeName);
         try {
             registryType = RegistryType.getType(registryTypeName);

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.config.ConfigurationKeys;
 import org.slf4j.Logger;
@@ -47,6 +48,10 @@ public class RegistryFactory {
         String registryTypeName = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(
             ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
                 + ConfigurationKeys.FILE_ROOT_TYPE);
+
+        if (StringUtils.isBlank(registryTypeName)) {
+            registryTypeName = RegistryType.File.name();
+        }
         LOGGER.info("use registry center type: {}", registryTypeName);
         try {
             registryType = RegistryType.getType(registryTypeName);

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
@@ -18,7 +18,6 @@ package org.apache.seata.discovery.registry;
 
 import java.util.Objects;
 
-import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.config.ConfigurationFactory;

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryFactory.java
@@ -43,20 +43,17 @@ public class RegistryFactory {
     }
 
     private static RegistryService buildRegistryService() {
-        RegistryType registryType;
         String registryTypeName = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(
                 ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE);
 
+        // If blank, use default configuration
         if (StringUtils.isBlank(registryTypeName)) {
             registryTypeName = RegistryType.File.name();
         }
 
         LOGGER.info("use registry center type: {}", registryTypeName);
-        try {
-            registryType = RegistryType.getType(registryTypeName);
-        } catch (Exception exx) {
-            throw new NotSupportYetException("not support registry type: " + registryTypeName);
-        }
+
+        RegistryType registryType = RegistryType.getType(registryTypeName);
         return EnhancedServiceLoader.load(RegistryProvider.class, Objects.requireNonNull(registryType).name()).provide();
 
     }

--- a/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryType.java
+++ b/discovery/seata-discovery-core/src/main/java/org/apache/seata/discovery/registry/RegistryType.java
@@ -16,6 +16,8 @@
  */
 package org.apache.seata.discovery.registry;
 
+import org.apache.seata.common.exception.NotSupportYetException;
+
 /**
  * The enum Registry type.
  *
@@ -78,6 +80,6 @@ public enum RegistryType {
                 return registryType;
             }
         }
-        throw new IllegalArgumentException("not support registry type: " + name);
+        throw new NotSupportYetException("not support registry type: " + name);
     }
 }

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MockNacosRegistryProvider.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MockNacosRegistryProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.discovery.registry;
+
+import org.apache.seata.common.loader.LoadLevel;
+
+/**
+ * the mock nacos RegistryProvider
+ */
+@LoadLevel(name = "Nacos", order = 1)
+public class MockNacosRegistryProvider implements RegistryProvider {
+    @Override
+    public RegistryService provide() {
+        return new MockNacosRegistryService();
+    }
+} 

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MockNacosRegistryService.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MockNacosRegistryService.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.discovery.registry;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * the mock nacos RegistryService
+ */
+public class MockNacosRegistryService implements RegistryService<Object> {
+
+    @Override
+    public void register(InetSocketAddress address) throws Exception {
+
+    }
+
+    @Override
+    public void unregister(InetSocketAddress address) throws Exception {
+
+    }
+
+    @Override
+    public void subscribe(String cluster, Object listener) throws Exception {
+
+    }
+
+    @Override
+    public void unsubscribe(String cluster, Object listener) throws Exception {
+
+    }
+
+    @Override
+    public List<InetSocketAddress> lookup(String key) throws Exception {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+} 

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
@@ -31,10 +31,14 @@ import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The type Multi registry factory test.
@@ -71,46 +75,45 @@ public class MultiRegistryFactoryTest {
         System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name());
 
         List<RegistryService> instances = MultiRegistryFactory.getInstances();
-        Assertions.assertNotNull(instances);
+        assertFalse(instances.isEmpty());
 
         for (RegistryService service : instances) {
-            Assertions.assertEquals(FileRegistryServiceImpl.class, service.getClass());
+            assertEquals(FileRegistryServiceImpl.class, service.getClass());
         }
     }
 
-    /**
-     * Test buildRegistryServices with multiple tests of the same registry type.
-     */
     @Test
-    public void testGetInstancesWithMultiRegistryTypes() throws Throwable {
-        // Set up two registry centers with capital and small letter
-        String twoRegistryTypes = "File,file";
-        System.setProperty(REGISTRY_TYPE_KEY, twoRegistryTypes);
+    public void testGetInstancesWithSameRegistryTypes() throws Throwable {
+        String sameRegistryType = "File,file";
+        System.setProperty(REGISTRY_TYPE_KEY, sameRegistryType);
         List<RegistryService> instances = invokeBuildRegistryServices();
 
-        Assertions.assertEquals(1, instances.size());
-        Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
-        Assertions.assertTrue(getLogs(Level.INFO).isEmpty());
+        assertEquals(1, instances.size());
+        assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
+        assertTrue(getLogs(Level.INFO).isEmpty());
+    }
 
-        // Set up three registry centers with multiple types
-        String threeRegistryTypes = twoRegistryTypes + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.Nacos.name();
-        System.setProperty(REGISTRY_TYPE_KEY, threeRegistryTypes);
-        List<RegistryService> instances1 = invokeBuildRegistryServices();
+    @Test
+    public void testGetInstancesWithDifferentRegistryTypes() throws Throwable {
+        String differentRegistryType = "File,file" + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.Nacos.name();
+        System.setProperty(REGISTRY_TYPE_KEY, differentRegistryType);
+        List<RegistryService> instances = invokeBuildRegistryServices();
 
-        Assertions.assertEquals(2, instances1.size());
-        Assertions.assertEquals(MockNacosRegistryService.class, instances1.get(1).getClass());
-        Assertions.assertEquals("use multi registry center type: [File, Nacos]", getLogs(Level.INFO).get(0));
+        assertEquals(2, instances.size());
+        assertEquals(MockNacosRegistryService.class, instances.get(1).getClass());
+        assertEquals("use multi registry center type: [File, Nacos]", getLogs(Level.INFO).get(0));
     }
 
     /**
      * Test buildRegistryServices with blank registry type.
+     * when the registry type is blank, the default registry type is File
      */
     @Test
     public void testGetInstancesWithBlankRegistryType() throws Throwable {
         System.setProperty(REGISTRY_TYPE_KEY, "");
 
         List<RegistryService> instances = invokeBuildRegistryServices();
-        Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
+        assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
     }
 
     /**
@@ -118,9 +121,12 @@ public class MultiRegistryFactoryTest {
      */
     @Test
     public void testGetInstancesWithInvalidRegistryType() {
-        System.setProperty(REGISTRY_TYPE_KEY, "InvalidRegistryType");
+        String invalidRegistryType = "InvalidRegistryType";
+        System.setProperty(REGISTRY_TYPE_KEY, invalidRegistryType);
 
-        Assertions.assertThrows(NotSupportYetException.class, MultiRegistryFactoryTest::invokeBuildRegistryServices);
+        assertThatThrownBy(MultiRegistryFactoryTest::invokeBuildRegistryServices)
+                .isExactlyInstanceOf(NotSupportYetException.class)
+                .hasMessage("not support registry type: " + invalidRegistryType);
     }
 
     /**

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
@@ -18,14 +18,23 @@ package org.apache.seata.discovery.registry;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * The type Multi registry factory test.
@@ -35,9 +44,23 @@ public class MultiRegistryFactoryTest {
     private static final String REGISTRY_TYPE_KEY =
             ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE;
 
+    private final List<Logger> watchedLoggers = new ArrayList<>();
+    private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
+
+    @BeforeEach
+    void setUp() {
+        logWatcher.start();
+
+        Logger logger = ((Logger) LoggerFactory.getLogger(MultiRegistryFactory.class.getName()));
+        logger.addAppender(logWatcher);
+
+        watchedLoggers.add(logger);
+    }
+
     @AfterEach
     public void tearDown() {
         System.clearProperty(REGISTRY_TYPE_KEY);
+        watchedLoggers.forEach(Logger::detachAndStopAllAppenders);
     }
 
     /**
@@ -52,7 +75,7 @@ public class MultiRegistryFactoryTest {
         Assertions.assertNotNull(instances);
 
         for (RegistryService service : instances) {
-            Assertions.assertNotNull(service);
+            Assertions.assertEquals(FileRegistryServiceImpl.class, service.getClass());
         }
     }
 
@@ -62,11 +85,16 @@ public class MultiRegistryFactoryTest {
     @Test
     public void testGetInstancesWithMultiRegistryTypes() throws Throwable {
         // Set up multiple registration center configurations
-        System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name() + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name());
+        String registryTypes = RegistryType.File.name() + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();
+        System.setProperty(REGISTRY_TYPE_KEY, registryTypes);
 
         List<RegistryService> instances = invokeBuildRegistryServices();
-        Assertions.assertNotNull(instances);
         Assertions.assertEquals(1, instances.size());
+        Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
+
+        Assertions.assertEquals("use multi registry center type: " + registryTypes, getLogs(Level.INFO).get(0));
+        Assertions.assertEquals("The duplicate registration center type '" + RegistryType.File.name() +
+                "' was found in the configuration and has been skipped.", getLogs(Level.WARN).get(0));
     }
 
     /**
@@ -77,7 +105,7 @@ public class MultiRegistryFactoryTest {
         System.setProperty(REGISTRY_TYPE_KEY, "");
 
         List<RegistryService> instances = invokeBuildRegistryServices();
-        Assertions.assertNotNull(instances);
+        Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
     }
 
     /**
@@ -102,5 +130,13 @@ public class MultiRegistryFactoryTest {
         } catch (InvocationTargetException e) {
             throw e.getTargetException();
         }
+    }
+
+    private List<String> getLogs(Level level) {
+        return logWatcher.list.stream()
+                .filter(event -> event.getLoggerName().endsWith(MultiRegistryFactory.class.getName())
+                        && event.getLevel().equals(level))
+                .map(ILoggingEvent::getFormattedMessage)
+                .collect(Collectors.toList());
     }
 }

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
@@ -92,9 +92,7 @@ public class MultiRegistryFactoryTest {
         List<RegistryService> instances = invokeBuildRegistryServices();
         Assertions.assertEquals(1, instances.size());
         Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
-        Assertions.assertEquals("use multi registry center type: " + twoRegistryTypes, getLogs(Level.INFO).get(0));
-        Assertions.assertEquals("The duplicate registration center type '" + RegistryType.File.name() +
-                "' was found in the configuration and has been skipped.", getLogs(Level.WARN).get(0));
+        Assertions.assertTrue(getLogs(Level.INFO).isEmpty());
 
         // Set up three identical registration center configurations
         String threeRegistryTypes = twoRegistryTypes + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
@@ -16,16 +16,17 @@
  */
 package org.apache.seata.discovery.registry;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.Constants;
 import org.apache.seata.common.exception.NotSupportYetException;
@@ -34,7 +35,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * The type Multi registry factory test.
@@ -68,7 +68,6 @@ public class MultiRegistryFactoryTest {
      */
     @Test
     public void testGetInstancesWithDefaultConfig() {
-        // Set "registry.type = file" as default config
         System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name());
 
         List<RegistryService> instances = MultiRegistryFactory.getInstances();
@@ -84,21 +83,23 @@ public class MultiRegistryFactoryTest {
      */
     @Test
     public void testGetInstancesWithMultiRegistryTypes() throws Throwable {
-        // Set up two identical registration center configurations
-        String twoRegistryTypes = RegistryType.File.name() + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name()
-                + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();
+        // Set up two registry centers with capital and small letter
+        String twoRegistryTypes = "File,file";
         System.setProperty(REGISTRY_TYPE_KEY, twoRegistryTypes);
-
         List<RegistryService> instances = invokeBuildRegistryServices();
+
         Assertions.assertEquals(1, instances.size());
         Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
         Assertions.assertTrue(getLogs(Level.INFO).isEmpty());
 
-        // Set up three identical registration center configurations
-        String threeRegistryTypes = twoRegistryTypes + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();
+        // Set up three registry centers with multiple types
+        String threeRegistryTypes = twoRegistryTypes + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.Nacos.name();
         System.setProperty(REGISTRY_TYPE_KEY, threeRegistryTypes);
         List<RegistryService> instances1 = invokeBuildRegistryServices();
-        Assertions.assertEquals(1, instances1.size());
+
+        Assertions.assertEquals(2, instances1.size());
+        Assertions.assertEquals(MockNacosRegistryService.class, instances1.get(1).getClass());
+        Assertions.assertEquals("use multi registry center type: [File, Nacos]", getLogs(Level.INFO).get(0));
     }
 
     /**

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
@@ -84,17 +84,23 @@ public class MultiRegistryFactoryTest {
      */
     @Test
     public void testGetInstancesWithMultiRegistryTypes() throws Throwable {
-        // Set up multiple registration center configurations
-        String registryTypes = RegistryType.File.name() + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();
-        System.setProperty(REGISTRY_TYPE_KEY, registryTypes);
+        // Set up two identical registration center configurations
+        String twoRegistryTypes = RegistryType.File.name() + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name()
+                + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();
+        System.setProperty(REGISTRY_TYPE_KEY, twoRegistryTypes);
 
         List<RegistryService> instances = invokeBuildRegistryServices();
         Assertions.assertEquals(1, instances.size());
         Assertions.assertEquals(FileRegistryServiceImpl.class, instances.get(0).getClass());
-
-        Assertions.assertEquals("use multi registry center type: " + registryTypes, getLogs(Level.INFO).get(0));
+        Assertions.assertEquals("use multi registry center type: " + twoRegistryTypes, getLogs(Level.INFO).get(0));
         Assertions.assertEquals("The duplicate registration center type '" + RegistryType.File.name() +
                 "' was found in the configuration and has been skipped.", getLogs(Level.WARN).get(0));
+
+        // Set up three identical registration center configurations
+        String threeRegistryTypes = twoRegistryTypes + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name();
+        System.setProperty(REGISTRY_TYPE_KEY, threeRegistryTypes);
+        List<RegistryService> instances1 = invokeBuildRegistryServices();
+        Assertions.assertEquals(1, instances1.size());
     }
 
     /**

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/MultiRegistryFactoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.discovery.registry;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.exception.NotSupportYetException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The type Multi registry factory test.
+ */
+public class MultiRegistryFactoryTest {
+
+    private static final String REGISTRY_TYPE_KEY =
+            ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE;
+
+    @AfterEach
+    public void tearDown() {
+        System.clearProperty(REGISTRY_TYPE_KEY);
+    }
+
+    /**
+     * Test getInstances with default config.
+     */
+    @Test
+    public void testGetInstancesWithDefaultConfig() {
+        // Set "registry.type = file" as default config
+        System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name());
+
+        List<RegistryService> instances = MultiRegistryFactory.getInstances();
+        Assertions.assertNotNull(instances);
+
+        for (RegistryService service : instances) {
+            Assertions.assertNotNull(service);
+        }
+    }
+
+    /**
+     * Test buildRegistryServices with multiple tests of the same registry type.
+     */
+    @Test
+    public void testGetInstancesWithMultiRegistryTypes() throws Throwable {
+        // Set up multiple registration center configurations
+        System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name() + Constants.REGISTRY_TYPE_SPLIT_CHAR + RegistryType.File.name());
+
+        List<RegistryService> instances = invokeBuildRegistryServices();
+        Assertions.assertNotNull(instances);
+        Assertions.assertEquals(1, instances.size());
+    }
+
+    /**
+     * Test buildRegistryServices with blank registry type.
+     */
+    @Test
+    public void testGetInstancesWithBlankRegistryType() throws Throwable {
+        System.setProperty(REGISTRY_TYPE_KEY, "");
+
+        List<RegistryService> instances = invokeBuildRegistryServices();
+        Assertions.assertNotNull(instances);
+    }
+
+    /**
+     * Test buildRegistryServices with invalid registry type.
+     */
+    @Test
+    public void testGetInstancesWithInvalidRegistryType() {
+        System.setProperty(REGISTRY_TYPE_KEY, "InvalidRegistryType");
+
+        Assertions.assertThrows(NotSupportYetException.class, MultiRegistryFactoryTest::invokeBuildRegistryServices);
+    }
+
+    /**
+     * Use reflection to call the buildRegistryServices method
+     */
+    private static List<RegistryService> invokeBuildRegistryServices() throws Throwable {
+        Method buildMethod = MultiRegistryFactory.class.getDeclaredMethod("buildRegistryServices");
+        buildMethod.setAccessible(true);
+
+        try {
+            return (List<RegistryService>) buildMethod.invoke(null);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+}

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/RegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/RegistryFactoryTest.java
@@ -46,7 +46,7 @@ public class RegistryFactoryTest {
         System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name());
 
         RegistryService instance = RegistryFactory.getInstance();
-        Assertions.assertNotNull(instance);
+        Assertions.assertEquals(FileRegistryServiceImpl.class, instance.getClass());
     }
 
     /**
@@ -67,11 +67,11 @@ public class RegistryFactoryTest {
         System.setProperty(REGISTRY_TYPE_KEY, "");
 
         RegistryService instance = invokeBuildRegistryService();
-        Assertions.assertEquals(instance.getClass(), FileRegistryServiceImpl.class);
+        Assertions.assertEquals(FileRegistryServiceImpl.class, instance.getClass());
     }
 
     /**
-     * Use reflection to call the buildRegistryServices method
+     * Use reflection to call the buildRegistryService method
      */
     private static RegistryService invokeBuildRegistryService() throws Throwable {
         Method buildMethod = RegistryFactory.class.getDeclaredMethod("buildRegistryService");

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/RegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/RegistryFactoryTest.java
@@ -22,8 +22,10 @@ import java.lang.reflect.Method;
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The type Registry factory test.
@@ -46,7 +48,7 @@ public class RegistryFactoryTest {
         System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name());
 
         RegistryService instance = RegistryFactory.getInstance();
-        Assertions.assertEquals(FileRegistryServiceImpl.class, instance.getClass());
+        assertEquals(FileRegistryServiceImpl.class, instance.getClass());
     }
 
     /**
@@ -54,20 +56,24 @@ public class RegistryFactoryTest {
      */
     @Test
     public void testGetInstanceOfInvalidRegistryType() {
-        System.setProperty(REGISTRY_TYPE_KEY, "InvalidRegistryType");
+        String invalidRegistryType = "InvalidRegistryType";
+        System.setProperty(REGISTRY_TYPE_KEY, invalidRegistryType);
 
-        Assertions.assertThrows(NotSupportYetException.class, RegistryFactoryTest::invokeBuildRegistryService);
+        assertThatThrownBy(RegistryFactoryTest::invokeBuildRegistryService)
+            .isExactlyInstanceOf(NotSupportYetException.class)
+            .hasMessage("not support registry type: " + invalidRegistryType);
     }
 
     /**
      * Test buildRegistryService with blank registry type.
+     * when the registry type is blank, the default registry type is File
      */
     @Test
     public void testGetInstancesWithBlankRegistryType() throws Throwable {
         System.setProperty(REGISTRY_TYPE_KEY, "");
 
         RegistryService instance = invokeBuildRegistryService();
-        Assertions.assertEquals(FileRegistryServiceImpl.class, instance.getClass());
+        assertEquals(FileRegistryServiceImpl.class, instance.getClass());
     }
 
     /**

--- a/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/RegistryFactoryTest.java
+++ b/discovery/seata-discovery-core/src/test/java/org/apache/seata/discovery/registry/RegistryFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.discovery.registry;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.common.exception.NotSupportYetException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The type Registry factory test.
+ */
+public class RegistryFactoryTest {
+
+    private static final String REGISTRY_TYPE_KEY =
+            ConfigurationKeys.FILE_ROOT_REGISTRY + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + ConfigurationKeys.FILE_ROOT_TYPE;
+
+    @AfterEach
+    public void tearDown() {
+        System.clearProperty(REGISTRY_TYPE_KEY);
+    }
+
+    /**
+     * Test getInstance with default config.
+     */
+    @Test
+    public void testGetInstanceWithDefaultConfig() {
+        System.setProperty(REGISTRY_TYPE_KEY, RegistryType.File.name());
+
+        RegistryService instance = RegistryFactory.getInstance();
+        Assertions.assertNotNull(instance);
+    }
+
+    /**
+     * Test buildRegistryService with invalid registry type.
+     */
+    @Test
+    public void testGetInstanceOfInvalidRegistryType() {
+        System.setProperty(REGISTRY_TYPE_KEY, "InvalidRegistryType");
+
+        Assertions.assertThrows(NotSupportYetException.class, RegistryFactoryTest::invokeBuildRegistryService);
+    }
+
+    /**
+     * Test buildRegistryService with blank registry type.
+     */
+    @Test
+    public void testGetInstancesWithBlankRegistryType() throws Throwable {
+        System.setProperty(REGISTRY_TYPE_KEY, "");
+
+        RegistryService instance = invokeBuildRegistryService();
+        Assertions.assertEquals(instance.getClass(), FileRegistryServiceImpl.class);
+    }
+
+    /**
+     * Use reflection to call the buildRegistryServices method
+     */
+    private static RegistryService invokeBuildRegistryService() throws Throwable {
+        Method buildMethod = RegistryFactory.class.getDeclaredMethod("buildRegistryService");
+
+        buildMethod.setAccessible(true);
+        try {
+            return (RegistryService) buildMethod.invoke(null);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+}

--- a/discovery/seata-discovery-core/src/test/resources/META-INF/services/org.apache.seata.discovery.registry.RegistryProvider
+++ b/discovery/seata-discovery-core/src/test/resources/META-INF/services/org.apache.seata.discovery.registry.RegistryProvider
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.seata.discovery.registry.MockNacosRegistryProvider 

--- a/discovery/seata-discovery-nacos/src/test/java/org/apache/seata/discovery/registry/nacos/NacosRegistryServiceImplTest.java
+++ b/discovery/seata-discovery-nacos/src/test/java/org/apache/seata/discovery/registry/nacos/NacosRegistryServiceImplTest.java
@@ -16,29 +16,42 @@
  */
 package org.apache.seata.discovery.registry.nacos;
 
-import java.lang.reflect.Method;
-import java.util.Properties;
-
-import org.apache.seata.common.util.ReflectionUtil;
-import org.assertj.core.api.Assertions;
+import org.apache.seata.discovery.registry.RegistryService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.List;
 
 
 /**
  * The type Nacos registry serivce impl test
- *
  */
 public class NacosRegistryServiceImplTest {
 
-    @Test
-    public void testGetConfigProperties() throws Exception {
-        Method method = ReflectionUtil.getMethod(NacosRegistryServiceImpl.class, "getNamingProperties");
-        Properties properties = (Properties) ReflectionUtil.invokeMethod(null, method);
-        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/foo");
-        System.setProperty("contextPath", "/bar");
-        properties = (Properties) ReflectionUtil.invokeMethod(null, method);
-        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/bar");
+    @BeforeAll
+    public static void init() {
+        System.setProperty("seata.registry.type", "nacos");
+        System.setProperty("seata.registry.nacos.server-addr", "10.21.32.10:8848");
+        System.setProperty("seata.registry.nacos.username", "nacos");
+        System.setProperty("seata.registry.nacos.password", "nacos");
+        System.setProperty("seata.registry.nacos.cluster", "testCluster");
     }
 
+    @Test
+    public void testGetInstance() {
+        RegistryService instance = NacosRegistryServiceImpl.getInstance();
+        Assertions.assertInstanceOf(NacosRegistryServiceImpl.class, instance);
+        Assertions.assertEquals(instance, NacosRegistryServiceImpl.getInstance());
+    }
+
+    @Test
+    public void testRegister() throws Exception {
+        RegistryService instance = NacosRegistryServiceImpl.getInstance();
+        instance.register(new InetSocketAddress("127.0.0.1", 8080));
+        List<InetSocketAddress> testCluster = instance.lookup("testCluster");
+        Assertions.assertEquals(testCluster.get(0), new InetSocketAddress("127.0.0.1", 8080));
+    }
 
 }

--- a/discovery/seata-discovery-nacos/src/test/java/org/apache/seata/discovery/registry/nacos/NacosRegistryServiceImplTest.java
+++ b/discovery/seata-discovery-nacos/src/test/java/org/apache/seata/discovery/registry/nacos/NacosRegistryServiceImplTest.java
@@ -16,42 +16,29 @@
  */
 package org.apache.seata.discovery.registry.nacos;
 
-import org.apache.seata.discovery.registry.RegistryService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import java.lang.reflect.Method;
+import java.util.Properties;
 
-import java.net.InetSocketAddress;
-import java.util.List;
+import org.apache.seata.common.util.ReflectionUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 /**
  * The type Nacos registry serivce impl test
+ *
  */
 public class NacosRegistryServiceImplTest {
 
-    @BeforeAll
-    public static void init() {
-        System.setProperty("seata.registry.type", "nacos");
-        System.setProperty("seata.registry.nacos.server-addr", "10.21.32.10:8848");
-        System.setProperty("seata.registry.nacos.username", "nacos");
-        System.setProperty("seata.registry.nacos.password", "nacos");
-        System.setProperty("seata.registry.nacos.cluster", "testCluster");
+    @Test
+    public void testGetConfigProperties() throws Exception {
+        Method method = ReflectionUtil.getMethod(NacosRegistryServiceImpl.class, "getNamingProperties");
+        Properties properties = (Properties) ReflectionUtil.invokeMethod(null, method);
+        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/foo");
+        System.setProperty("contextPath", "/bar");
+        properties = (Properties) ReflectionUtil.invokeMethod(null, method);
+        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/bar");
     }
 
-    @Test
-    public void testGetInstance() {
-        RegistryService instance = NacosRegistryServiceImpl.getInstance();
-        Assertions.assertInstanceOf(NacosRegistryServiceImpl.class, instance);
-        Assertions.assertEquals(instance, NacosRegistryServiceImpl.getInstance());
-    }
-
-    @Test
-    public void testRegister() throws Exception {
-        RegistryService instance = NacosRegistryServiceImpl.getInstance();
-        instance.register(new InetSocketAddress("127.0.0.1", 8080));
-        List<InetSocketAddress> testCluster = instance.lookup("testCluster");
-        Assertions.assertEquals(testCluster.get(0), new InetSocketAddress("127.0.0.1", 8080));
-    }
 
 }


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
1. Use TreeSet to Increase the MultiRegistryFactory check for repeated registryType
2. Increase the inspection of RegistryFactory to air registryTypeName(align MultiRegistryFactory)
3. Put the logic of throwing NotSupportYetException into RegistryType.getType ()


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
https://github.com/apache/incubator-seata/discussions/7342

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Covers two factory

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

