### PR TITLE
optimize: metrics add retry status

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -62,7 +62,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7426](https://github.com/apache/incubator-seata/pull/7426)] add some license header
 - [[#7450](https://github.com/apache/incubator-seata/pull/7450)] Apply Spotless to the entire codebase
 - [[#7456](https://github.com/apache/incubator-seata/pull/7456)] Druid SQL parser throws ParserException for unsupported REPLACE statement
-
+- [[#7478](https://github.com/apache/incubator-seata/pull/7478)] metrics add retry status
 
 ### security:
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -131,6 +131,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [maple525866](https://github.com/maple525866)
 - [YvCeung](https://github.com/YvCeung)
 - [jsbxyyx](https://github.com/jsbxyyx)
+- [simzyoo](https://github.com/simzyoo)
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -61,7 +61,7 @@
 - [[#7426](https://github.com/apache/incubator-seata/pull/7426)] 添加 license header
 - [[#7450](https://github.com/apache/incubator-seata/pull/7450)] 将 Spotless 应用于整个代码库
 - [[#7456](https://github.com/apache/incubator-seata/pull/7456)] Druid SQL 解析器因不支持的 REPLACE 语句而抛出 ParserException
-
+- [[#7478](https://github.com/apache/incubator-seata/pull/7478)] 增加处于重试状态的数据采集
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -133,6 +133,7 @@
 - [maple525866](https://github.com/maple525866)
 - [YvCeung](https://github.com/YvCeung)
 - [jsbxyyx](https://github.com/jsbxyyx)
+- [simzyoo](https://github.com/simzyoo)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
+++ b/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
@@ -28,7 +28,11 @@ public interface IdConstants {
     String SEATA_RATE_LIMIT = "seata.rate.limit";
 
     String APP_ID_KEY = "applicationId";
-    
+
+    String TRANSACTION_ID_KEY = "transactionId";
+
+    String TRANSACTION_NAME_KEY = "transactionName";
+
     String GROUP_KEY = "group";
 
     String NAME_KEY = "name";
@@ -86,4 +90,12 @@ public interface IdConstants {
     String CLIENT_ID_KEY = "clientId";
 
     String HOST_AND_PORT = "hostAndPort";
+
+    String STATUS_VALUE_COMMIT_RETRYING_KEY = "CommitRetrying";
+
+    String STATUS_VALUE_ROLLBACK_RETRYING_KEY = "RollbackRetrying";
+
+    String STATUS_VALUE_TIMEOUT_ROLLBACK_RETRYING_KEY = "TimeoutRollbackRetrying";
+
+
 }

--- a/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
+++ b/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
@@ -29,8 +29,6 @@ public interface IdConstants {
 
     String APP_ID_KEY = "applicationId";
 
-    String TRANSACTION_ID_KEY = "transactionId";
-
     String TRANSACTION_NAME_KEY = "transactionName";
 
     String GROUP_KEY = "group";

--- a/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
+++ b/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
@@ -97,5 +97,4 @@ public interface IdConstants {
 
     String STATUS_VALUE_TIMEOUT_ROLLBACK_RETRYING_KEY = "TimeoutRollbackRetrying";
 
-
 }

--- a/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
+++ b/metrics/seata-metrics-api/src/main/java/org/apache/seata/metrics/IdConstants.java
@@ -96,5 +96,4 @@ public interface IdConstants {
     String STATUS_VALUE_ROLLBACK_RETRYING_KEY = "RollbackRetrying";
 
     String STATUS_VALUE_TIMEOUT_ROLLBACK_RETRYING_KEY = "TimeoutRollbackRetrying";
-
 }

--- a/server/src/main/java/org/apache/seata/server/metrics/MeterIdConstants.java
+++ b/server/src/main/java/org/apache/seata/server/metrics/MeterIdConstants.java
@@ -120,8 +120,6 @@ public interface MeterIdConstants {
             .withTag(IdConstants.METER_KEY, IdConstants.METER_VALUE_SUMMARY)
             .withTag(IdConstants.STATUS_KEY, IdConstants.STATUS_VALUE_TIMEOUT_ROLLBACK_RETRYING_KEY);
 
-
-
     Id SUMMARY_EXP =  new Id(IdConstants.SEATA_EXCEPTION)
             .withTag(IdConstants.ROLE_KEY, IdConstants.ROLE_VALUE_TC)
             .withTag(IdConstants.METER_KEY, IdConstants.METER_VALUE_SUMMARY);

--- a/server/src/main/java/org/apache/seata/server/metrics/MeterIdConstants.java
+++ b/server/src/main/java/org/apache/seata/server/metrics/MeterIdConstants.java
@@ -105,6 +105,22 @@ public interface MeterIdConstants {
         .withTag(IdConstants.METER_KEY, IdConstants.METER_VALUE_TIMER)
         .withTag(IdConstants.STATUS_KEY, IdConstants.STATUS_VALUE_AFTER_COMMITTED_KEY);
 
+    Id SUMMARY_COMMIT_RETRYING = new Id(IdConstants.SEATA_TRANSACTION)
+            .withTag(IdConstants.ROLE_KEY, IdConstants.ROLE_VALUE_TC)
+            .withTag(IdConstants.METER_KEY, IdConstants.METER_VALUE_SUMMARY)
+            .withTag(IdConstants.STATUS_KEY, IdConstants.STATUS_VALUE_COMMIT_RETRYING_KEY);
+
+    Id SUMMARY_ROLLBACK_RETRYING = new Id(IdConstants.SEATA_TRANSACTION)
+            .withTag(IdConstants.ROLE_KEY, IdConstants.ROLE_VALUE_TC)
+            .withTag(IdConstants.METER_KEY, IdConstants.METER_VALUE_SUMMARY)
+            .withTag(IdConstants.STATUS_KEY, IdConstants.STATUS_VALUE_ROLLBACK_RETRYING_KEY);
+
+    Id SUMMARY_TIMEOUT_ROLLBACK_RETRYING = new Id(IdConstants.SEATA_TRANSACTION)
+            .withTag(IdConstants.ROLE_KEY, IdConstants.ROLE_VALUE_TC)
+            .withTag(IdConstants.METER_KEY, IdConstants.METER_VALUE_SUMMARY)
+            .withTag(IdConstants.STATUS_KEY, IdConstants.STATUS_VALUE_TIMEOUT_ROLLBACK_RETRYING_KEY);
+
+
 
     Id SUMMARY_EXP =  new Id(IdConstants.SEATA_EXCEPTION)
             .withTag(IdConstants.ROLE_KEY, IdConstants.ROLE_VALUE_TC)

--- a/server/src/main/java/org/apache/seata/server/metrics/MetricsSubscriber.java
+++ b/server/src/main/java/org/apache/seata/server/metrics/MetricsSubscriber.java
@@ -101,10 +101,10 @@ public class MetricsSubscriber {
 
     private void increaseSummaryWithDetail(Id summaryId, GlobalTransactionEvent event, long value) {
         registry.getSummary(summaryId
-                .withTag(APP_ID_KEY, event.getApplicationId())
-                .withTag(GROUP_KEY, event.getGroup())
-                .withTag(TRANSACTION_NAME_KEY, event.getName())
-        ).increase(value);
+                        .withTag(APP_ID_KEY, event.getApplicationId())
+                        .withTag(GROUP_KEY, event.getGroup())
+                        .withTag(TRANSACTION_NAME_KEY, event.getName()))
+                .increase(value);
     }
 
     private void increaseTimer(Id timerId, GlobalTransactionEvent event) {

--- a/server/src/main/java/org/apache/seata/server/metrics/MetricsSubscriber.java
+++ b/server/src/main/java/org/apache/seata/server/metrics/MetricsSubscriber.java
@@ -39,6 +39,8 @@ import static org.apache.seata.metrics.IdConstants.LIMIT_TYPE_KEY;
 import static org.apache.seata.metrics.IdConstants.HOST_AND_PORT;
 import static org.apache.seata.metrics.IdConstants.STATUS_VALUE_AFTER_COMMITTED_KEY;
 import static org.apache.seata.metrics.IdConstants.STATUS_VALUE_AFTER_ROLLBACKED_KEY;
+import static org.apache.seata.metrics.IdConstants.TRANSACTION_ID_KEY;
+import static org.apache.seata.metrics.IdConstants.TRANSACTION_NAME_KEY;
 
 /**
  * Event subscriber for metrics
@@ -72,6 +74,11 @@ public class MetricsSubscriber {
 
         consumerMap.put(STATUS_VALUE_AFTER_COMMITTED_KEY, this::processAfterGlobalCommitted);
         consumerMap.put(STATUS_VALUE_AFTER_ROLLBACKED_KEY, this::processAfterGlobalRollbacked);
+
+        consumerMap.put(GlobalStatus.CommitRetrying.name(), this::processGlobalStatusCommitRetrying);
+        consumerMap.put(GlobalStatus.RollbackRetrying.name(), this::processGlobalStatusRollbackRetrying);
+        consumerMap.put(GlobalStatus.TimeoutRollbackRetrying.name(), this::processGlobalStatusTimeoutRollbackRetrying);
+
         return consumerMap;
     }
 
@@ -87,6 +94,15 @@ public class MetricsSubscriber {
     private void increaseSummary(Id summaryId, GlobalTransactionEvent event, long value) {
         registry.getSummary(
             summaryId.withTag(APP_ID_KEY, event.getApplicationId()).withTag(GROUP_KEY, event.getGroup())).increase(value);
+    }
+
+    private void increaseSummaryWithDetail(Id summaryId, GlobalTransactionEvent event, long value) {
+        registry.getSummary(summaryId
+                .withTag(APP_ID_KEY, event.getApplicationId())
+                .withTag(GROUP_KEY, event.getGroup())
+                .withTag(TRANSACTION_ID_KEY, String.valueOf(event.getId()))
+                .withTag(TRANSACTION_NAME_KEY, event.getName())
+        ).increase(value);
     }
 
     private void increaseTimer(Id timerId, GlobalTransactionEvent event) {
@@ -174,6 +190,18 @@ public class MetricsSubscriber {
         increaseSummary(MeterIdConstants.SUMMARY_TWO_PHASE_TIMEOUT, event, 1);
         //The phase 2 retry timeout state should be considered a transaction failed
         reportFailed(event);
+    }
+
+    private void processGlobalStatusCommitRetrying(GlobalTransactionEvent event) {
+        increaseSummaryWithDetail(MeterIdConstants.SUMMARY_COMMIT_RETRYING, event, 1);
+    }
+
+    private void processGlobalStatusRollbackRetrying(GlobalTransactionEvent event) {
+        increaseSummaryWithDetail(MeterIdConstants.SUMMARY_ROLLBACK_RETRYING, event, 1);
+    }
+
+    private void processGlobalStatusTimeoutRollbackRetrying(GlobalTransactionEvent event) {
+        increaseSummaryWithDetail(MeterIdConstants.SUMMARY_TIMEOUT_ROLLBACK_RETRYING, event, 1);
     }
 
     private void reportFailed(GlobalTransactionEvent event) {

--- a/server/src/main/java/org/apache/seata/server/metrics/MetricsSubscriber.java
+++ b/server/src/main/java/org/apache/seata/server/metrics/MetricsSubscriber.java
@@ -39,7 +39,6 @@ import static org.apache.seata.metrics.IdConstants.HOST_AND_PORT;
 import static org.apache.seata.metrics.IdConstants.LIMIT_TYPE_KEY;
 import static org.apache.seata.metrics.IdConstants.STATUS_VALUE_AFTER_COMMITTED_KEY;
 import static org.apache.seata.metrics.IdConstants.STATUS_VALUE_AFTER_ROLLBACKED_KEY;
-import static org.apache.seata.metrics.IdConstants.TRANSACTION_ID_KEY;
 import static org.apache.seata.metrics.IdConstants.TRANSACTION_NAME_KEY;
 
 /**
@@ -104,7 +103,6 @@ public class MetricsSubscriber {
         registry.getSummary(summaryId
                 .withTag(APP_ID_KEY, event.getApplicationId())
                 .withTag(GROUP_KEY, event.getGroup())
-                .withTag(TRANSACTION_ID_KEY, String.valueOf(event.getId()))
                 .withTag(TRANSACTION_NAME_KEY, event.getName())
         ).increase(value);
     }


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

1.Server metrics add global retry statuses, including GlobalStatus.CommitRetrying, GlobalStatus.RollbackRetrying, and GlobalStatus.TimeoutRollbackRetrying.
2.The collected data for the above statuses now includes information on transactionId and transactionName.

### Ⅱ. Does this pull request fix one issue?

fixes https://github.com/apache/incubator-seata/issues/7447


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

