### PR TITLE
optimize: Remove the unused defaultEventExecutorGroup

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -49,6 +49,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7363](https://github.com/apache/incubator-seata/pull/7363)] Upgrade npmjs dependencies
 - [[#7372](https://github.com/apache/incubator-seata/pull/7372)] optimize license ignore
 - [[#7412](https://github.com/apache/incubator-seata/pull/7412)] Helm template adapted to the new version of seata
+- [[#7414](https://github.com/apache/incubator-seata/pull/7414)] Remove the unused defaultEventExecutorGroup initialization in NettyClientBootstrap and make it final
 
 ### security:
 
@@ -102,5 +103,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [PleaseGiveMeTheCoke](https://github.com/PleaseGiveMeTheCoke)
 - [funky-eyes](https://github.com/funky-eyes)
 - [xucq07](https://github.com/xucq07)
+- [PengningYang](https://github.com/PengningYang)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -49,7 +49,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7363](https://github.com/apache/incubator-seata/pull/7363)] Upgrade npmjs dependencies
 - [[#7372](https://github.com/apache/incubator-seata/pull/7372)] optimize license ignore
 - [[#7412](https://github.com/apache/incubator-seata/pull/7412)] Helm template adapted to the new version of seata
-- [[#7414](https://github.com/apache/incubator-seata/pull/7414)] Remove the unused defaultEventExecutorGroup initialization in NettyClientBootstrap and make it final
+- [[#7414](https://github.com/apache/incubator-seata/pull/7414)] Remove the unused defaultEventExecutorGroup from the NettyClientBootstrap
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,6 +49,7 @@
 - [[#7363](https://github.com/apache/incubator-seata/pull/7363)] 升级 npmjs 依赖项
 - [[#7372](https://github.com/apache/incubator-seata/pull/7372)] 改进忽略许可证标头检查
 - [[#7412](https://github.com/apache/incubator-seata/pull/7412)] 适配新版本 Seata 的 Helm 模板
+- [[#7414](https://github.com/apache/incubator-seata/pull/7414)] 移除 NettyClientBootstrap 中 defaultEventExecutorGroup 初始化代码并将该变量声明为 final
 
 
 ### security:
@@ -104,6 +105,7 @@
 - [PleaseGiveMeTheCoke](https://github.com/PleaseGiveMeTheCoke)
 - [funky-eyes](https://github.com/funky-eyes)
 - [xucq07](https://github.com/xucq07)
+- [PengningYang](https://github.com/PengningYang)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,7 +49,7 @@
 - [[#7363](https://github.com/apache/incubator-seata/pull/7363)] 升级 npmjs 依赖项
 - [[#7372](https://github.com/apache/incubator-seata/pull/7372)] 改进忽略许可证标头检查
 - [[#7412](https://github.com/apache/incubator-seata/pull/7412)] 适配新版本 Seata 的 Helm 模板
-- [[#7414](https://github.com/apache/incubator-seata/pull/7414)] 移除 NettyClientBootstrap 中 defaultEventExecutorGroup 初始化代码并将该变量声明为 final
+- [[#7414](https://github.com/apache/incubator-seata/pull/7414)] 移除 NettyClientBootstrap 中 defaultEventExecutorGroup
 
 
 ### security:

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -27,7 +27,6 @@ import io.netty.channel.ChannelId;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.netty.util.concurrent.EventExecutorGroup;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
@@ -143,12 +142,11 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
 
     public AbstractNettyRemotingClient(
         NettyClientConfig nettyClientConfig,
-        EventExecutorGroup eventExecutorGroup,
         ThreadPoolExecutor messageExecutor,
         NettyPoolKey.TransactionRole transactionRole) {
         super(messageExecutor);
         this.transactionRole = transactionRole;
-        clientBootstrap = new NettyClientBootstrap(nettyClientConfig, eventExecutorGroup, transactionRole);
+        clientBootstrap = new NettyClientBootstrap(nettyClientConfig, transactionRole);
         clientBootstrap.setChannelHandlers(new ClientHandler(), new ChannelEventHandler(this));
         clientChannelManager = new NettyClientChannelManager(
             new NettyPoolableFactory(this, clientBootstrap), getPoolKeyFunction(), nettyClientConfig);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientBootstrap.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientBootstrap.java
@@ -36,7 +36,6 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.internal.PlatformDependent;
 import org.apache.seata.common.exception.FrameworkException;
 import org.apache.seata.common.thread.NamedThreadFactory;
@@ -68,11 +67,9 @@ public class NettyClientBootstrap implements RemotingBootstrap {
     private final AtomicBoolean initialized = new AtomicBoolean(false);
     private final NettyPoolKey.TransactionRole transactionRole;
     private final EventLoopGroup eventLoopGroupWorker;
-
-    private final EventExecutorGroup defaultEventExecutorGroup;
     private ChannelHandler[] channelHandlers;
 
-    public NettyClientBootstrap(NettyClientConfig nettyClientConfig, final EventExecutorGroup eventExecutorGroup,
+    public NettyClientBootstrap(NettyClientConfig nettyClientConfig,
                                 NettyPoolKey.TransactionRole transactionRole) {
         if (nettyClientConfig == null) {
             nettyClientConfig = new NettyClientConfig();
@@ -93,7 +90,6 @@ public class NettyClientBootstrap implements RemotingBootstrap {
         } else {
             eventLoopGroupWorker = createEventLoopGroupWorker(selectorThreadSizeThreadSize);
         }
-        this.defaultEventExecutorGroup = eventExecutorGroup;
     }
 
     /**
@@ -169,9 +165,6 @@ public class NettyClientBootstrap implements RemotingBootstrap {
     public void shutdown() {
         try {
             eventLoopGroupWorker.shutdownGracefully();
-            if (this.defaultEventExecutorGroup != null) {
-                this.defaultEventExecutorGroup.shutdownGracefully();
-            }
         } catch (Exception exx) {
             LOGGER.error("Failed to shutdown: {}", exx.getMessage());
         }

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientBootstrap.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientBootstrap.java
@@ -36,7 +36,6 @@ import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.internal.PlatformDependent;
 import org.apache.seata.common.exception.FrameworkException;
@@ -70,7 +69,7 @@ public class NettyClientBootstrap implements RemotingBootstrap {
     private final NettyPoolKey.TransactionRole transactionRole;
     private final EventLoopGroup eventLoopGroupWorker;
 
-    private EventExecutorGroup defaultEventExecutorGroup;
+    private final EventExecutorGroup defaultEventExecutorGroup;
     private ChannelHandler[] channelHandlers;
 
     public NettyClientBootstrap(NettyClientConfig nettyClientConfig, final EventExecutorGroup eventExecutorGroup,
@@ -122,11 +121,6 @@ public class NettyClientBootstrap implements RemotingBootstrap {
 
     @Override
     public void start() {
-        if (this.defaultEventExecutorGroup == null) {
-            this.defaultEventExecutorGroup = new DefaultEventExecutorGroup(nettyClientConfig.getClientWorkerThreads(),
-                new NamedThreadFactory(getThreadPrefix(nettyClientConfig.getClientWorkerThreadPrefix()),
-                    nettyClientConfig.getClientWorkerThreads()));
-        }
         this.bootstrap.group(eventLoopGroupWorker).channel(
             nettyClientConfig.getClientChannelClazz()).option(
             ChannelOption.TCP_NODELAY, true).option(ChannelOption.SO_KEEPALIVE, true).option(

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import io.netty.channel.Channel;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.seata.common.DefaultValues;
 import org.apache.seata.common.exception.FrameworkErrorCode;
 import org.apache.seata.common.exception.FrameworkException;
@@ -108,9 +107,9 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         });
     }
 
-    private RmNettyRemotingClient(NettyClientConfig nettyClientConfig, EventExecutorGroup eventExecutorGroup,
+    private RmNettyRemotingClient(NettyClientConfig nettyClientConfig,
                                   ThreadPoolExecutor messageExecutor) {
-        super(nettyClientConfig, eventExecutorGroup, messageExecutor, TransactionRole.RMROLE);
+        super(nettyClientConfig, messageExecutor, TransactionRole.RMROLE);
         // set enableClientBatchSendRequest
         Configuration configuration = ConfigurationFactory.getInstance();
         this.enableClientBatchSendRequest = configuration.getBoolean(ConfigurationKeys.ENABLE_RM_CLIENT_BATCH_SEND_REQUEST,
@@ -156,7 +155,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                         KEEP_ALIVE_TIME, TimeUnit.SECONDS, new LinkedBlockingQueue<>(MAX_QUEUE_SIZE),
                         new NamedThreadFactory(nettyClientConfig.getRmDispatchThreadPrefix(),
                             nettyClientConfig.getClientWorkerThreads()), new ThreadPoolExecutor.CallerRunsPolicy());
-                    instance = new RmNettyRemotingClient(nettyClientConfig, null, messageExecutor);
+                    instance = new RmNettyRemotingClient(nettyClientConfig, messageExecutor);
                 }
             }
         }

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/TmNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/TmNettyRemotingClient.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import io.netty.channel.Channel;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.apache.commons.lang.StringUtils;
 import org.apache.seata.common.DefaultValues;
 import org.apache.seata.common.exception.FrameworkException;
@@ -66,9 +65,8 @@ public final class TmNettyRemotingClient extends AbstractNettyRemotingClient {
 
 
     private TmNettyRemotingClient(NettyClientConfig nettyClientConfig,
-                                  EventExecutorGroup eventExecutorGroup,
                                   ThreadPoolExecutor messageExecutor) {
-        super(nettyClientConfig, eventExecutorGroup, messageExecutor, NettyPoolKey.TransactionRole.TMROLE);
+        super(nettyClientConfig, messageExecutor, NettyPoolKey.TransactionRole.TMROLE);
         this.signer = EnhancedServiceLoader.load(AuthSigner.class);
         // set enableClientBatchSendRequest
         Configuration configuration = ConfigurationFactory.getInstance();
@@ -152,7 +150,7 @@ public final class TmNettyRemotingClient extends AbstractNettyRemotingClient {
                             new NamedThreadFactory(nettyClientConfig.getTmDispatchThreadPrefix(),
                                     nettyClientConfig.getClientWorkerThreads()),
                             RejectedPolicies.runsOldestTaskPolicy());
-                    instance = new TmNettyRemotingClient(nettyClientConfig, null, messageExecutor);
+                    instance = new TmNettyRemotingClient(nettyClientConfig, messageExecutor);
                 }
             }
         }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientBootstrapTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientBootstrapTest.java
@@ -17,9 +17,7 @@
 package org.apache.seata.core.rpc.netty;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,20 +30,13 @@ class NettyClientBootstrapTest {
 
     @Mock
     private NettyClientConfig nettyClientConfig;
-    private DefaultEventExecutorGroup eventExecutorGroup;
-
-    @BeforeEach
-    void init() {
-        eventExecutorGroup = new DefaultEventExecutorGroup(1);
-    }
-
     @Test
     void testSharedEventLoopGroupEnabled() {
         when(nettyClientConfig.getEnableClientSharedEventLoop()).thenReturn(true);
-        NettyClientBootstrap tmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, eventExecutorGroup, NettyPoolKey.TransactionRole.TMROLE);
+        NettyClientBootstrap tmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, NettyPoolKey.TransactionRole.TMROLE);
         EventLoopGroup tmEventLoopGroupWorker = getEventLoopGroupWorker(tmNettyClientBootstrap);
 
-        NettyClientBootstrap rmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, eventExecutorGroup, NettyPoolKey.TransactionRole.RMROLE);
+        NettyClientBootstrap rmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, NettyPoolKey.TransactionRole.RMROLE);
         EventLoopGroup rmEventLoopGroupWorker = getEventLoopGroupWorker(rmNettyClientBootstrap);
 
         Assertions.assertEquals(tmEventLoopGroupWorker, rmEventLoopGroupWorker);
@@ -54,10 +45,10 @@ class NettyClientBootstrapTest {
     @Test
     void testSharedEventLoopGroupDisabled() {
         when(nettyClientConfig.getEnableClientSharedEventLoop()).thenReturn(false);
-        NettyClientBootstrap tmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, eventExecutorGroup, NettyPoolKey.TransactionRole.TMROLE);
+        NettyClientBootstrap tmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, NettyPoolKey.TransactionRole.TMROLE);
         EventLoopGroup tmEventLoopGroupWorker = getEventLoopGroupWorker(tmNettyClientBootstrap);
 
-        NettyClientBootstrap rmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, eventExecutorGroup, NettyPoolKey.TransactionRole.RMROLE);
+        NettyClientBootstrap rmNettyClientBootstrap = new NettyClientBootstrap(nettyClientConfig, NettyPoolKey.TransactionRole.RMROLE);
         EventLoopGroup rmEventLoopGroupWorker = getEventLoopGroupWorker(rmNettyClientBootstrap);
 
         Assertions.assertNotEquals(tmEventLoopGroupWorker, rmEventLoopGroupWorker);


### PR DESCRIPTION
…make it final

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Remove the unused defaultEventExecutorGroup initialization in NettyClientBootstrap and make it final

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #6132 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

