### PR TITLE
optimize: pmd-check log as ERROR level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,9 @@ jobs:
         run: |
           ./mvnw -T 4C clean test \
                  -Dcheckstyle.skip=false -Dpmd.skip=false -Dlicense.skip=false -DredisCaseEnabled=true \
-                 -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+                 -e -B \
+                 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+                 -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error;
       # step 6.2
       - name: "Test with Maven and Java${{ matrix.java }}"
         if: matrix.java != '8'

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -53,6 +53,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7414](https://github.com/apache/incubator-seata/pull/7414)] Remove the unused defaultEventExecutorGroup from the NettyClientBootstrap
 - [[#7415](https://github.com/apache/incubator-seata/pull/7415)] Use threadPool to asynchronously process server http requests
 - [[#7418](https://github.com/apache/incubator-seata/pull/7418)] add jackson notice
+- [[#7428](https://github.com/apache/incubator-seata/pull/7428)] pmd-check log as ERROR level
 
 
 ### security:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -53,6 +53,7 @@
 - [[#7414](https://github.com/apache/incubator-seata/pull/7414)] 移除 NettyClientBootstrap 中 defaultEventExecutorGroup
 - [[#7415](https://github.com/apache/incubator-seata/pull/7415)] 使用线程池异步处理server http请求
 - [[#7418](https://github.com/apache/incubator-seata/pull/7418)] 添加 jackson notice
+- [[#7428](https://github.com/apache/incubator-seata/pull/7428)] 修改 pmd-check 输出日志为 ERROR 级别
 
 
 ### security:


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
If the build fails, pmd-check will only output logs at the info level, which is difficult to see in the large number of logs generated by the ci build process. 
Therefore, it is changed to the error level and highlighted to make it easier for developers to view

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Based on: https://github.com/apache/incubator-seata/pull/7421#discussion_r2135050547

### Ⅴ. Special notes for reviews

