### PR TITLE
optimize: add contribution intention check box to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -27,9 +27,12 @@ body:
   attributes:
     label: Check Ahead
     options:
-    - label: >
-        I have searched the [issues](https://github.com/seata/seata/issues) of this repository and believe that this is not a duplicate.
-      required: true
+      - label: >
+          I have searched the [issues](https://github.com/seata/seata/issues) of this repository and believe that this is not a duplicate.
+        required: true
+      - label: >
+          I am willing to try to fix this bug myself.
+        required: false
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -19,6 +19,17 @@ name: Feature Request
 description: Suggest an idea for Seata
 
 body:
+- type: checkboxes
+  attributes:
+    label: Check Ahead
+    options:
+      - label: >
+          I have searched the [issues](https://github.com/seata/seata/issues) of this repository and believe that this is not a duplicate.
+        required: true
+      - label: >
+          I am willing to try to implement this feature myself.
+        required: false
+
 - type: markdown
   attributes:
     value: |

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -21,6 +21,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### feature:
 
 - [[#7261](https://github.com/apache/incubator-seata/pull/7261)] enforce account initialization and disable default credentials
+- [[#7466](https://github.com/apache/incubator-seata/pull/7466)] add contribution intention check box to issue template
 
 
 ### bugfix:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -21,7 +21,6 @@ Add changes here for all PR submitted to the 2.x branch.
 ### feature:
 
 - [[#7261](https://github.com/apache/incubator-seata/pull/7261)] enforce account initialization and disable default credentials
-- [[#7466](https://github.com/apache/incubator-seata/pull/7466)] add contribution intention check box to issue template
 
 
 ### bugfix:
@@ -63,6 +62,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7426](https://github.com/apache/incubator-seata/pull/7426)] add some license header
 - [[#7450](https://github.com/apache/incubator-seata/pull/7450)] Apply Spotless to the entire codebase
 - [[#7456](https://github.com/apache/incubator-seata/pull/7456)] Druid SQL parser throws ParserException for unsupported REPLACE statement
+- [[#7466](https://github.com/apache/incubator-seata/pull/7466)] add contribution intention check box to issue template
 
 
 ### security:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -21,6 +21,7 @@
 ### feature:
 
 - [[#7261](https://github.com/apache/incubator-seata/pull/7261)] 强制进行账户初始化并禁用默认凭据
+- [[#7466](https://github.com/apache/incubator-seata/pull/7466)] 在 issue 模板中添加贡献意向勾选框
 
 
 ### bugfix:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -21,7 +21,6 @@
 ### feature:
 
 - [[#7261](https://github.com/apache/incubator-seata/pull/7261)] 强制进行账户初始化并禁用默认凭据
-- [[#7466](https://github.com/apache/incubator-seata/pull/7466)] 在 issue 模板中添加贡献意向勾选框
 
 
 ### bugfix:
@@ -62,6 +61,8 @@
 - [[#7426](https://github.com/apache/incubator-seata/pull/7426)] 添加 license header
 - [[#7450](https://github.com/apache/incubator-seata/pull/7450)] 将 Spotless 应用于整个代码库
 - [[#7456](https://github.com/apache/incubator-seata/pull/7456)] Druid SQL 解析器因不支持的 REPLACE 语句而抛出 ParserException
+- [[#7466](https://github.com/apache/incubator-seata/pull/7466)] 在 issue 模板中添加贡献意向勾选框
+
 
 
 ### security:


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
Most issue creators do not have write permissions to assign issues. So, add a confirmation checkbox to the issue template, allowing them to express their willingness to contribute. This helps developers identify which issues are available to be taken.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Go:
https://github.com/YoWuwuuuw/incubator-seata/issues/26
https://github.com/YoWuwuuuw/incubator-seata/issues/25

### Ⅴ. Special notes for reviews

