### PR TITLE
feature: add SqlMonitor and SlowSqlEntry for SQL execution monitoring

### DIFF
--- a/common/src/main/java/org/apache/seata/common/monitor/SlowSqlEntry.java
+++ b/common/src/main/java/org/apache/seata/common/monitor/SlowSqlEntry.java
@@ -24,7 +24,6 @@ public class SlowSqlEntry {
     private final long executionTimeMillis;
     private final Instant timestamp;
 
-
     public SlowSqlEntry(String sql, long executionTimeMillis, Instant timestamp) {
         this.sql = sql;
         this.executionTimeMillis = executionTimeMillis;
@@ -34,6 +33,7 @@ public class SlowSqlEntry {
     public String getSql() {
         return sql;
     }
+
     public long getExecutionTimeMillis() {
         return executionTimeMillis;
     }
@@ -42,14 +42,11 @@ public class SlowSqlEntry {
         return timestamp;
     }
 
-
     @Override
     public String toString() {
-        return "SlowSqlEntry{" +
-                "sql='" + sql + '\'' +
-                ", executionTimeMillis=" + executionTimeMillis +
-                ", timestamp=" + timestamp +
-                '}';
+        return "SlowSqlEntry{" + "sql='"
+                + sql + '\'' + ", executionTimeMillis="
+                + executionTimeMillis + ", timestamp="
+                + timestamp + '}';
     }
 }
-

--- a/common/src/main/java/org/apache/seata/common/monitor/SlowSqlEntry.java
+++ b/common/src/main/java/org/apache/seata/common/monitor/SlowSqlEntry.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.monitor;
+
+import java.time.Instant;
+
+public class SlowSqlEntry {
+
+    private final String sql;
+    private final long executionTimeMillis;
+    private final Instant timestamp;
+
+
+    public SlowSqlEntry(String sql, long executionTimeMillis, Instant timestamp) {
+        this.sql = sql;
+        this.executionTimeMillis = executionTimeMillis;
+        this.timestamp = timestamp;
+    }
+
+    public String getSql() {
+        return sql;
+    }
+    public long getExecutionTimeMillis() {
+        return executionTimeMillis;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+
+    @Override
+    public String toString() {
+        return "SlowSqlEntry{" +
+                "sql='" + sql + '\'' +
+                ", executionTimeMillis=" + executionTimeMillis +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}
+

--- a/common/src/main/java/org/apache/seata/common/monitor/SqlMonitor.java
+++ b/common/src/main/java/org/apache/seata/common/monitor/SqlMonitor.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.monitor;
+
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class SqlMonitor {
+
+    private static final SqlMonitor INSTANCE = new SqlMonitor();
+    private volatile long slowThreshold = 1000;
+    private volatile int maxSlowEntries = 50;
+    private final Deque<SlowSqlEntry> slowSqlQueue = new ConcurrentLinkedDeque<>();
+    private final Lock slowLock = new ReentrantLock();
+    private final Map<String, Integer> txnHistogram = new ConcurrentHashMap<>();
+    private final Map<String, Integer> holdHistogram = new ConcurrentHashMap<>();
+
+    private SqlMonitor() {
+    }
+
+    public static SqlMonitor getInstance() {
+        return INSTANCE;
+    }
+
+    public void record(String sql, long execMs, long holdMs) {
+        // slow sql
+        if (execMs > slowThreshold) {
+            slowLock.lock();
+            try {
+                slowSqlQueue.addLast(new SlowSqlEntry(sql, execMs, Instant.now()));
+                if (slowSqlQueue.size() > maxSlowEntries) {
+                    slowSqlQueue.removeFirst();
+                }
+            } finally {
+                slowLock.unlock();
+            }
+        }
+
+        // transaction histogram
+        String bin = chooseTxnBucket(execMs);
+        txnHistogram.merge(bin, 1, Integer::sum);
+
+        // connection hold time histogram
+        String bin2 = chooseHoldBucket(holdMs);
+        holdHistogram.merge(bin2, 1, Integer::sum);
+    }
+
+    /**
+     * Set the execution time threshold for slow SQL.
+     * Intended for use by dynamic configuration (e.g. Nacos or application.yml binding).
+     */
+    public void setSlowThreshold(long threshold) {
+        this.slowThreshold = threshold;
+    }
+
+    /**
+     * Set the max entries for slow SQL
+     * Intended for use by dunamic configuration (e.g. Nacos or application.yml binding)
+     */
+    public void setMaxSlowEntries(int maxEntries) {
+        this.maxSlowEntries = maxEntries;
+    }
+
+
+    public List<SlowSqlEntry> getSlowSqlList() {
+        return new ArrayList<>(slowSqlQueue);
+    }
+
+    public Map<String, Integer> getTxnHistogram() {
+        return new LinkedHashMap<>(txnHistogram);
+    }
+
+    public Map<String, Integer> getHoldHistogram() {
+        return new LinkedHashMap<>(holdHistogram);
+    }
+
+
+    private String chooseTxnBucket(long ms) {
+        if (ms <= 50) {
+            return "0-50ms";
+        } else if (ms <= 200) {
+            return "50-200ms";
+        } else if (ms <= 500) {
+            return "200-500ms";
+        } else if (ms <= 1000) {
+            return "500ms-1s";
+        } else if (ms <= 3000) {
+            return "1s-3s";
+        } else {
+            return "3s+";
+        }
+    }
+
+
+    private String chooseHoldBucket(long ms) {
+        if (ms <= 50) {
+            return "0-50ms";
+        } else if (ms <= 200) {
+            return "50-200ms";
+        } else if (ms <= 500) {
+            return "200-500ms";
+        } else if (ms <= 1000) {
+            return "500ms-1s";
+        } else {
+            return "1s+";
+        }
+    }
+
+    /**
+     * Reset all internal states, only for testing purpose.
+     */
+    public void resetForTest() {
+        slowLock.lock();
+        try {
+            slowSqlQueue.clear();
+        } finally {
+            slowLock.unlock();
+        }
+        txnHistogram.clear();
+        holdHistogram.clear();
+    }
+}
+

--- a/common/src/main/java/org/apache/seata/common/monitor/SqlMonitor.java
+++ b/common/src/main/java/org/apache/seata/common/monitor/SqlMonitor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.common.monitor;
 
-
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,8 +33,7 @@ public class SqlMonitor {
     private final Map<String, Integer> txnHistogram = new ConcurrentHashMap<>();
     private final Map<String, Integer> holdHistogram = new ConcurrentHashMap<>();
 
-    private SqlMonitor() {
-    }
+    private SqlMonitor() {}
 
     public static SqlMonitor getInstance() {
         return INSTANCE;
@@ -80,7 +78,6 @@ public class SqlMonitor {
         this.maxSlowEntries = maxEntries;
     }
 
-
     public List<SlowSqlEntry> getSlowSqlList() {
         return new ArrayList<>(slowSqlQueue);
     }
@@ -92,7 +89,6 @@ public class SqlMonitor {
     public Map<String, Integer> getHoldHistogram() {
         return new LinkedHashMap<>(holdHistogram);
     }
-
 
     private String chooseTxnBucket(long ms) {
         if (ms <= 50) {
@@ -109,7 +105,6 @@ public class SqlMonitor {
             return "3s+";
         }
     }
-
 
     private String chooseHoldBucket(long ms) {
         if (ms <= 50) {
@@ -139,4 +134,3 @@ public class SqlMonitor {
         holdHistogram.clear();
     }
 }
-

--- a/common/src/test/java/org/apache/seata/common/monitor/SqlMonitorTest.java
+++ b/common/src/test/java/org/apache/seata/common/monitor/SqlMonitorTest.java
@@ -19,7 +19,6 @@ package org.apache.seata.common.monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -73,12 +72,9 @@ public class SqlMonitorTest {
                     slowSqlList.stream()
                             .map(SlowSqlEntry::getSql)
                             .anyMatch(sql -> sql.equals("SELECT * FROM orders WHERE id = " + finalI)),
-                    "Entry with id = " + finalI + " should have been evicted"
-            );
-
+                    "Entry with id = " + finalI + " should have been evicted");
         }
     }
-
 
     @Test
     public void testRecordForFastSql() {

--- a/common/src/test/java/org/apache/seata/common/monitor/SqlMonitorTest.java
+++ b/common/src/test/java/org/apache/seata/common/monitor/SqlMonitorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.monitor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SqlMonitorTest {
+    private SqlMonitor monitor;
+
+    @BeforeEach
+    public void setUp() {
+        monitor = SqlMonitor.getInstance();
+        monitor.resetForTest();
+    }
+
+    @Test
+    public void testRecordSlowSqlEntry() {
+        monitor.record("SELECT * FROM users", 1500, 100);
+        List<SlowSqlEntry> slowSqlList = monitor.getSlowSqlList();
+        assertEquals(1, slowSqlList.size());
+        SlowSqlEntry entry = slowSqlList.get(0);
+        assertEquals("SELECT * FROM users", entry.getSql());
+        assertTrue(entry.getExecutionTimeMillis() >= 1500);
+    }
+
+    @Test
+    public void testRecordMultiSlowEntry() {
+        monitor.record("SELECT * FROM student", 1200, 100);
+        monitor.record("SELECT * FROM school", 1300, 100);
+        List<SlowSqlEntry> slowSqlList = monitor.getSlowSqlList();
+        assertEquals(2, slowSqlList.size());
+        SlowSqlEntry entry1 = slowSqlList.get(0);
+        SlowSqlEntry entry2 = slowSqlList.get(1);
+        assertEquals("SELECT * FROM student", entry1.getSql());
+        assertEquals("SELECT * FROM school", entry2.getSql());
+    }
+
+    @Test
+    public void testMaxSlowSqlQueueSize() {
+        // maxSlowEntries = 50 by default
+        for (int i = 0; i < 55; i++) {
+            monitor.record("SELECT * FROM orders WHERE id = " + i, 1500, 200);
+        }
+
+        List<SlowSqlEntry> slowSqlList = monitor.getSlowSqlList();
+        assertEquals(50, slowSqlList.size());
+
+        // Should not contain the first 5 entries
+        for (int i = 0; i < 5; i++) {
+            int finalI = i;
+            assertFalse(
+                    slowSqlList.stream()
+                            .map(SlowSqlEntry::getSql)
+                            .anyMatch(sql -> sql.equals("SELECT * FROM orders WHERE id = " + finalI)),
+                    "Entry with id = " + finalI + " should have been evicted"
+            );
+
+        }
+    }
+
+
+    @Test
+    public void testRecordForFastSql() {
+        monitor.record("SELECT 1", 100, 50);
+        List<SlowSqlEntry> slowSqlList = monitor.getSlowSqlList();
+        assertTrue(slowSqlList.isEmpty());
+    }
+
+    @Test
+    public void testTxnHistogramBuckets() {
+        monitor.record("SELECT * FROM t1", 30, 0);
+        monitor.record("SELECT * FROM t2", 150, 0);
+        monitor.record("SELECT * FROM t3", 300, 0);
+        monitor.record("SELECT * FROM t4", 800, 0);
+        monitor.record("SELECT * FROM t5", 2000, 0);
+        monitor.record("SELECT * FROM t6", 4000, 0);
+
+        Map<String, Integer> histogram = monitor.getTxnHistogram();
+        assertEquals(1, histogram.get("0-50ms"));
+        assertEquals(1, histogram.get("50-200ms"));
+        assertEquals(1, histogram.get("200-500ms"));
+        assertEquals(1, histogram.get("500ms-1s"));
+        assertEquals(1, histogram.get("1s-3s"));
+        assertEquals(1, histogram.get("3s+"));
+    }
+
+    @Test
+    public void testHoldHistogramBuckets() {
+        monitor.record("SELECT * FROM hold1", 0, 30);
+        monitor.record("SELECT * FROM hold2", 0, 150);
+        monitor.record("SELECT * FROM hold3", 0, 300);
+        monitor.record("SELECT * FROM hold4", 0, 800);
+        monitor.record("SELECT * FROM hold5", 0, 2000);
+
+        Map<String, Integer> histogram = monitor.getHoldHistogram();
+        assertEquals(1, histogram.get("0-50ms"));
+        assertEquals(1, histogram.get("50-200ms"));
+        assertEquals(1, histogram.get("200-500ms"));
+        assertEquals(1, histogram.get("500ms-1s"));
+        assertEquals(1, histogram.get("1s+"));
+    }
+}


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
This PR introduces a new SQL monitoring utility to the `seata-common` module:

- `SqlMonitor`: a singleton class for collecting SQL execution statistics.
  - Tracks slow SQL (execution time > threshold), up to `maxSlowEntries`
  - Maintains histogram of transaction execution time
  - Maintains histogram of connection hold time
  - Thread-safe using concurrent data structures and explicit locking
  - Includes setters `setSlowThreshold()` and `setMaxSlowEntries()` for future dynamic configuration
- `SlowSqlEntry`: a simple immutable model class holding slow SQL info (text, exec time, timestamp)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
No. This is a new feature and the first step in the SQL monitoring implementation plan.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Test cases are included:
- `SqlMonitorTest.java` covers:
  - Slow SQL recording and eviction behavior
  - Histogram bucket logic for transaction/hold times
  - Fast SQL skip logic
  - Queue size trimming

### Ⅳ. Describe how to verify it
- Run `SqlMonitorTest` with JUnit 
- Verify correctness of slow SQL detection, histogram aggregation, and bounded queue behavior

### Ⅴ. Special notes for reviews
- This is **PR 1/3** in the SQL monitoring feature set
- Follow-up PRs will integrate this utility with `seata-rm-datasource` (recording) and `seata-server` (metrics exposure)
- Configuration injection will be addressed later via `application.yml` or dynamic configuration center
