### PR TITLE
optimize: avoid using unstable API in ChannelEventHandlerIntegrationTest

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -71,6 +71,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7478](https://github.com/apache/incubator-seata/pull/7478)] metrics add retry status
 - [[#7483](https://github.com/apache/incubator-seata/pull/7483)] change the value of retryDeadThreshold to 70 seconds
 - [[#7488](https://github.com/apache/incubator-seata/pull/7488)] upgrade tomcat to 9.0.106
+- [[#7518](https://github.com/apache/incubator-seata/pull/7518)] avoid using unstable API in ChannelEventHandlerIntegrationTest
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -69,6 +69,7 @@
 - [[#7466](https://github.com/apache/incubator-seata/pull/7466)] 在 issue 模板中添加贡献意向勾选框
 - [[#7478](https://github.com/apache/incubator-seata/pull/7478)] 增加处于重试状态的数据采集
 - [[#7483](https://github.com/apache/incubator-seata/pull/7483)] 将retryDeadThreshold改为70秒
+- [[#7518](https://github.com/apache/incubator-seata/pull/7518)] 避免在 ChannelEventHandlerIntegrationTest 中使用不稳定的 API
 
 
 ### security:


### PR DESCRIPTION

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

optimize: avoid using unstable API in ChannelEventHandlerIntegrationTest

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

