### PR TITLE
optimize: avoid using unstable API in ChannelEventHandlerIntegrationTest

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -71,7 +71,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7478](https://github.com/apache/incubator-seata/pull/7478)] metrics add retry status
 - [[#7483](https://github.com/apache/incubator-seata/pull/7483)] change the value of retryDeadThreshold to 70 seconds
 - [[#7488](https://github.com/apache/incubator-seata/pull/7488)] upgrade tomcat to 9.0.106
-- [[#7514](https://github.com/apache/incubator-seata/pull/7514)] avoid using unstable API in ChannelEventHandlerIntegrationTest
+- [[#7518](https://github.com/apache/incubator-seata/pull/7518)] avoid using unstable API in ChannelEventHandlerIntegrationTest
 
 ### security:
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -71,6 +71,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7478](https://github.com/apache/incubator-seata/pull/7478)] metrics add retry status
 - [[#7483](https://github.com/apache/incubator-seata/pull/7483)] change the value of retryDeadThreshold to 70 seconds
 - [[#7488](https://github.com/apache/incubator-seata/pull/7488)] upgrade tomcat to 9.0.106
+- [[#7514](https://github.com/apache/incubator-seata/pull/7514)] avoid using unstable API in ChannelEventHandlerIntegrationTest
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -69,6 +69,7 @@
 - [[#7466](https://github.com/apache/incubator-seata/pull/7466)] 在 issue 模板中添加贡献意向勾选框
 - [[#7478](https://github.com/apache/incubator-seata/pull/7478)] 增加处于重试状态的数据采集
 - [[#7483](https://github.com/apache/incubator-seata/pull/7483)] 将retryDeadThreshold改为70秒
+- [[#7514](https://github.com/apache/incubator-seata/pull/7514)] 避免在 ChannelEventHandlerIntegrationTest 中使用不稳定的 API
 
 
 ### security:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -69,7 +69,7 @@
 - [[#7466](https://github.com/apache/incubator-seata/pull/7466)] 在 issue 模板中添加贡献意向勾选框
 - [[#7478](https://github.com/apache/incubator-seata/pull/7478)] 增加处于重试状态的数据采集
 - [[#7483](https://github.com/apache/incubator-seata/pull/7483)] 将retryDeadThreshold改为70秒
-- [[#7514](https://github.com/apache/incubator-seata/pull/7514)] 避免在 ChannelEventHandlerIntegrationTest 中使用不稳定的 API
+- [[#7518](https://github.com/apache/incubator-seata/pull/7518)] 避免在 ChannelEventHandlerIntegrationTest 中使用不稳定的 API
 
 
 ### security:


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
After my research on the error, I found that it cannot be compiled on macOS 14, and the error "cannot find symbol: method registeredChannelsIterator()" is reported. The main reason is that the unstable API (@UnstableApi) in netty is used, specifically eventLoop.registeredChannelsIterator() in collectServerChannels.

My solution:
Avoid using unstable APIs, remove the original collectServerChannels, and refactor the testChannelInactiveByServer() method.

Results:

The code should be able to compile normally on macOS
All event handling of ChannelEventHandler is tested
The test logic is simplified, cross-platform compatibility is improved, and each test method does not affect each other

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7510 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
mvn clean test

### Ⅴ. Special notes for reviews

