### PR TITLE
optimize: seata-server independent HTTP thread pool

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -49,6 +49,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7363](https://github.com/apache/incubator-seata/pull/7363)] Upgrade npmjs dependencies
 - [[#7372](https://github.com/apache/incubator-seata/pull/7372)] optimize license ignore
 - [[#7412](https://github.com/apache/incubator-seata/pull/7412)] Helm template adapted to the new version of seata
+- [[#7415](https://github.com/apache/incubator-seata/pull/7415)] Use threadPool to asynchronously process server http requests
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,6 +49,7 @@
 - [[#7363](https://github.com/apache/incubator-seata/pull/7363)] 升级 npmjs 依赖项
 - [[#7372](https://github.com/apache/incubator-seata/pull/7372)] 改进忽略许可证标头检查
 - [[#7412](https://github.com/apache/incubator-seata/pull/7412)] 适配新版本 Seata 的 Helm 模板
+- [[#7415](https://github.com/apache/incubator-seata/pull/7415)] 使用线程池异步处理server http请求
 
 
 ### security:

--- a/common/src/main/java/org/apache/seata/common/ConfigurationKeys.java
+++ b/common/src/main/java/org/apache/seata/common/ConfigurationKeys.java
@@ -645,6 +645,26 @@ public interface ConfigurationKeys {
     String KEEP_ALIVE_TIME = TRANSPORT_PREFIX + "keepAliveTime";
 
     /**
+     * The constant MIN_HTTP_POOL_SIZE.
+     */
+    String MIN_HTTP_POOL_SIZE = TRANSPORT_PREFIX + "minHttpPoolSize";
+
+    /**
+     * The constant MAX_HTTP_POOL_SIZE.
+     */
+    String MAX_HTTP_POOL_SIZE = TRANSPORT_PREFIX + "maxHttpPoolSize";
+
+    /**
+     * The constant MAX_HTTP_TASK_QUEUE_SIZE.
+     */
+    String MAX_HTTP_TASK_QUEUE_SIZE = TRANSPORT_PREFIX + "maxHttpTaskQueueSize";
+
+    /**
+     * The constant HTTP_POOL_KEEP_ALIVE_TIME.
+     */
+    String HTTP_POOL_KEEP_ALIVE_TIME = TRANSPORT_PREFIX + "httpPoolKeepAliveTime";
+
+    /**
      * The constant TRANSPORT_TYPE
      */
     String TRANSPORT_TYPE = TRANSPORT_PREFIX + "type";

--- a/common/src/main/java/org/apache/seata/common/DefaultValues.java
+++ b/common/src/main/java/org/apache/seata/common/DefaultValues.java
@@ -162,6 +162,26 @@ public interface DefaultValues {
     String DEFAULT_PROTOCOL = "seata";
 
     /**
+     * The constant DEFAULT_MIN_HTTP_POOL_SIZE.
+     */
+    int DEFAULT_MIN_HTTP_POOL_SIZE = 10;
+    
+    /**
+     * The constant DEFAULT_MAX_HTTP_POOL_SIZE.
+     */
+    int DEFAULT_MAX_HTTP_POOL_SIZE = 100;
+    
+    /**
+     * The constant DEFAULT_MAX_HTTP_TASK_QUEUE_SIZE.
+     */
+    int DEFAULT_MAX_HTTP_TASK_QUEUE_SIZE = 1000;
+    
+    /**
+     * The constant DEFAULT_HTTP_POOL_KEEP_ALIVE_TIME.
+     */
+    int DEFAULT_HTTP_POOL_KEEP_ALIVE_TIME = 500;
+
+    /**
      * The constant DEFAULT_TRANSPORT_HEARTBEAT.
      */
     boolean DEFAULT_TRANSPORT_HEARTBEAT = true;

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyServerConfig.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyServerConfig.java
@@ -69,6 +69,11 @@ public class NettyServerConfig extends NettyBaseConfig {
     private static boolean ENABLE_TC_SERVER_BATCH_SEND_RESPONSE = CONFIG.getBoolean(ConfigurationKeys.ENABLE_TC_SERVER_BATCH_SEND_RESPONSE,
         DefaultValues.DEFAULT_ENABLE_TC_SERVER_BATCH_SEND_RESPONSE);
 
+    private static int minHttpPoolSize = CONFIG.getInt(ConfigurationKeys.MIN_HTTP_POOL_SIZE, 10);
+    private static int maxHttpPoolSize = CONFIG.getInt(ConfigurationKeys.MAX_HTTP_POOL_SIZE, 100);
+    private static int maxHttpTaskQueueSize = CONFIG.getInt(ConfigurationKeys.MAX_HTTP_TASK_QUEUE_SIZE, 1000);
+    private static int httpKeepAliveTime = CONFIG.getInt(ConfigurationKeys.HTTP_POOL_KEEP_ALIVE_TIME, 500);
+
     /**
      * The Server channel clazz.
      */
@@ -313,6 +318,22 @@ public class NettyServerConfig extends NettyBaseConfig {
 
     public static int getKeepAliveTime() {
         return keepAliveTime;
+    }
+
+    public static int getMinHttpPoolSize() {
+        return minHttpPoolSize;
+    }
+
+    public static int getMaxHttpPoolSize() {
+        return maxHttpPoolSize;
+    }
+
+    public static int getMaxHttpTaskQueueSize() {
+        return maxHttpTaskQueueSize;
+    }
+
+    public static int getHttpKeepAliveTime() {
+        return httpKeepAliveTime;
     }
 
     /**

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -39,12 +39,7 @@ import org.apache.seata.common.thread.NamedThreadFactory;
 import org.apache.seata.core.rpc.netty.NettyServerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-
 import org.apache.seata.common.rpc.http.HttpContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
@@ -76,45 +71,36 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, HttpRequest httpRequest) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, HttpRequest httpRequest) {
         boolean keepAlive = HttpUtil.isKeepAlive(httpRequest) && httpRequest.protocolVersion().isKeepAliveDefault();
         try {
             httpHandlerThreads.execute(() -> {
                 try {
                     processHttpRequest(ctx, httpRequest, keepAlive);
+                } catch (IllegalArgumentException e) {
+                    LOGGER.error("Illegal argument exception: {}", e.getMessage(), e);
+                    sendErrorResponse(ctx, HttpResponseStatus.BAD_REQUEST, false);
                 } catch (Exception e) {
-                    LOGGER.error("HTTP request processing error", e);
-                    sendResponse(ctx, null, keepAlive);
+                    LOGGER.error("Exception occurred while processing HTTP request: {}", e.getMessage(), e);
+                    sendErrorResponse(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, false);
                 }
             });
         } catch (RejectedExecutionException e) {
-            sendUnavailable(ctx, keepAlive);
-            LOGGER.warn("HTTP thread pool is full, return 503 status code", e);
+            sendErrorResponse(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, false);
+            LOGGER.error("HTTP thread pool is full: {}", e.getMessage(), e);
         }
     }
 
-
-    /*
-    catch (IllegalArgumentException e) {
-            keepAlive = false;
-            LOGGER.error("Illegal argument exception: {}", e.getMessage(), e);
-            response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST,
-                    Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
-        } catch (Exception e) {
-            keepAlive = false;
-            LOGGER.error("Exception occurred while processing HTTP request: {}", e.getMessage(), e);
-            response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                    Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
-        }
-     */
     private void processHttpRequest(ChannelHandlerContext ctx, HttpRequest httpRequest, boolean keepAlive) throws Exception {
         QueryStringDecoder queryStringDecoder = new QueryStringDecoder(httpRequest.uri());
         String path = queryStringDecoder.path();
         HttpInvocation httpInvocation = ControllerManager.getHttpInvocation(path);
+
         if (httpInvocation == null) {
-            sendNotFound(ctx, keepAlive);
+            sendErrorResponse(ctx, HttpResponseStatus.NOT_FOUND, keepAlive);
             return;
         }
+
         HttpContext httpContext = new HttpContext(httpRequest, ctx, keepAlive);
         ObjectNode requestDataNode = OBJECT_MAPPER.createObjectNode();
         requestDataNode.putIfAbsent("param", ParameterParser.convertParamMap(queryStringDecoder.parameters()));
@@ -149,45 +135,20 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
             return;
         }
 
-        if (requestDataNode.get("channel") == null) {
-            return;
-        }
-
         sendResponse(ctx, result, keepAlive);
     }
 
-    private void sendResponse(ChannelHandlerContext ctx, Object result, boolean keepAlive) {
-        try {
-            FullHttpResponse response;
-            if (result != null) {
-                byte[] body = OBJECT_MAPPER.writeValueAsBytes(result);
-                response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
-                        Unpooled.wrappedBuffer(body));
-                response.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length);
-            } else {
-                response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
-                        Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
-            }
-            if (!keepAlive) {
-                ctx.writeAndFlush(response).addListeners(ChannelFutureListener.CLOSE);
-            } else {
-                ctx.writeAndFlush(response);
-            }
-        } catch (JsonProcessingException e) {
-            LOGGER.error("Failed to serialize response", e);
-            FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+    private void sendResponse(ChannelHandlerContext ctx, Object result, boolean keepAlive) throws JsonProcessingException {
+        FullHttpResponse response;
+        if (result != null) {
+            byte[] body = OBJECT_MAPPER.writeValueAsBytes(result);
+            response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                    Unpooled.wrappedBuffer(body));
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length);
+        } else {
+            response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                     Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
-            if (!keepAlive) {
-                ctx.writeAndFlush(response).addListeners(ChannelFutureListener.CLOSE);
-            } else {
-                ctx.writeAndFlush(response);
-            }
         }
-    }
-
-    private void sendNotFound(ChannelHandlerContext ctx, boolean keepAlive) {
-        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND,
-                Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
         if (!keepAlive) {
             ctx.writeAndFlush(response).addListeners(ChannelFutureListener.CLOSE);
         } else {
@@ -195,9 +156,9 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
         }
     }
 
-    private void sendUnavailable(ChannelHandlerContext ctx, boolean keepAlive) {
-        FullHttpResponse response = new DefaultFullHttpResponse(
-                HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE, Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
+    private void sendErrorResponse(ChannelHandlerContext ctx, HttpResponseStatus status, boolean keepAlive) {
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status,
+                Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
         if (!keepAlive) {
             ctx.writeAndFlush(response).addListeners(ChannelFutureListener.CLOSE);
         } else {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -63,7 +63,7 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(NettyServerConfig.getMaxHttpTaskQueueSize()),
             new NamedThreadFactory("HTTPHandlerThread", NettyServerConfig.getMaxHttpPoolSize()),
-            new ThreadPoolExecutor.CallerRunsPolicy()
+            new ThreadPoolExecutor.AbortPolicy()
     );
 
     static {
@@ -84,7 +84,8 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
                 }
             });
         } catch (RejectedExecutionException e) {
-            LOGGER.error("HTTP thread pool is full, rejecting request", e);
+            sendUnavalable(ctx, keepAlive);
+            LOGGER.warn("HTTP thread pool is full, return 503 status code", e);
         }
     }
 
@@ -157,6 +158,16 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
     private void sendNotFound(ChannelHandlerContext ctx, boolean keepAlive) {
         FullHttpResponse response = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND, Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
+        if (!keepAlive) {
+            ctx.writeAndFlush(response).addListeners(ChannelFutureListener.CLOSE);
+        } else {
+            ctx.writeAndFlush(response);
+        }
+    }
+
+    private void sendUnavalable(ChannelHandlerContext ctx, boolean keepAlive) {
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE, Unpooled.wrappedBuffer(Unpooled.EMPTY_BUFFER));
         if (!keepAlive) {
             ctx.writeAndFlush(response).addListeners(ChannelFutureListener.CLOSE);
         } else {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.seata.core.rpc.netty.http;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.buffer.Unpooled;
@@ -34,16 +35,60 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.multipart.Attribute;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import org.apache.seata.common.thread.NamedThreadFactory;
+import org.apache.seata.core.rpc.netty.NettyServerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpDispatchHandler.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * HTTP request processing thread pool, independent of Netty IO threads, to avoid blocking network processing
+     */
+    private static final ExecutorService httpHandlerThreads = new ThreadPoolExecutor(
+            NettyServerConfig.getMinHttpPoolSize(),
+            NettyServerConfig.getMaxHttpPoolSize(),
+            NettyServerConfig.getHttpKeepAliveTime(),
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(NettyServerConfig.getMaxHttpTaskQueueSize()),
+            new NamedThreadFactory("HTTPHandlerThread", NettyServerConfig.getMaxHttpPoolSize()),
+            new ThreadPoolExecutor.CallerRunsPolicy()
+    );
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(httpHandlerThreads::shutdown));
+    }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, HttpRequest httpRequest) throws Exception {
         final boolean keepAlive = HttpUtil.isKeepAlive(httpRequest)
                 && httpRequest.protocolVersion().isKeepAliveDefault();
+
+        try {
+            httpHandlerThreads.execute(() -> {
+                try {
+                    processHttpRequest(ctx, httpRequest, keepAlive);
+                } catch (Exception e) {
+                    LOGGER.error("HTTP request processing error", e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            LOGGER.error("HTTP thread pool is full, rejecting request", e);
+        }
+    }
+
+    private void processHttpRequest(ChannelHandlerContext ctx, HttpRequest httpRequest, boolean keepAlive) throws Exception {
         QueryStringDecoder queryStringDecoder = new QueryStringDecoder(httpRequest.uri());
         String path = queryStringDecoder.path();
 
@@ -70,6 +115,8 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
                     bodyDataNode.put(attribute.getName(), attribute.getValue());
                 }
                 requestDataNode.putIfAbsent("body", bodyDataNode);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             } finally {
                 if (httpPostRequestDecoder != null) {
                     httpPostRequestDecoder.destroy();
@@ -85,6 +132,11 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
         if (requestDataNode.get("channel") == null) {
             return;
         }
+
+        sendResponse(ctx, result, keepAlive);
+    }
+
+    private void sendResponse(ChannelHandlerContext ctx, Object result, boolean keepAlive) throws JsonProcessingException {
         FullHttpResponse response;
         if (result != null) {
             byte[] body = OBJECT_MAPPER.writeValueAsBytes(result);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -130,8 +130,8 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
                     }
                 });
             } catch (RejectedExecutionException e) {
-                sendErrorResponse(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, false);
                 LOGGER.error("HTTP thread pool is full: {}", e.getMessage(), e);
+                sendErrorResponse(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, false);
             }
         } catch (Exception e) {
             LOGGER.error("Exception occurred while processing HTTP request: {}", e.getMessage(), e);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.seata.common.rpc.http.HttpContext;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -54,7 +55,7 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     /**
-     * HTTP request processing thread pool, independent of Netty IO threads, to avoid blocking network processing
+     * HTTP request processing thread pool, independent of Netty IO threads, to avoid blocking network processing.
      */
     private static final ExecutorService httpHandlerThreads = new ThreadPoolExecutor(
             NettyServerConfig.getMinHttpPoolSize(),
@@ -72,73 +73,74 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, HttpRequest httpRequest) {
-        boolean keepAlive = HttpUtil.isKeepAlive(httpRequest) && httpRequest.protocolVersion().isKeepAliveDefault();
         try {
-            httpHandlerThreads.execute(() -> {
+            boolean keepAlive = HttpUtil.isKeepAlive(httpRequest) && httpRequest.protocolVersion().isKeepAliveDefault();
+            QueryStringDecoder queryStringDecoder = new QueryStringDecoder(httpRequest.uri());
+            String path = queryStringDecoder.path();
+            HttpInvocation httpInvocation = ControllerManager.getHttpInvocation(path);
+
+            if (httpInvocation == null) {
+                sendErrorResponse(ctx, HttpResponseStatus.NOT_FOUND, keepAlive);
+                return;
+            }
+
+            HttpContext httpContext = new HttpContext(httpRequest, ctx, keepAlive);
+            ObjectNode requestDataNode = OBJECT_MAPPER.createObjectNode();
+            requestDataNode.putIfAbsent("param", ParameterParser.convertParamMap(queryStringDecoder.parameters()));
+
+            if (httpRequest.method() == HttpMethod.POST) {
+                HttpPostRequestDecoder httpPostRequestDecoder = null;
                 try {
-                    processHttpRequest(ctx, httpRequest, keepAlive);
-                } catch (IllegalArgumentException e) {
-                    LOGGER.error("Illegal argument exception: {}", e.getMessage(), e);
-                    sendErrorResponse(ctx, HttpResponseStatus.BAD_REQUEST, false);
-                } catch (Exception e) {
-                    LOGGER.error("Exception occurred while processing HTTP request: {}", e.getMessage(), e);
-                    sendErrorResponse(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, false);
-                }
-            });
-        } catch (RejectedExecutionException e) {
-            sendErrorResponse(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, false);
-            LOGGER.error("HTTP thread pool is full: {}", e.getMessage(), e);
-        }
-    }
-
-    private void processHttpRequest(ChannelHandlerContext ctx, HttpRequest httpRequest, boolean keepAlive) throws Exception {
-        QueryStringDecoder queryStringDecoder = new QueryStringDecoder(httpRequest.uri());
-        String path = queryStringDecoder.path();
-        HttpInvocation httpInvocation = ControllerManager.getHttpInvocation(path);
-
-        if (httpInvocation == null) {
-            sendErrorResponse(ctx, HttpResponseStatus.NOT_FOUND, keepAlive);
-            return;
-        }
-
-        HttpContext httpContext = new HttpContext(httpRequest, ctx, keepAlive);
-        ObjectNode requestDataNode = OBJECT_MAPPER.createObjectNode();
-        requestDataNode.putIfAbsent("param", ParameterParser.convertParamMap(queryStringDecoder.parameters()));
-
-        if (httpRequest.method() == HttpMethod.POST) {
-            HttpPostRequestDecoder httpPostRequestDecoder = null;
-            try {
-                httpPostRequestDecoder = new HttpPostRequestDecoder(httpRequest);
-                ObjectNode bodyDataNode = OBJECT_MAPPER.createObjectNode();
-                for (InterfaceHttpData interfaceHttpData : httpPostRequestDecoder.getBodyHttpDatas()) {
-                    if (interfaceHttpData.getHttpDataType() != InterfaceHttpData.HttpDataType.Attribute) {
-                        continue;
+                    httpPostRequestDecoder = new HttpPostRequestDecoder(httpRequest);
+                    ObjectNode bodyDataNode = OBJECT_MAPPER.createObjectNode();
+                    for (InterfaceHttpData interfaceHttpData : httpPostRequestDecoder.getBodyHttpDatas()) {
+                        if (interfaceHttpData.getHttpDataType() != InterfaceHttpData.HttpDataType.Attribute) {
+                            continue;
+                        }
+                        Attribute attribute = (Attribute) interfaceHttpData;
+                        bodyDataNode.put(attribute.getName(), attribute.getValue());
                     }
-                    Attribute attribute = (Attribute) interfaceHttpData;
-                    bodyDataNode.put(attribute.getName(), attribute.getValue());
-                }
-                requestDataNode.putIfAbsent("body", bodyDataNode);
-            } finally {
-                if (httpPostRequestDecoder != null) {
-                    httpPostRequestDecoder.destroy();
+                    requestDataNode.putIfAbsent("body", bodyDataNode);
+                } finally {
+                    if (httpPostRequestDecoder != null) {
+                        httpPostRequestDecoder.destroy();
+                    }
                 }
             }
+
+            Object httpController = httpInvocation.getController();
+            Method handleMethod = httpInvocation.getMethod();
+            Object[] args = ParameterParser.getArgValues(httpInvocation.getParamMetaData(), handleMethod,
+                    requestDataNode, httpContext);
+
+            try {
+                httpHandlerThreads.execute(() -> {
+                    try {
+                        Object result = handleMethod.invoke(httpController, args);
+                        if (httpContext.isAsync()) {
+                            return;
+                        }
+
+                        sendResponse(ctx, keepAlive, result);
+                    } catch (IllegalArgumentException e) {
+                        LOGGER.error("Illegal argument exception: {}", e.getMessage(), e);
+                        sendErrorResponse(ctx, HttpResponseStatus.BAD_REQUEST, false);
+                    } catch (Exception e) {
+                        LOGGER.error("Exception occurred while processing HTTP request: {}", e.getMessage(), e);
+                        sendErrorResponse(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, false);
+                    }
+                });
+            } catch (RejectedExecutionException e) {
+                sendErrorResponse(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE, false);
+                LOGGER.error("HTTP thread pool is full: {}", e.getMessage(), e);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Exception occurred while processing HTTP request: {}", e.getMessage(), e);
+            sendErrorResponse(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, false);
         }
-
-        Object httpController = httpInvocation.getController();
-        Method handleMethod = httpInvocation.getMethod();
-        Object[] args = ParameterParser.getArgValues(httpInvocation.getParamMetaData(), handleMethod,
-                requestDataNode, httpContext);
-        Object result = handleMethod.invoke(httpController, args);
-
-        if (httpContext.isAsync()) {
-            return;
-        }
-
-        sendResponse(ctx, result, keepAlive);
     }
 
-    private void sendResponse(ChannelHandlerContext ctx, Object result, boolean keepAlive) throws JsonProcessingException {
+    private void sendResponse(ChannelHandlerContext ctx, boolean keepAlive, Object result) throws JsonProcessingException {
         FullHttpResponse response;
         if (result != null) {
             byte[] body = OBJECT_MAPPER.writeValueAsBytes(result);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -56,7 +56,7 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
     /**
      * HTTP request processing thread pool, independent of Netty IO threads, to avoid blocking network processing.
      */
-    private static final ExecutorService httpHandlerThreads = new ThreadPoolExecutor(
+    private static final ExecutorService HTTP_HANDLER_THREADS = new ThreadPoolExecutor(
             NettyServerConfig.getMinHttpPoolSize(),
             NettyServerConfig.getMaxHttpPoolSize(),
             NettyServerConfig.getHttpKeepAliveTime(),
@@ -67,7 +67,7 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
     );
 
     static {
-        Runtime.getRuntime().addShutdownHook(new Thread(httpHandlerThreads::shutdown));
+        Runtime.getRuntime().addShutdownHook(new Thread(HTTP_HANDLER_THREADS::shutdown));
     }
 
     @Override
@@ -113,7 +113,7 @@ public class HttpDispatchHandler extends SimpleChannelInboundHandler<HttpRequest
                     requestDataNode, httpContext);
 
             try {
-                httpHandlerThreads.execute(() -> {
+                HTTP_HANDLER_THREADS.execute(() -> {
                     try {
                         Object result = handleMethod.invoke(httpController, args);
                         if (httpContext.isAsync()) {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandler.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.seata.common.rpc.http.HttpContext;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandlerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandlerTest.java
@@ -25,12 +25,11 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,19 +54,20 @@ class HttpDispatchHandlerTest {
 
     @Test
     void testGetRequestWithParameters() throws Exception {
-        try (MockedStatic<ControllerManager> mocked = Mockito.mockStatic(ControllerManager.class)) {
-            Method method = TestController.class.getMethod("handleRequest", String.class);
-            ParamMetaData paramMetaData = new ParamMetaData();
-            paramMetaData.setParamConvertType(ParamMetaData.ParamConvertType.REQUEST_PARAM);
-            ParamMetaData[] paramMetaDatas = new ParamMetaData[]{paramMetaData};
-            HttpInvocation invocation = new HttpInvocation();
-            invocation.setController(testController);
-            invocation.setMethod(method);
-            invocation.setParamMetaData(paramMetaDatas);
+        Method method = TestController.class.getMethod("handleRequest", String.class);
+        ParamMetaData paramMetaData = new ParamMetaData();
+        paramMetaData.setParamConvertType(ParamMetaData.ParamConvertType.REQUEST_PARAM);
+        ParamMetaData[] paramMetaDatas = new ParamMetaData[]{paramMetaData};
 
-            mocked.when(() -> ControllerManager.getHttpInvocation("/test"))
-                    .thenReturn(invocation);
+        HttpInvocation invocation = new HttpInvocation();
+        invocation.setController(testController);
+        invocation.setMethod(method);
+        invocation.setPath("/test");
+        invocation.setParamMetaData(paramMetaDatas);
 
+        ControllerManager.addHttpInvocation(invocation);
+
+        try {
             HttpRequest request = new DefaultFullHttpRequest(
                     HttpVersion.HTTP_1_1,
                     HttpMethod.GET,
@@ -76,50 +76,42 @@ class HttpDispatchHandlerTest {
 
             channel.writeInbound(request);
 
-            FullHttpResponse response = waitForResponse(10000);
+            FullHttpResponse response = waitForResponse(5000);
             assertEquals(HttpResponseStatus.OK, response.status());
             String content = response.content().toString(StandardCharsets.UTF_8);
             assertTrue(content.contains("Processed: testValue"));
+        } finally {
+            clearControllerManager();
         }
     }
 
     @Test
     void testRequestToNonexistentPath() {
-        try (MockedStatic<ControllerManager> mocked = Mockito.mockStatic(ControllerManager.class)) {
-            mocked.when(() -> ControllerManager.getHttpInvocation("/notfound"))
-                    .thenReturn(null);
+        HttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.GET,
+                "/notfound"
+        );
 
-            HttpRequest request = new DefaultFullHttpRequest(
-                    HttpVersion.HTTP_1_1,
-                    HttpMethod.GET,
-                    "/notfound"
-            );
+        channel.writeInbound(request);
 
-            channel.writeInbound(request);
-
-            FullHttpResponse response = waitForResponse(10000);
-            assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
-        }
+        FullHttpResponse response = waitForResponse(5000);
+        assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
     }
 
     @Test
     void testHttpHeadMethod() {
-        try (MockedStatic<ControllerManager> mocked = Mockito.mockStatic(ControllerManager.class)) {
-            mocked.when(() -> ControllerManager.getHttpInvocation("/head"))
-                    .thenReturn(null);
+        HttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.HEAD,
+                "/head"
+        );
 
-            HttpRequest request = new DefaultFullHttpRequest(
-                    HttpVersion.HTTP_1_1,
-                    HttpMethod.HEAD,
-                    "/head"
-            );
+        channel.writeInbound(request);
 
-            channel.writeInbound(request);
-
-            FullHttpResponse response = waitForResponse(10000);
-            assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
-            assertEquals(0, response.content().readableBytes());
-        }
+        FullHttpResponse response = waitForResponse(5000);
+        assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
+        assertEquals(0, response.content().readableBytes());
     }
 
     private FullHttpResponse waitForResponse(long timeoutMs) {
@@ -130,7 +122,7 @@ class HttpDispatchHandlerTest {
             response = channel.readOutbound();
             if (response == null) {
                 try {
-                    Thread.sleep(5);
+                    Thread.sleep(10);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new RuntimeException("Interrupted while waiting for response", e);
@@ -139,5 +131,13 @@ class HttpDispatchHandlerTest {
         }
 
         return response;
+    }
+
+    private void clearControllerManager() throws Exception {
+        Field field = ControllerManager.class.getDeclaredField("HTTP_CONTROLLER_MAP");
+        field.setAccessible(true);
+        Map<String, HttpInvocation> map = (java.util.Map<String, HttpInvocation>) field.get(null);
+        map.clear();
+
     }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandlerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/http/HttpDispatchHandlerTest.java
@@ -76,7 +76,7 @@ class HttpDispatchHandlerTest {
 
             channel.writeInbound(request);
 
-            FullHttpResponse response = channel.readOutbound();
+            FullHttpResponse response = waitForResponse(10000);
             assertEquals(HttpResponseStatus.OK, response.status());
             String content = response.content().toString(StandardCharsets.UTF_8);
             assertTrue(content.contains("Processed: testValue"));
@@ -97,7 +97,7 @@ class HttpDispatchHandlerTest {
 
             channel.writeInbound(request);
 
-            FullHttpResponse response = channel.readOutbound();
+            FullHttpResponse response = waitForResponse(10000);
             assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
         }
     }
@@ -116,9 +116,28 @@ class HttpDispatchHandlerTest {
 
             channel.writeInbound(request);
 
-            FullHttpResponse response = channel.readOutbound();
+            FullHttpResponse response = waitForResponse(10000);
             assertEquals(HttpResponseStatus.NOT_FOUND, response.status());
             assertEquals(0, response.content().readableBytes());
         }
+    }
+
+    private FullHttpResponse waitForResponse(long timeoutMs) {
+        long startTime = System.currentTimeMillis();
+        FullHttpResponse response = null;
+
+        while (response == null && (System.currentTimeMillis() - startTime) < timeoutMs) {
+            response = channel.readOutbound();
+            if (response == null) {
+                try {
+                    Thread.sleep(5);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while waiting for response", e);
+                }
+            }
+        }
+
+        return response;
     }
 }

--- a/script/config-center/config.txt
+++ b/script/config-center/config.txt
@@ -40,6 +40,11 @@ transport.threadFactory.workerThreadSize=default
 transport.shutdown.wait=3
 transport.serialization=seata
 transport.compressor=none
+#HTTP thread pool
+transport.minHttpPoolSize=10
+transport.maxHttpPoolSize=100
+transport.maxHttpTaskQueueSize=1000
+transport.httpPoolKeepAliveTime=500
 
 #Transaction routing rules configuration, only for the client
 service.vgroupMapping.default_tx_group=default

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/TransportProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/TransportProperties.java
@@ -23,6 +23,10 @@ import static org.apache.seata.common.DefaultValues.DEFAULT_ENABLE_CLIENT_BATCH_
 import static org.apache.seata.common.DefaultValues.DEFAULT_ENABLE_RM_CLIENT_BATCH_SEND_REQUEST;
 import static org.apache.seata.common.DefaultValues.DEFAULT_ENABLE_TC_SERVER_BATCH_SEND_RESPONSE;
 import static org.apache.seata.common.DefaultValues.DEFAULT_ENABLE_TM_CLIENT_BATCH_SEND_REQUEST;
+import static org.apache.seata.common.DefaultValues.DEFAULT_HTTP_POOL_KEEP_ALIVE_TIME;
+import static org.apache.seata.common.DefaultValues.DEFAULT_MAX_HTTP_POOL_SIZE;
+import static org.apache.seata.common.DefaultValues.DEFAULT_MAX_HTTP_TASK_QUEUE_SIZE;
+import static org.apache.seata.common.DefaultValues.DEFAULT_MIN_HTTP_POOL_SIZE;
 import static org.apache.seata.common.DefaultValues.DEFAULT_PROTOCOL;
 import static org.apache.seata.common.DefaultValues.DEFAULT_RPC_RM_REQUEST_TIMEOUT;
 import static org.apache.seata.common.DefaultValues.DEFAULT_RPC_TC_REQUEST_TIMEOUT;
@@ -97,6 +101,26 @@ public class TransportProperties {
      * use shared event loop group
      */
     private boolean enableClientSharedEventLoop = DEFAULT_ENABLE_CLIENT_USE_SHARED_EVENT_LOOP;
+
+    /**
+     * minimum HTTP pool size
+     */
+    private int minHttpPoolSize = DEFAULT_MIN_HTTP_POOL_SIZE;
+
+    /**
+     * maximum HTTP pool size
+     */
+    private int maxHttpPoolSize = DEFAULT_MAX_HTTP_POOL_SIZE;
+
+    /**
+     * maximum HTTP task queue size
+     */
+    private int maxHttpTaskQueueSize = DEFAULT_MAX_HTTP_TASK_QUEUE_SIZE;
+
+    /**
+     * HTTP pool keep alive time
+     */
+    private int httpPoolKeepAliveTime = DEFAULT_HTTP_POOL_KEEP_ALIVE_TIME;
 
 
     public String getType() {
@@ -217,5 +241,37 @@ public class TransportProperties {
 
     public void setProtocol(String protocol) {
         this.protocol = protocol;
+    }
+
+    public int getMinHttpPoolSize() {
+        return minHttpPoolSize;
+    }
+
+    public void setMinHttpPoolSize(int minHttpPoolSize) {
+        this.minHttpPoolSize = minHttpPoolSize;
+    }
+
+    public int getMaxHttpPoolSize() {
+        return maxHttpPoolSize;
+    }
+
+    public void setMaxHttpPoolSize(int maxHttpPoolSize) {
+        this.maxHttpPoolSize = maxHttpPoolSize;
+    }
+
+    public int getMaxHttpTaskQueueSize() {
+        return maxHttpTaskQueueSize;
+    }
+
+    public void setMaxHttpTaskQueueSize(int maxHttpTaskQueueSize) {
+        this.maxHttpTaskQueueSize = maxHttpTaskQueueSize;
+    }
+
+    public int getHttpPoolKeepAliveTime() {
+        return httpPoolKeepAliveTime;
+    }
+
+    public void setHttpPoolKeepAliveTime(int httpPoolKeepAliveTime) {
+        this.httpPoolKeepAliveTime = httpPoolKeepAliveTime;
     }
 }

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/TransportPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/TransportPropertiesTest.java
@@ -37,6 +37,10 @@ public class TransportPropertiesTest {
         transportProperties.setRpcTmRequestTimeout(1);
         transportProperties.setRpcTcRequestTimeout(1);
         transportProperties.setEnableClientSharedEventLoop(true);
+        transportProperties.setMinHttpPoolSize(20);
+        transportProperties.setMaxHttpPoolSize(200);
+        transportProperties.setMaxHttpTaskQueueSize(2000);
+        transportProperties.setHttpPoolKeepAliveTime(600);
 
         Assertions.assertEquals("server", transportProperties.getServer());
         Assertions.assertEquals("type", transportProperties.getType());
@@ -51,5 +55,9 @@ public class TransportPropertiesTest {
         Assertions.assertEquals(1, transportProperties.getRpcTmRequestTimeout());
         Assertions.assertEquals(1, transportProperties.getRpcTcRequestTimeout());
         Assertions.assertTrue(transportProperties.isEnableClientSharedEventLoop());
+        Assertions.assertEquals(20, transportProperties.getMinHttpPoolSize());
+        Assertions.assertEquals(200, transportProperties.getMaxHttpPoolSize());
+        Assertions.assertEquals(2000, transportProperties.getMaxHttpTaskQueueSize());
+        Assertions.assertEquals(600, transportProperties.getHttpPoolKeepAliveTime());
     }
 }

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -245,6 +245,11 @@ seata:
   transport:
     rpc-tc-request-timeout: 15000
     enable-tc-server-batch-send-response: false
+    # HTTP thread pool
+    min-http-pool-size: 10
+    max-http-pool-size: 100
+    max-http-task-queue-size: 1000
+    http-pool-keep-alive-time: 500
     shutdown:
       wait: 3
     thread-factory:

--- a/server/src/main/resources/application.raft.example.yml
+++ b/server/src/main/resources/application.raft.example.yml
@@ -168,6 +168,11 @@ seata:
   transport:
     rpc-tc-request-timeout: 15000
     enable-tc-server-batch-send-response: false
+    # HTTP thread pool
+    min-http-pool-size: 10
+    max-http-pool-size: 100
+    max-http-task-queue-size: 1000
+    http-pool-keep-alive-time: 500
     shutdown:
       wait: 3
     thread-factory:


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Currently, seata-server uses netty to manage network requests, and HTTP request processing is executed synchronously with the io thread pool of netty itself. At the same time, due to the mechanism of multiple protocols on a single port, blocking may occur under high concurrency.
Therefore, an independent thread pool is added to process HTTP requests for processing of HTTP requests asynchronously. (align seata, grpc protocol asynchronous processing)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
#7405


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

