### PR TITLE
optimize: Template-based LICENSE/NOTICE generation for future module expansion

### DIFF
--- a/distribution/NOTICE-template.ftl
+++ b/distribution/NOTICE-template.ftl
@@ -1,0 +1,43 @@
+<#--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+Apache Seata (incubating)
+Copyright 2019-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+================================================================================
+
+The following dependencies are included in this binary package:
+
+<#if dependencyMap?size == 0>
+No dependencies found.
+<#else>
+<#list dependencyMap as entry>
+<#assign project = entry.getKey()/>
+<#assign licenses = entry.getValue()/>
+    - ${project.name} (${project.groupId}:${project.artifactId}:${project.version})
+<#if licenses?size != 0>
+<#list licenses as license>
+      License: ${license}
+</#list>
+<#else>
+      License: Not specified
+</#if>
+
+</#list>
+</#if> 

--- a/distribution/release-seata.xml
+++ b/distribution/release-seata.xml
@@ -48,14 +48,14 @@
             <includes>
                 <include>licenses/*</include>
             </includes>
-            <outputDirectory>seata-namingserver/</outputDirectory>
+            <outputDirectory>seata-namingserver/licenses/</outputDirectory>
         </fileSet>
 
         <fileSet>
             <includes>
                 <include>licenses/*</include>
             </includes>
-            <outputDirectory>seata-server/</outputDirectory>
+            <outputDirectory>seata-server/licenses/</outputDirectory>
         </fileSet>
 
         <fileSet>
@@ -135,13 +135,13 @@
         </file>
 
         <file>
-            <source>NOTICE</source>
+            <source>licenses/NOTICE-seata-server</source>
             <destName>NOTICE</destName>
             <outputDirectory>seata-server/</outputDirectory>
         </file>
 
         <file>
-            <source>NOTICE</source>
+            <source>licenses/NOTICE-seata-namingserver</source>
             <destName>NOTICE</destName>
             <outputDirectory>seata-namingserver/</outputDirectory>
         </file>

--- a/pom.xml
+++ b/pom.xml
@@ -159,14 +159,14 @@
                                     <includeOptional>false</includeOptional>
                                     <useMissingFile>false</useMissingFile>
                                     <failOnMissing>false</failOnMissing>
+                                    <excludedScopes>test</excludedScopes>
+                                    <thirdPartyFilename>NOTICE-${project.artifactId}</thirdPartyFilename>
+                                    <fileTemplate>${session.executionRootDirectory}/distribution/NOTICE-template.ftl</fileTemplate>
+                                    <outputDirectory>${session.executionRootDirectory}/distribution/licenses</outputDirectory>
                                     <licenseMerges>
-                                        <licenseMerge>Apache License, Version 2.0|The Apache Software License, Version
-                                            2.0|ASF 2.0|Apache 2|Apache-2.0|Apache 2.0 License|Apache 2.0|Apache License v2.0|Apache License 2.0|The Apache License, Version 2.0|The Apache Software License, Version 2.0
-                                        </licenseMerge>
+                                        <licenseMerge>Apache License, Version 2.0|The Apache Software License, Version 2.0|ASF 2.0|Apache 2|Apache-2.0|Apache 2.0 License|Apache License v2.0|Apache License 2.0|The Apache License, Version 2.0</licenseMerge>
                                         <licenseMerge>The MIT License|MIT License</licenseMerge>
-                                        <licenseMerge>The 3-Clause BSD License|New BSD License|3-Clause BSD
-                                            License|BSD|3-Clause BSD License|The New BSD License
-                                        </licenseMerge>
+                                        <licenseMerge>The 3-Clause BSD License|New BSD License|BSD|The New BSD License</licenseMerge>
                                     </licenseMerges>
                                 </configuration>
                             </execution>
@@ -313,6 +313,7 @@
                 </plugins>
             </build>
         </profile>
+
         <!-- profile: spotless -->
         <profile>
             <id>jdk9-jdk11-spotless</id>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
**Current Implementation:**
- Separates LICENSE and NOTICE for `seata-server` and `seata-namingserver`

**Scalable Architecture:**
- **Generic template system**: Uses FreeMarker template that can generate NOTICE files for any module
- **Dynamic naming**: `NOTICE-${project.artifactId}` pattern supports unlimited modules
- **Extensible configuration**: New modules can be easily added by updating the assembly configuration

**Key Changes:**
- **Modified parent pom.xml**: Enhanced `licenseCheck` profile with dynamic file naming
- **Created universal template**: `distribution/NOTICE-template.ftl` works for any module
- **Updated assembly**: Currently configured for server and namingserver, easily extensible

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
Closes #7369 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This change involves build-time license file generation which is better verified through:
1. Manual build verification using: `./mvnw -Prelease-seata,licenseCheck -Dmaven.test.skip=true -Dskip.npm=true -T4C -Dpmd.skip=true clean install -U`
2. Checking the generated binary package structure
3. Integration tests would require complex Maven build lifecycle simulation

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
**Usage for Future Modules:**

To add license separation for a new module (e.g., `seata-console`):

1. **No code changes needed** - the template and Maven configuration are already generic

2. **Update assembly configuration** in `distribution/release-seata.xml`:
   ```xml
   <file>
     <source>${project.basedir}/target/generated-sources/license/NOTICE-seata-console</source>
     <outputDirectory>licenses</outputDirectory>
     <destName>NOTICE-seata-console</destName>
   </file>
   ```
3. **Build with the same command** - the system will automatically:
   - Scan `seata-console` module dependencies
   - Generate `NOTICE-seata-console` using the template
   - Include it in the binary package

