### PR TITLE
bugfix: prevent Netty I/O thread blocking by async channel release via reconnectExecutor

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -26,6 +26,8 @@ Add changes here for all PR submitted to the 2.x branch.
 ### bugfix:
 
 - [[#7546](https://github.com/seata/seata/pull/7546)] fix client spring version compatible
+- [[#7505](https://github.com/apache/incubator-seata/pull/7505)] prevent Netty I/O thread blocking by async channel release via reconnectExecutor
+
 
 ### optimize:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -26,6 +26,8 @@
 ### bugfix:
 
 - [[#7546](https://github.com/seata/seata/pull/7546)] 修复客户端spring版本兼容
+- [[#7505](https://github.com/apache/incubator-seata/pull/7505)] 通过使用 reconnectExecutor 异步释放 channel，防止阻塞 Netty I/O 线程
+
 
 
 ### optimize:


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

Fixes a potential Netty I/O thread blocking issue by executing `releaseChannel()` asynchronously via a dedicated `reconnectExecutor` thread pool.

Also ensures proper shutdown of `reconnectExecutor` to avoid thread leaks.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #7497


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
- Naming conventions (`rpcReconnectExecutor`) aligned with existing merge thread patterns.
- `reconnectExecutor` is now managed with proper init and destroy lifecycle hooks.
