### PR TITLE
Replace `mockito-inline` with `mockito-core`

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -135,8 +135,7 @@
         <tomcat-embed.version>9.0.106</tomcat-embed.version>
 
         <!-- # for test -->
-        <mockito.version>4.11.0</mockito.version>
-        <mockito-inline.version>4.11.0</mockito-inline.version>
+        <mockito.version>5.18.0</mockito.version>
         <assertj-core.version>3.12.2</assertj-core.version>
         <janino-version>3.1.10</janino-version>
         <mockwebserver-version>4.12.0</mockwebserver-version>
@@ -840,17 +839,6 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>${mockito-inline.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.mockito</groupId>
-                        <artifactId>mockito-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -92,11 +92,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

Replace mockito-inline with mockito-core

In version 5.x mockito switched their default mockmaker to mockito-inline ([source](https://github.com/mockito/mockito/releases/tag/v5.0.0)).
The corresponding artifact became obsolete and can be replaced with mockito-core

This PR replaces / removes the artifact and switches on mockito-core which in turn allows upgrading to latest 5.18.0.

### Ⅱ. Does this pull request fix one issue?

Enables upgrading mockito.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

Does not apply

### Ⅳ. Describe how to verify it

Build locally without issues

### Ⅴ. Special notes for reviews

