### PR TITLE
feature: add SQL monitoring and connection pool abstraction with implementation and tests

### DIFF
--- a/common/src/main/java/org/apache/seata/common/monitor/SqlExecutionEntry.java
+++ b/common/src/main/java/org/apache/seata/common/monitor/SqlExecutionEntry.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.monitor;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public class SqlExecutionEntry {
+
+    private final String sql;
+    private final long executionTimeMillis;
+    private final long holdTimeMillis;
+    private final Instant timestamp;
+
+    public SqlExecutionEntry(String sql, long executionTimeMillis, long holdTimeMillis, Instant timestamp) {
+        this.sql = sql;
+        this.executionTimeMillis = executionTimeMillis;
+        this.holdTimeMillis = holdTimeMillis;
+        this.timestamp = timestamp;
+    }
+
+    public String getSql() {
+        return sql;
+    }
+
+    public long getExecutionTimeMillis() {
+        return executionTimeMillis;
+    }
+    public long getHoldTimeMillis() {
+        return holdTimeMillis;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "SlowSqlEntry{" +
+                "sql='" + sql + '\'' +
+                ", executionTimeMillis=" + executionTimeMillis +
+                ", holdTimeMillis=" + holdTimeMillis +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SqlExecutionEntry entry = (SqlExecutionEntry) o;
+        return executionTimeMillis == entry.executionTimeMillis && holdTimeMillis == entry.holdTimeMillis && Objects.equals(sql, entry.sql) && Objects.equals(timestamp, entry.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sql, executionTimeMillis, holdTimeMillis, timestamp);
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/monitor/SqlMonitor.java
+++ b/common/src/main/java/org/apache/seata/common/monitor/SqlMonitor.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.monitor;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class SqlMonitor {
+
+    private static final SqlMonitor INSTANCE = new SqlMonitor();
+    private volatile long slowThreshold = 1000;
+    private volatile int maxSlowEntries = 100;
+    private volatile int maxAllRecord = 1000;
+    private final Deque<SqlExecutionEntry> slowSqlQueue = new ConcurrentLinkedDeque<>();
+    private final Deque<SqlExecutionEntry> allRecord = new ConcurrentLinkedDeque<>();
+    private final Lock slowLock = new ReentrantLock();
+    private final Lock recordLock = new ReentrantLock();
+
+    private SqlMonitor() {
+    }
+
+    public static SqlMonitor getInstance() {
+        return INSTANCE;
+    }
+
+    public void record(String sql, long execMs, long holdMs) {
+        Instant now = Instant.now();
+        SqlExecutionEntry entry = new SqlExecutionEntry(sql, execMs, holdMs, now);
+
+        recordLock.lock();
+        // record all SQL executions for histogram
+        try {
+            allRecord.addLast(entry);
+            while (allRecord.size() > maxAllRecord) {
+                allRecord.removeFirst();
+            }
+        } finally {
+            recordLock.unlock();
+        }
+
+        // record the slow sql
+        if (execMs > slowThreshold) {
+            slowLock.lock();
+            try {
+                slowSqlQueue.addLast(entry);
+                while (slowSqlQueue.size() > maxSlowEntries) {
+                    slowSqlQueue.removeFirst();
+                }
+            } finally {
+                slowLock.unlock();
+            }
+        }
+    }
+
+    public List<SqlExecutionEntry> getSlowSqlList() {
+        slowLock.lock();
+        try {
+            return new ArrayList<>(slowSqlQueue);
+        } finally {
+            slowLock.unlock();
+        }
+    }
+
+    public List<SqlExecutionEntry> getAllRecords() {
+        recordLock.lock();
+        try {
+            return new ArrayList<>(allRecord);
+        } finally {
+            recordLock.unlock();
+        }
+    }
+
+    public void clearOldRecords(Instant beforeTime) {
+        recordLock.lock();
+        try {
+            allRecord.removeIf(record -> record.getTimestamp().isBefore(beforeTime));
+        } finally {
+            recordLock.unlock();
+        }
+
+        slowLock.lock();
+        try {
+            slowSqlQueue.removeIf(entry -> entry.getTimestamp().isBefore(beforeTime));
+        } finally {
+            slowLock.unlock();
+        }
+    }
+
+
+    /**
+     * Set the execution time threshold for slow SQL.
+     * Intended for use by dynamic configuration (e.g. Nacos or application.yml binding).
+     */
+    public void setSlowThreshold(long threshold) {
+        this.slowThreshold = threshold;
+    }
+
+    /**
+     * Set the max entries for slow SQL
+     * Intended for use by dunamic configuration (e.g. Nacos or application.yml binding)
+     */
+    public void setMaxSlowEntries(int maxEntries) {
+        this.maxSlowEntries = maxEntries;
+    }
+
+    public long getSlowThreshold() {
+        return slowThreshold;
+    }
+
+    public int getMaxSlowEntries() {
+        return maxSlowEntries;
+    }
+
+    public int getMaxAllRecord() {
+        return maxAllRecord;
+    }
+
+    public int getSlowSqlCount() {
+        return slowSqlQueue.size();
+    }
+
+    public int getAllRecordCount() {
+        return allRecord.size();
+    }
+
+
+    /**
+     * Reset all internal states, only for testing purpose.
+     */
+    public void resetForTest() {
+        slowLock.lock();
+        try {
+            slowSqlQueue.clear();
+        } finally {
+            slowLock.unlock();
+        }
+
+        recordLock.lock();
+        try {
+            allRecord.clear();
+        } finally {
+            recordLock.unlock();
+        }
+    }
+
+
+}

--- a/common/src/main/java/org/apache/seata/common/pool/ConnectionPoolConfig.java
+++ b/common/src/main/java/org/apache/seata/common/pool/ConnectionPoolConfig.java
@@ -32,6 +32,8 @@ public class ConnectionPoolConfig {
     private long maxLifeTime;
     private long keepaliveTime;
 
+    public ConnectionPoolConfig() {}
+
     private ConnectionPoolConfig(Builder builder) {
         this.serviceName = builder.serviceName;
         this.maxPoolSize = builder.maxPoolSize;

--- a/common/src/main/java/org/apache/seata/common/pool/ConnectionPoolConfig.java
+++ b/common/src/main/java/org/apache/seata/common/pool/ConnectionPoolConfig.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.pool;
+
+public class ConnectionPoolConfig {
+    private final String serviceName;
+
+    // General field
+    private int maxPoolSize;
+    private int minIdle;
+    private int connectionTimeout;
+
+    // field for Druid
+    private long timeBetweenEvictionRunsMills;
+    private long maxEvictableTimeMills;
+
+    // field for HikariCP
+    private long maxLifeTime;
+    private long keepaliveTime;
+
+    private ConnectionPoolConfig(Builder builder) {
+        this.serviceName = builder.serviceName;
+        this.maxPoolSize = builder.maxPoolSize;
+        this.minIdle = builder.minIdle;
+        this.connectionTimeout = builder.connectionTimeout;
+        this.timeBetweenEvictionRunsMills = builder.timeBetweenEvictionRunsMills;
+        this.maxEvictableTimeMills = builder.maxEvictableTimeMills;
+        this.maxLifeTime = builder.maxLifeTime;
+        this.keepaliveTime = builder.keepaliveTime;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String serviceName;
+        private int maxPoolSize;
+        private int minIdle;
+        private int connectionTimeout;
+        private long timeBetweenEvictionRunsMills;
+        private long maxEvictableTimeMills;
+        private long maxLifeTime;
+        private long keepaliveTime;
+
+        public Builder serviceName(String val) {
+            this.serviceName = val;
+            return this;
+        }
+
+        public Builder maxPoolSize(int val) {
+            this.maxPoolSize = val;
+            return this;
+        }
+
+        public Builder minIdle(int val) {
+            this.minIdle = val;
+            return this;
+        }
+
+        public Builder connectionTimeout(int val) {
+            this.connectionTimeout = val;
+            return this;
+        }
+
+        public Builder timeBetweenEvictionRunsMills(long val) {
+            this.timeBetweenEvictionRunsMills = val;
+            return this;
+        }
+
+        public Builder maxEvictableTimeMills(long val) {
+            this.maxEvictableTimeMills = val;
+            return this;
+        }
+
+        public Builder maxLifeTime(long val) {
+            this.maxLifeTime = val;
+            return this;
+        }
+
+        public Builder keepaliveTime(long val) {
+            this.keepaliveTime = val;
+            return this;
+        }
+
+        public ConnectionPoolConfig build() {
+            return new ConnectionPoolConfig(this);
+        }
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public int getMinIdle() {
+        return minIdle;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public long getTimeBetweenEvictionRunsMills() {
+        return timeBetweenEvictionRunsMills;
+    }
+
+
+    public long getMaxEvictableTimeMills() {
+        return maxEvictableTimeMills;
+    }
+
+
+    public long getMaxLifeTime() {
+        return maxLifeTime;
+    }
+
+    public long getKeepaliveTime() {
+        return keepaliveTime;
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/pool/ConnectionPoolMetrics.java
+++ b/common/src/main/java/org/apache/seata/common/pool/ConnectionPoolMetrics.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.pool;
+
+import org.apache.seata.common.monitor.SqlExecutionEntry;
+
+import java.util.List;
+
+public class ConnectionPoolMetrics {
+    private String serviceName;
+
+    // common filed (supported by both Druid & HikariCP)
+    private int activeConnections;
+    private int idleConnections;
+    private int totalConnections;
+    private int maxPoolSize;
+    private int minIdle;
+    private int waitThreadCount;
+    private int connectionTimeout;
+    private long validationTimeout;
+    private boolean autoCommit;
+    private long idleTimeout;
+
+    // Druid specific fields
+    private long executeCount;
+    private long errorCount;
+    private long commitCount;
+    private long rollbackCount;
+    private long logicConnectCount;
+    private List<SqlExecutionEntry> slowSqlList;
+    private List<SqlExecutionEntry> sqlExecutionRecord;
+    private long[] transactionHistogramValues;
+    private long[] transactionHistogramRanges;
+
+    // HikariCP specific fields
+    private long connectionAcquiredNanos; // optional: reserved for Micrometer
+    private double connectionTimeoutRate; // reserved for Micrometer
+    private long leakDetectionThreshold;
+    private String poolName;
+    private long timestamp;
+
+    public ConnectionPoolMetrics() {
+    }
+
+    private ConnectionPoolMetrics(Builder builder) {
+        this.serviceName = builder.serviceName;
+        this.activeConnections = builder.activeConnections;
+        this.idleConnections = builder.idleConnections;
+        this.totalConnections = builder.totalConnections;
+        this.maxPoolSize = builder.maxPoolSize;
+        this.minIdle = builder.minIdle;
+        this.waitThreadCount = builder.waitThreadCount;
+        this.connectionTimeout = builder.connectionTimeout;
+        this.validationTimeout = builder.validationTimeout;
+        this.autoCommit = builder.autoCommit;
+        this.idleTimeout = builder.idleTimeout;
+        this.executeCount = builder.executeCount;
+        this.errorCount = builder.errorCount;
+        this.commitCount = builder.commitCount;
+        this.rollbackCount = builder.rollbackCount;
+        this.logicConnectCount = builder.logicConnectCount;
+        this.slowSqlList = builder.slowSqlList;
+        this.sqlExecutionRecord = builder.sqlExecutionRecord;
+        this.transactionHistogramValues = builder.transactionHistogramValues;
+        this.transactionHistogramRanges = builder.transactionHistogramRanges;
+        this.connectionAcquiredNanos = builder.connectionAcquiredNanos;
+        this.connectionTimeoutRate = builder.connectionTimeoutRate;
+        this.leakDetectionThreshold = builder.leakDetectionThreshold;
+        this.poolName = builder.poolName;
+        this.timestamp = builder.timestamp;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String serviceName;
+        private int activeConnections;
+        private int idleConnections;
+        private int totalConnections;
+        private int maxPoolSize;
+        private int minIdle;
+        private int waitThreadCount;
+        private int connectionTimeout; // unit: ms
+        private long validationTimeout; // unit: ms
+        private boolean autoCommit;
+        private long idleTimeout;
+
+        private long executeCount;
+        private long errorCount;
+        private long commitCount;
+        private long rollbackCount;
+        private long logicConnectCount;
+        private List<SqlExecutionEntry> slowSqlList;
+        private List<SqlExecutionEntry> sqlExecutionRecord;
+        private long[] transactionHistogramValues;
+        private long[] transactionHistogramRanges;
+
+        private long connectionAcquiredNanos;
+        private double connectionTimeoutRate;
+        private long leakDetectionThreshold;
+        private String poolName;
+        private long timestamp;
+
+
+        public Builder serviceName(String val) {
+            this.serviceName = val;
+            return this;
+        }
+
+        public Builder activeConnections(int val) {
+            this.activeConnections = val;
+            return this;
+        }
+
+        public Builder idleConnections(int val) {
+            this.idleConnections = val;
+            return this;
+        }
+
+        public Builder totalConnections(int val) {
+            this.totalConnections = val;
+            return this;
+        }
+
+        public Builder maxPoolSize(int val) {
+            this.maxPoolSize = val;
+            return this;
+        }
+
+        public Builder minIdle(int val) {
+            this.minIdle = val;
+            return this;
+        }
+
+        public Builder waitThreadCount(int val) {
+            this.waitThreadCount = val;
+            return this;
+        }
+
+        public Builder connectionTimeout(int val) {
+            this.connectionTimeout = val;
+            return this;
+        }
+
+        public Builder validationTimeout(long val) {
+            this.validationTimeout = val;
+            return this;
+        }
+
+        public Builder autoCommit(boolean val) {
+            this.autoCommit = val;
+            return this;
+        }
+
+        public Builder idleTimeout(long val) {
+            this.idleTimeout = val;
+            return this;
+        }
+
+        public Builder executeCount(long val) {
+            this.executeCount = val;
+            return this;
+        }
+
+        public Builder errorCount(long val) {
+            this.errorCount = val;
+            return this;
+        }
+
+        public Builder commitCount(long val) {
+            this.commitCount = val;
+            return this;
+        }
+
+        public Builder rollbackCount(long val) {
+            this.rollbackCount = val;
+            return this;
+        }
+
+        public Builder logicConnectCount(long val) {
+            this.logicConnectCount = val;
+            return this;
+        }
+
+        public Builder slowSqlList(List<SqlExecutionEntry> val) {
+            this.slowSqlList = val;
+            return this;
+        }
+
+        public Builder sqlExecutionRecords(List<SqlExecutionEntry> val) {
+            this.sqlExecutionRecord = val;
+            return this;
+        }
+
+        public Builder transactionHistogramValues(long[] val) {
+            this.transactionHistogramValues = val;
+            return this;
+        }
+
+        public Builder transactionHistogramRanges(long[] val) {
+            this.transactionHistogramRanges = val;
+            return this;
+        }
+
+        public Builder connectionAcquiredNanos(long val) {
+            this.connectionAcquiredNanos = val;
+            return this;
+        }
+
+        public Builder connectionTimeoutRate(double val) {
+            this.connectionTimeoutRate = val;
+            return this;
+        }
+
+        public Builder leakDetectionThreshold(long val) {
+            this.leakDetectionThreshold = val;
+            return this;
+        }
+
+        public Builder poolName(String val) {
+            this.poolName = val;
+            return this;
+        }
+
+        public Builder timestamp(long val) {
+            this.timestamp = val;
+            return this;
+        }
+
+        public ConnectionPoolMetrics build() {
+            return new ConnectionPoolMetrics(this);
+        }
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+
+    public int getActiveConnections() {
+        return activeConnections;
+    }
+
+    public int getIdleConnections() {
+        return idleConnections;
+    }
+
+    public int getTotalConnections() {
+        return totalConnections;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public int getMinIdle() {
+        return minIdle;
+    }
+
+    public int getWaitThreadCount() {
+        return waitThreadCount;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public long getValidationTimeout() {
+        return validationTimeout;
+    }
+
+    public boolean isAutoCommit() {
+        return autoCommit;
+    }
+
+    public long getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public long getExecuteCount() {
+        return executeCount;
+    }
+
+    public long getErrorCount() {
+        return errorCount;
+    }
+
+    public long getCommitCount() {
+        return commitCount;
+    }
+
+    public long getRollbackCount() {
+        return rollbackCount;
+    }
+
+    public long getLogicConnectCount() {
+        return logicConnectCount;
+    }
+
+    public List<SqlExecutionEntry> getSlowSqlList() {
+        return slowSqlList;
+    }
+    public List<SqlExecutionEntry> getSqlExecutionRecord() {
+        return sqlExecutionRecord;
+    }
+
+    public long[] getTransactionHistogramValues() {
+        return transactionHistogramValues;
+    }
+
+    public long[] getTransactionHistogramRanges() {
+        return transactionHistogramRanges;
+    }
+
+
+    public long getConnectionAcquiredNanos() {
+        return connectionAcquiredNanos;
+    }
+
+    public double getConnectionTimeoutRate() {
+        return connectionTimeoutRate;
+    }
+
+    public long getLeakDetectionThreshold() {
+        return leakDetectionThreshold;
+    }
+
+    public String getPoolName() {
+        return poolName;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/pool/PoolManager.java
+++ b/common/src/main/java/org/apache/seata/common/pool/PoolManager.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.pool;
+
+import org.apache.seata.common.pool.ConnectionPoolConfig;
+import org.apache.seata.common.pool.ConnectionPoolMetrics;
+
+public interface PoolManager {
+    ConnectionPoolMetrics getMetric();
+
+    ConnectionPoolConfig getConfig();
+
+    void updateConfig(ConnectionPoolConfig cfg);
+}

--- a/common/src/main/java/org/apache/seata/common/pool/PoolManagerRegistry.java
+++ b/common/src/main/java/org/apache/seata/common/pool/PoolManagerRegistry.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.pool;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Static registry for managing all PoolManager instances
+ */
+public class PoolManagerRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PoolManagerRegistry.class);
+    private static final Map<String, PoolManager> REGISTRY = new ConcurrentHashMap<>();
+
+
+    public static void register(String serviceName, PoolManager poolManager) {
+        if (serviceName == null || poolManager == null) {
+            LOGGER.warn("Cannot register null serviceName or poolManager");
+            return;
+        }
+
+        PoolManager existing = REGISTRY.put(serviceName, poolManager);
+        if (existing != null) {
+            LOGGER.warn("PoolManager for service {} has been replaced", serviceName);
+        } else {
+            LOGGER.info("PoolManager for service {} has been registered", serviceName);
+        }
+    }
+
+
+    /**
+     * Unregister a PoolManager for a given service
+     */
+    public static void unregister(String serviceName) {
+        if (serviceName == null) {
+            return;
+        }
+
+        PoolManager removed = REGISTRY.remove(serviceName);
+        if (removed != null) {
+            LOGGER.info("PoolManager for service {} has been unregistered", serviceName);
+        }
+    }
+
+    /**
+     * Get a PoolManager for a given service
+     *
+     * @param serviceName the service name
+     * @return the pool manager or null if not found
+     */
+    public static PoolManager get(String serviceName) {
+        return serviceName == null ? null : REGISTRY.get(serviceName);
+    }
+
+    /**
+     * Get all registered service names
+     *
+     * @return collection of service names
+     */
+    public static Collection<String> getAllServiceNames() {
+        return new ArrayList<>(REGISTRY.keySet());
+    }
+
+    /**
+     * Get all registered PoolManagers
+     *
+     * @return collection of pool managers
+     */
+    public static Collection<PoolManager> getAllPoolManagers() {
+        return new ArrayList<>(REGISTRY.values());
+    }
+
+    /**
+     * Check if a service is registered
+     *
+     * @param serviceName the service name
+     * @return true if registered, false otherwise
+     */
+    public static boolean isRegistered(String serviceName) {
+        return serviceName != null && REGISTRY.containsKey(serviceName);
+    }
+
+    /**
+     * Get the number of registered services
+     *
+     * @return the count of registered services
+     */
+    public static int size() {
+        return REGISTRY.size();
+    }
+
+    /**
+     * Clear all registrations
+     */
+    public static void clear() {
+        REGISTRY.clear();
+        LOGGER.info("All PoolManagers have been cleared");
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/monitor/SqlMonitorTest.java
+++ b/common/src/test/java/org/apache/seata/common/monitor/SqlMonitorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.monitor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SqlMonitorTest {
+    private SqlMonitor monitor;
+
+    @BeforeEach
+    public void setUp() {
+        monitor = SqlMonitor.getInstance();
+        monitor.resetForTest();
+        monitor.setSlowThreshold(1000);
+        monitor.setMaxSlowEntries(100);
+    }
+
+    @Test
+    public void recordSlowSql_goesToBothQueues() {
+        monitor.record("SELECT * FROM users", 1500, 10);
+        List<SqlExecutionEntry> slow = monitor.getSlowSqlList();
+        List<SqlExecutionEntry> all = monitor.getAllRecords();
+
+        assertEquals(1, slow.size());
+        assertEquals(1, all.size());
+
+        SqlExecutionEntry e = slow.get(0);
+        assertEquals("SELECT * FROM users", e.getSql());
+        assertTrue(e.getExecutionTimeMillis() >= 1500);
+        assertEquals(e, all.get(0));
+    }
+
+    @Test
+    public void recordFastSql_onlyInAllRecords() {
+        monitor.record("SELECT * FROM student", 100, 5);
+        assertTrue(monitor.getSlowSqlList().isEmpty());
+        assertEquals(1, monitor.getAllRecordCount());
+        assertEquals("SELECT * FROM student", monitor.getAllRecords().get(0).getSql());
+    }
+
+    @Test
+    public void slowQueueOverCapacity() {
+        // decrease the capacity for test
+        monitor.setMaxSlowEntries(5);
+        for (int i = 0; i < 7; i++) {
+            monitor.record("SLOW " + i, 2000, 10);
+        }
+
+        List<SqlExecutionEntry> slow = monitor.getSlowSqlList();
+        assertEquals(5, slow.size());
+
+        // Should not contain the first 2 entries
+        for (int i = 0; i < 2; i++) {
+            String sql = "SLOW " + i;
+            assertFalse(slow.stream().anyMatch(e -> e.getSql().equals(sql)),
+                    "Entry " + sql + " should have been evicted");
+        }
+
+        for (int i = 2; i < 7; i++) {
+            String sql = "SLOW " + i;
+            assertTrue(slow.stream().anyMatch(e -> e.getSql().equals(sql)),
+                    "Entry " + sql + " should remain");
+        }
+    }
+
+    @Test
+    public void allRecordOverCapacity() {
+        int cap = monitor.getMaxAllRecord();
+
+        // all set to fast SQL
+        for (int i = 0; i < cap + 3; i++) {
+            monitor.record("SQL " + i, 10, 1);
+        }
+
+        assertEquals(cap, monitor.getAllRecordCount());
+
+        List<SqlExecutionEntry> all = monitor.getAllRecords();
+
+        for (int i = 0; i < 3; i++) {
+            String sql = "SQL " + i;
+            assertFalse(all.stream().anyMatch(e -> e.getSql().equals(sql)),
+                    "Entry " + sql + " should have been evicted from allRecord");
+        }
+    }
+
+
+    @Test
+    public void clearOldRecords_removeBeforeGivenTime() throws InterruptedException {
+        monitor.record("old slow", 2000, 1);
+        monitor.record("old fast", 10, 1);
+
+        Thread.sleep(5);
+        Instant cutoff = Instant.now();
+        monitor.record("new slow", 2000, 1);
+        monitor.record("new fast", 10, 1);
+
+        monitor.clearOldRecords(cutoff);
+        assertEquals(1, monitor.getSlowSqlCount());
+        assertEquals("new slow", monitor.getSlowSqlList().get(0).getSql());
+
+        assertEquals(2, monitor.getAllRecordCount());
+        assertTrue(monitor.getAllRecords().stream().anyMatch(e -> e.getSql().equals("new slow")));
+        assertTrue(monitor.getAllRecords().stream().anyMatch(e -> e.getSql().equals("new fast")));
+    }
+
+
+
+    @Test
+    public void gettersReturnInternalState() {
+        monitor.record("A", 2000, 1);
+        monitor.record("B", 10, 1);
+        assertEquals(1, monitor.getSlowSqlCount());
+        assertEquals(2, monitor.getAllRecordCount());
+        assertEquals(1000, monitor.getMaxAllRecord());
+        assertEquals(100,  monitor.getMaxSlowEntries());
+        assertEquals(1000L, monitor.getSlowThreshold());
+    }
+}

--- a/rm-datasource/pom.xml
+++ b/rm-datasource/pom.xml
@@ -134,6 +134,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <optional>true</optional>

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/pool/PoolManagerFactory.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/pool/PoolManagerFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.pool;
+
+import org.apache.seata.common.pool.PoolManager;
+import org.apache.seata.rm.datasource.SeataDataSourceProxy;
+
+import java.sql.SQLException;
+
+// Factory class to create appropriate PoolManager based on the type of DataSource.
+public class PoolManagerFactory {
+
+    private static final String HIKARI_CLASS_NAME = "com.zaxxer.hikari.HikariDataSource";
+    private static final String DRUID_CLASS_NAME = "com.alibaba.druid.pool.DruidDataSource";
+
+    public static PoolManager create(SeataDataSourceProxy proxy, String serviceName) {
+        try {
+            Class<?> hikariClass = Class.forName(HIKARI_CLASS_NAME);
+            Object hikariDs = proxy.unwrap(hikariClass);
+            if (hikariClass.isInstance(hikariDs)) {
+                return new ReflectionHikariPoolManager(proxy, serviceName);
+            }
+        } catch (ClassNotFoundException ignored) {
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to unwrap HikariDataSource from proxy: " +
+                    proxy.getTargetDataSource().getClass().getName(), e);
+        }
+
+        try {
+            Class<?> druidClass = Class.forName(DRUID_CLASS_NAME);
+            Object druidDs = proxy.unwrap(druidClass);
+            if (druidClass.isInstance(druidDs)) {
+                return new ReflectionDruidPoolManager(proxy, serviceName);
+            }
+        } catch (ClassNotFoundException ignored) {
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to unwrap DruidDataSource from proxy: " +
+                    proxy.getTargetDataSource().getClass().getName(), e);
+        }
+
+        throw new IllegalArgumentException("No supported connection pool implementation found on proxy: " +
+                proxy.getTargetDataSource().getClass().getName());
+    }
+}

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/pool/ReflectionDruidPoolManager.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/pool/ReflectionDruidPoolManager.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.pool;
+
+
+import org.apache.seata.common.monitor.SqlExecutionEntry;
+import org.apache.seata.common.monitor.SqlMonitor;
+import org.apache.seata.common.pool.ConnectionPoolConfig;
+import org.apache.seata.common.pool.ConnectionPoolMetrics;
+import org.apache.seata.common.pool.PoolManager;
+import org.apache.seata.rm.datasource.SeataDataSourceProxy;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.List;
+
+public class ReflectionDruidPoolManager implements PoolManager {
+
+    private final Object dataSource;  // actual DruidDataSource
+    private final String serviceName;
+
+    public ReflectionDruidPoolManager(SeataDataSourceProxy proxy, String serviceName) {
+        this.serviceName = serviceName;
+        try {
+            Class<?> dsClass = Class.forName("com.alibaba.druid.pool.DruidDataSource");
+            Method unwrap = proxy.getClass().getMethod("unwrap", Class.class);
+            Object ds = unwrap.invoke(proxy, dsClass);
+            if (ds == null) {
+                throw new IllegalArgumentException(
+                        "DruidPoolManager requires a DruidDataSource wrapped by Seata proxy");
+            }
+            this.dataSource = ds;
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Druid is not on the classpath", e);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to initialize Druid reflection", e);
+        }
+    }
+
+    @Override
+    public ConnectionPoolMetrics getMetric() {
+        try {
+            Class<?> dsClass = dataSource.getClass();
+
+            // Collect slow SQL entries and all SQL entries
+            List<SqlExecutionEntry> slowSqlList = SqlMonitor.getInstance().getSlowSqlList();
+            List<SqlExecutionEntry> allSqlRecords = SqlMonitor.getInstance().getAllRecords();
+
+            int active = ((Number) dsClass.getMethod("getActiveCount").invoke(dataSource)).intValue();
+            int idle = ((Number) dsClass.getMethod("getPoolingCount").invoke(dataSource)).intValue();
+            int total = active + idle;
+            int maxPool = ((Number) dsClass.getMethod("getMaxActive").invoke(dataSource)).intValue();
+            int minIdle = ((Number) dsClass.getMethod("getMinIdle").invoke(dataSource)).intValue();
+            int waiting = ((Number) dsClass.getMethod("getNotEmptyWaitThreadCount").invoke(dataSource)).intValue();
+            int connTimeout = ((Number) dsClass.getMethod("getMaxWait").invoke(dataSource)).intValue();
+            long validationQueryT = ((Number) dsClass.getMethod("getValidationQueryTimeout").invoke(dataSource)).longValue();
+            long validationTimeout = validationQueryT * 1000L;
+            long idleTimeout = ((Number) dsClass.getMethod("getMaxEvictableIdleTimeMillis").invoke(dataSource)).longValue();
+            boolean autoCommit = (boolean) dsClass.getMethod("isDefaultAutoCommit").invoke(dataSource);
+            int executeCount = ((Number) dsClass.getMethod("getExecuteCount").invoke(dataSource)).intValue();
+            int errorCount = ((Number) dsClass.getMethod("getErrorCount").invoke(dataSource)).intValue();
+            int commitCount = ((Number) dsClass.getMethod("getCommitCount").invoke(dataSource)).intValue();
+            int rollbackCount = ((Number) dsClass.getMethod("getRollbackCount").invoke(dataSource)).intValue();
+            int logicConnectCount = ((Number) dsClass.getMethod("getConnectCount").invoke(dataSource)).intValue();
+            long[] transactionHistogramValues = (long[]) dsClass.getMethod("getTransactionHistogramValues").invoke(dataSource);
+            long[] transactionHistogramRanges = (long[]) dsClass.getMethod("getTransactionHistogramRanges").invoke(dataSource);
+
+
+            return ConnectionPoolMetrics.builder()
+                    .serviceName(serviceName)
+                    .timestamp(Instant.now().toEpochMilli())
+                    .activeConnections(active)
+                    .idleConnections(idle)
+                    .totalConnections(total)
+                    .maxPoolSize(maxPool)
+                    .minIdle(minIdle)
+                    .waitThreadCount(waiting)
+                    .connectionTimeout(connTimeout)
+                    .validationTimeout(validationTimeout)
+                    .idleTimeout(idleTimeout)
+                    .autoCommit(autoCommit)
+                    .executeCount(executeCount)
+                    .errorCount(errorCount)
+                    .commitCount(commitCount)
+                    .rollbackCount(rollbackCount)
+                    .logicConnectCount(logicConnectCount)
+                    .transactionHistogramValues(transactionHistogramValues)
+                    .transactionHistogramRanges(transactionHistogramRanges)
+                    .slowSqlList(slowSqlList)
+                    .sqlExecutionRecords(allSqlRecords)
+                    .build();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read Druid metrics via reflection", e);
+        }
+    }
+
+    @Override
+    public ConnectionPoolConfig getConfig() {
+        try {
+            Class<?> dsClass = dataSource.getClass();
+
+            int maxPool = ((Number) dsClass.getMethod("getMaxActive").invoke(dataSource)).intValue();
+            int minIdle = ((Number) dsClass.getMethod("getMinIdle").invoke(dataSource)).intValue();
+            int connTimeout = ((Number) dsClass.getMethod("getConnectTimeout")
+                    .invoke(dataSource)).intValue();
+            long evictionRun = ((Number) dsClass.getMethod("getTimeBetweenEvictionRunsMillis")
+                    .invoke(dataSource)).longValue();
+            long maxEvictable = ((Number) dsClass.getMethod("getMaxEvictableIdleTimeMillis")
+                    .invoke(dataSource)).longValue();
+
+            return ConnectionPoolConfig.builder()
+                    .serviceName(serviceName)
+                    .maxPoolSize(maxPool)
+                    .minIdle(minIdle)
+                    .connectionTimeout(connTimeout)
+                    .timeBetweenEvictionRunsMills(evictionRun)
+                    .maxEvictableTimeMills(maxEvictable)
+                    .build();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read Druid config via reflection", e);
+        }
+    }
+
+    @Override
+    public void updateConfig(ConnectionPoolConfig cfg) {
+        try {
+            Class<?> dsClass = dataSource.getClass();
+            dsClass.getMethod("setMaxActive", int.class)
+                    .invoke(dataSource, cfg.getMaxPoolSize());
+            dsClass.getMethod("setMinIdle", int.class)
+                    .invoke(dataSource, cfg.getMinIdle());
+            dsClass.getMethod("setConnectTimeout", int.class)
+                    .invoke(dataSource, cfg.getConnectionTimeout());
+            dsClass.getMethod("setTimeBetweenEvictionRunsMillis", long.class)
+                    .invoke(dataSource, cfg.getTimeBetweenEvictionRunsMills());
+            dsClass.getMethod("setMaxEvictableIdleTimeMillis", long.class)
+                    .invoke(dataSource, cfg.getMaxEvictableTimeMills());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to update Druid config via reflection", e);
+        }
+    }
+}

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/pool/ReflectionHikariPoolManager.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/pool/ReflectionHikariPoolManager.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.pool;
+
+import org.apache.seata.common.pool.ConnectionPoolConfig;
+import org.apache.seata.common.pool.ConnectionPoolMetrics;
+import org.apache.seata.common.pool.PoolManager;
+import org.apache.seata.rm.datasource.SeataDataSourceProxy;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.time.Instant;
+
+public class ReflectionHikariPoolManager implements PoolManager {
+
+    private final Object dataSource; //actual HikariDataSource
+    private final Object poolMXBean;
+    private final String serviceName;
+
+    public ReflectionHikariPoolManager(SeataDataSourceProxy proxy, String serviceName) {
+        this.serviceName = serviceName;
+        try {
+            Class<?> dsClass = Class.forName("com.zaxxer.hikari.HikariDataSource");
+            Method unwrap = proxy.getClass().getMethod("unwrap", Class.class);
+            Object ds = unwrap.invoke(proxy, dsClass);
+            if (ds == null) {
+                throw new IllegalArgumentException(
+                        "HikariPoolManager requires a HikariDataSource wrapped by Seata proxy");
+            }
+            this.dataSource = ds;
+            Method getMx = dsClass.getMethod("getHikariPoolMXBean");
+            this.poolMXBean = getMx.invoke(ds);
+
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("HikariCP is not on the classpath", e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof SQLException) {
+                throw new IllegalStateException("Failed to unwrap HikariDataSource", cause);
+            }
+            throw new IllegalStateException("Failed to initialize Hikari reflection", e);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to initialize Hikari reflection", e);
+        }
+    }
+
+    @Override
+    public ConnectionPoolMetrics getMetric() {
+        try {
+            Class<?> mxClass = poolMXBean.getClass();
+            int active = ((Number) mxClass
+                    .getMethod("getActiveConnections")
+                    .invoke(poolMXBean))
+                    .intValue();
+
+            int idle = ((Number) mxClass
+                    .getMethod("getIdleConnections")
+                    .invoke(poolMXBean))
+                    .intValue();
+
+            int total = ((Number) mxClass
+                    .getMethod("getTotalConnections")
+                    .invoke(poolMXBean))
+                    .intValue();
+
+            int waiting = ((Number) mxClass
+                    .getMethod("getThreadsAwaitingConnection")
+                    .invoke(poolMXBean))
+                    .intValue();
+
+            Number maxPoolN = (Number) dataSource.getClass()
+                    .getMethod("getMaximumPoolSize")
+                    .invoke(dataSource);
+            int maxPool = maxPoolN.intValue();
+
+            Number minIdleN = (Number) dataSource.getClass()
+                    .getMethod("getMinimumIdle")
+                    .invoke(dataSource);
+            int minIdle = minIdleN.intValue();
+
+            int connTimeout = ((Number) dataSource.getClass()
+                    .getMethod("getConnectionTimeout")
+                    .invoke(dataSource))
+                    .intValue();
+
+            long validationTimeout = ((Number) dataSource.getClass()
+                    .getMethod("getValidationTimeout")
+                    .invoke(dataSource))
+                    .longValue();
+
+            long idleTimeout = ((Number) dataSource.getClass()
+                    .getMethod("getIdleTimeout")
+                    .invoke(dataSource))
+                    .longValue();
+
+            boolean autoCommit = (Boolean) dataSource.getClass()
+                    .getMethod("isAutoCommit")
+                    .invoke(dataSource);
+
+            long leakDetectionThreshold = ((Number) dataSource.getClass()
+                    .getMethod("getLeakDetectionThreshold")
+                    .invoke(dataSource))
+                    .longValue();
+
+            String poolName = (String) dataSource.getClass()
+                    .getMethod("getPoolName")
+                    .invoke(dataSource);
+
+            return ConnectionPoolMetrics.builder()
+                    .serviceName(serviceName)
+                    .timestamp(Instant.now().toEpochMilli())
+                    .poolName(poolName)
+                    .activeConnections(active)
+                    .idleConnections(idle)
+                    .totalConnections(total)
+                    .maxPoolSize(maxPool)
+                    .minIdle(minIdle)
+                    .waitThreadCount(waiting)
+                    .connectionTimeout(connTimeout)
+                    .validationTimeout(validationTimeout)
+                    .idleTimeout(idleTimeout)
+                    .autoCommit(autoCommit)
+                    .leakDetectionThreshold(leakDetectionThreshold)
+                    .build();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read Hikari metrics via reflection", e);
+        }
+    }
+
+    @Override
+    public ConnectionPoolConfig getConfig() {
+        try {
+            Class<?> dsClass = dataSource.getClass();
+
+            int maxPool = ((Number) dsClass
+                    .getMethod("getMaximumPoolSize")
+                    .invoke(dataSource))
+                    .intValue();
+
+            int minIdle = ((Number) dsClass
+                    .getMethod("getMinimumIdle")
+                    .invoke(dataSource))
+                    .intValue();
+
+            int connectionTimeout = ((Number) dsClass
+                    .getMethod("getConnectionTimeout")
+                    .invoke(dataSource))
+                    .intValue();
+
+            long maxLifetime = ((Number) dsClass
+                    .getMethod("getMaxLifetime")
+                    .invoke(dataSource))
+                    .longValue();
+
+            Number keepaliveN;
+            try {
+                keepaliveN = (Number) dsClass
+                        .getMethod("getKeepaliveTime")
+                        .invoke(dataSource);
+            } catch (NoSuchMethodException e) {
+                keepaliveN = 0L;
+            }
+            long keepaliveTime = keepaliveN.longValue();
+
+
+            return ConnectionPoolConfig.builder()
+                    .maxPoolSize(maxPool)
+                    .minIdle(minIdle)
+                    .connectionTimeout(connectionTimeout)
+                    .maxLifeTime(maxLifetime)
+                    .keepaliveTime(keepaliveTime)
+                    .build();
+
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to reflectively read Hikari config", e);
+        }
+    }
+
+    @Override
+    public void updateConfig(ConnectionPoolConfig cfg) {
+        try {
+            Class<?> dsClass = dataSource.getClass();
+
+            // maxPoolSize
+            dsClass
+                    .getMethod("setMaximumPoolSize", int.class)
+                    .invoke(dataSource, cfg.getMaxPoolSize());
+
+            // minIdle
+            dsClass
+                    .getMethod("setMinimumIdle", int.class)
+                    .invoke(dataSource, cfg.getMinIdle());
+
+            // connectionTimeout
+            dsClass
+                    .getMethod("setConnectionTimeout", long.class)
+                    .invoke(dataSource, cfg.getConnectionTimeout());
+
+            // maxLifetime
+            dsClass
+                    .getMethod("setMaxLifetime", long.class)
+                    .invoke(dataSource, cfg.getMaxLifeTime());
+
+            try {
+                dsClass
+                        .getMethod("setKeepaliveTime", long.class)
+                        .invoke(dataSource, cfg.getKeepaliveTime());
+            } catch (NoSuchMethodException ignored) {
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to reflectively update Hikari config", e);
+        }
+    }
+}

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/pool/PoolManagerFactoryTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/pool/PoolManagerFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.pool;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.seata.common.pool.PoolManager;
+import org.apache.seata.rm.datasource.SeataDataSourceProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PoolManagerFactoryTest {
+
+    private SeataDataSourceProxy proxy;
+
+    @BeforeEach
+    void setUp() {
+        proxy = mock(SeataDataSourceProxy.class);
+    }
+
+    @Test
+    void createReturnsHikariPoolManagerWhenProxyWrapsHikari() throws SQLException {
+        HikariDataSource hikari = mock(HikariDataSource.class);
+        when(proxy.unwrap(HikariDataSource.class)).thenReturn(hikari);
+
+        PoolManager mgr = PoolManagerFactory.create(proxy, "svc-h");
+        assertInstanceOf(ReflectionHikariPoolManager.class, mgr);
+
+        verify(proxy, times(2)).unwrap(HikariDataSource.class);
+        verify(proxy, never()).unwrap(DruidDataSource.class);
+    }
+
+    @Test
+    void createReturnsDruidPoolManagerWhenProxyWrapsDruid() throws SQLException {
+        DruidDataSource druid = new DruidDataSource();
+        when(proxy.unwrap(HikariDataSource.class)).thenReturn(null);
+        when(proxy.unwrap(DruidDataSource.class)).thenReturn(druid);
+
+        PoolManager mgr = PoolManagerFactory.create(proxy, "svc-d");
+        assertInstanceOf(ReflectionDruidPoolManager.class, mgr);
+
+        verify(proxy, times(1)).unwrap(HikariDataSource.class);
+        verify(proxy, times(2)).unwrap(DruidDataSource.class);
+    }
+
+    @Test
+    void createThrowsWhenUnsupported() throws SQLException {
+        when(proxy.unwrap(HikariDataSource.class)).thenReturn(null);
+        when(proxy.unwrap(DruidDataSource.class)).thenReturn(null);
+        DataSource unsupported = mock(DruidDataSource.class);
+        when(proxy.getTargetDataSource()).thenReturn(unsupported);
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> PoolManagerFactory.create(proxy, "svc-none"));
+        String msg = ex.getMessage();
+        assertTrue(msg.contains("No supported connection pool"));
+        assertTrue(msg.contains(unsupported.getClass().getName()));
+    }
+}

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/pool/ReflectionDruidPoolManagerTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/pool/ReflectionDruidPoolManagerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.pool;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import org.apache.seata.common.monitor.SqlExecutionEntry;
+import org.apache.seata.common.monitor.SqlMonitor;
+import org.apache.seata.common.pool.ConnectionPoolConfig;
+import org.apache.seata.common.pool.ConnectionPoolMetrics;
+import org.apache.seata.rm.datasource.SeataDataSourceProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ReflectionDruidPoolManagerTest {
+
+    private DruidDataSource ds;
+    private SeataDataSourceProxy proxy;
+    private ReflectionDruidPoolManager mgr;
+
+    @BeforeEach
+    public void setUp() throws SQLException {
+        proxy = mock(SeataDataSourceProxy.class);
+        ds = mock(DruidDataSource.class);
+        when(proxy.unwrap(DruidDataSource.class)).thenReturn(ds);
+        SqlMonitor.getInstance().resetForTest();
+        SqlMonitor.getInstance().record("slow-sql", 2000, 5);
+        SqlMonitor.getInstance().record("fast-sql", 100, 5);
+
+        when(ds.getActiveCount()).thenReturn(5);
+        when(ds.getPoolingCount()).thenReturn(3);
+        when(ds.getMaxActive()).thenReturn(20);
+        when(ds.getMinIdle()).thenReturn(2);
+        when(ds.getNotEmptyWaitThreadCount()).thenReturn(1);
+        when(ds.getMaxWait()).thenReturn(500L);
+        when(ds.getValidationQueryTimeout()).thenReturn(2);
+        when(ds.getMaxEvictableIdleTimeMillis()).thenReturn(1000L);
+        when(ds.isDefaultAutoCommit()).thenReturn(false);
+        when(ds.getExecuteCount()).thenReturn(10L);
+        when(ds.getErrorCount()).thenReturn(1L);
+        when(ds.getCommitCount()).thenReturn(2L);
+        when(ds.getRollbackCount()).thenReturn(3L);
+        when(ds.getConnectCount()).thenReturn(4L);
+        when(ds.getTransactionHistogramValues()).thenReturn(new long[]{1, 2, 3});
+        when(ds.getTransactionHistogramRanges()).thenReturn(new long[]{10, 20, 30});
+
+        mgr = new ReflectionDruidPoolManager(proxy, "svc-A");
+    }
+
+    @Test
+    public void testUnwrapNull() throws SQLException {
+        when(proxy.unwrap(DruidDataSource.class)).thenReturn(null);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new ReflectionDruidPoolManager(proxy, "svc-A")
+        );
+
+        assertTrue(ex.getMessage().contains("requires a DruidDataSource"));
+    }
+
+    @Test
+    public void testGetMetric() {
+        ConnectionPoolMetrics m = mgr.getMetric();
+
+        List<SqlExecutionEntry> slow = m.getSlowSqlList();
+        assertEquals(1, slow.size());
+        assertEquals("slow-sql", slow.get(0).getSql());
+
+        List<SqlExecutionEntry> all = m.getSqlExecutionRecord();
+        assertEquals(2, all.size());
+
+        assertEquals(5, m.getActiveConnections());
+        assertEquals(3, m.getIdleConnections());
+        assertEquals(8, m.getTotalConnections());
+        assertEquals(20, m.getMaxPoolSize());
+        assertEquals(2, m.getMinIdle());
+        assertEquals(1, m.getWaitThreadCount());
+        assertEquals(500, m.getConnectionTimeout());
+        assertEquals(2 * 1000, m.getValidationTimeout());
+        assertEquals(1000L, m.getIdleTimeout());
+        assertFalse(m.isAutoCommit());
+
+        assertEquals(10L, m.getExecuteCount());
+        assertEquals(1L, m.getErrorCount());
+        assertEquals(2L, m.getCommitCount());
+        assertEquals(3L, m.getRollbackCount());
+        assertEquals(4L, m.getLogicConnectCount());
+
+        assertArrayEquals(new long[]{1, 2, 3}, m.getTransactionHistogramValues());
+        assertArrayEquals(new long[]{10, 20, 30}, m.getTransactionHistogramRanges());
+        assertTrue(m.getTimestamp() > 0L);
+    }
+
+    @Test
+    public void testGetConfig() {
+        when(ds.getConnectTimeout()).thenReturn(700);
+        when(ds.getTimeBetweenEvictionRunsMillis()).thenReturn(800L);
+        when(ds.getMaxEvictableIdleTimeMillis()).thenReturn(900L);
+        when(ds.getMaxActive()).thenReturn(20);
+        when(ds.getMinIdle()).thenReturn(2);
+
+
+        ConnectionPoolConfig cfg = mgr.getConfig();
+        assertEquals("svc-A", cfg.getServiceName());
+        assertEquals(20, cfg.getMaxPoolSize());
+        assertEquals(2, cfg.getMinIdle());
+        assertEquals(700, cfg.getConnectionTimeout());
+        assertEquals(800L, cfg.getTimeBetweenEvictionRunsMills());
+        assertEquals(900L, cfg.getMaxEvictableTimeMills());
+    }
+
+    @Test
+    public void testUpdateConfig() {
+        ConnectionPoolConfig newCfg = ConnectionPoolConfig.builder()
+                .serviceName("svc-A")
+                .maxPoolSize(30)
+                .minIdle(3)
+                .connectionTimeout(400)
+                .timeBetweenEvictionRunsMills(500L)
+                .maxEvictableTimeMills(600L)
+                .build();
+
+        mgr.updateConfig(newCfg);
+
+        verify(ds).setMaxActive(30);
+        verify(ds).setMinIdle(3);
+        verify(ds).setConnectTimeout(400);
+        verify(ds).setTimeBetweenEvictionRunsMillis(500L);
+        verify(ds).setMaxEvictableIdleTimeMillis(600L);
+    }
+}

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/pool/ReflectionHikariPoolManagerTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/pool/ReflectionHikariPoolManagerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.pool;
+
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import org.apache.seata.common.pool.ConnectionPoolConfig;
+import org.apache.seata.common.pool.ConnectionPoolMetrics;
+import org.apache.seata.rm.datasource.SeataDataSourceProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Test for ReflectionHikariPoolManager
+ */
+public class ReflectionHikariPoolManagerTest {
+
+    private HikariDataSource ds;
+    private HikariPoolMXBean mxBean;
+    private SeataDataSourceProxy proxy;
+    private ReflectionHikariPoolManager mgr;
+
+    @BeforeEach
+    public void setUp() throws SQLException {
+        proxy = mock(SeataDataSourceProxy.class);
+        ds = mock(HikariDataSource.class);
+        when(proxy.unwrap(HikariDataSource.class)).thenReturn(ds);
+
+        mxBean = mock(HikariPoolMXBean.class);
+        when(ds.getHikariPoolMXBean()).thenReturn(mxBean);
+        when(mxBean.getActiveConnections()).thenReturn(2);
+        when(mxBean.getIdleConnections()).thenReturn(3);
+        when(mxBean.getTotalConnections()).thenReturn(5);
+        when(mxBean.getThreadsAwaitingConnection()).thenReturn(1);
+        when(ds.getMaximumPoolSize()).thenReturn(10);
+        when(ds.getMinimumIdle()).thenReturn(1);
+        when(ds.getConnectionTimeout()).thenReturn(1000L);
+        when(ds.getValidationTimeout()).thenReturn(2000L);
+        when(ds.getIdleTimeout()).thenReturn(3000L);
+        when(ds.isAutoCommit()).thenReturn(true);
+        when(ds.getLeakDetectionThreshold()).thenReturn(4000L);
+        when(ds.getPoolName()).thenReturn("pool1");
+
+        mgr = new ReflectionHikariPoolManager(proxy, "svcName");
+    }
+
+    @Test
+    public void testWhenUnwrapReturnNull() throws SQLException {
+        when(proxy.unwrap(HikariDataSource.class)).thenReturn(null);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new ReflectionHikariPoolManager(proxy, "svc")
+        );
+        assertTrue(ex.getMessage().contains("requires a HikariDataSource"));
+    }
+
+
+    @Test
+    public void testGetMetrics() {
+        ConnectionPoolMetrics m = mgr.getMetric();
+
+        assertEquals("svcName", m.getServiceName());
+        assertEquals("pool1", m.getPoolName());
+        assertEquals(2, m.getActiveConnections());
+        assertEquals(3, m.getIdleConnections());
+        assertEquals(5, m.getTotalConnections());
+        assertEquals(1, m.getWaitThreadCount());
+        assertEquals(10, m.getMaxPoolSize());
+        assertEquals(1, m.getMinIdle());
+        assertEquals(1000L, m.getConnectionTimeout());
+        assertEquals(2000L, m.getValidationTimeout());
+        assertEquals(3000L, m.getIdleTimeout());
+        assertTrue(m.isAutoCommit());
+        assertEquals(4000L, m.getLeakDetectionThreshold());
+        assertTrue(m.getTimestamp() > 0L, "timestamp should be set");
+    }
+
+    @Test
+    public void testGetConfig() {
+        when(ds.getMaxLifetime()).thenReturn(5000L);
+        when(ds.getKeepaliveTime()).thenReturn(6000L);
+
+        ConnectionPoolConfig cfg = mgr.getConfig();
+        assertEquals(10, cfg.getMaxPoolSize());
+        assertEquals(1, cfg.getMinIdle());
+        assertEquals(1000L, cfg.getConnectionTimeout());
+        assertEquals(5000L, cfg.getMaxLifeTime());
+        assertEquals(6000L, cfg.getKeepaliveTime());
+    }
+
+    @Test
+    public void testUpdateConfig() {
+        // Create new config
+        ConnectionPoolConfig newConfig = ConnectionPoolConfig.builder()
+                .maxPoolSize(20)
+                .minIdle(5)
+                .connectionTimeout(1100)
+                .maxLifeTime(5200L)
+                .keepaliveTime(6200L)
+                .build();
+
+        mgr.updateConfig(newConfig);
+
+        // Verify changes
+        verify(ds).setMaximumPoolSize(20);
+        verify(ds).setMinimumIdle(5);
+        verify(ds).setConnectionTimeout(1100L);
+        verify(ds).setMaxLifetime(5200L);
+        verify(ds).setKeepaliveTime(6200L);
+    }
+
+}


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
This PR introduces a **complete SQL monitoring system and a connection pool abstraction with a concrete implementation**, forming the foundation of the connection-pool in Seata.

1. **SQL‑event collector (package `org.apache.seata.common.monitor`)**  
   - **`SqlExecutionEntry`**: immutable model of a single SQL execution event (`sql`, `executionTimeMillis`, `holdTimeMillis`, `timestamp`).  
   - **`SqlMonitor`**: singleton collector that  
     - records **all** SQL events (up to `maxAllRecords`)  
     - records **slow** SQL events (`execMs > slowThreshold`) up to `maxSlowEntries`  
     - exposes `getAllRecords()`, `getSlowSqlList()`, `clearOldRecords()`, `resetForTest()`.
2. **ConnectionPool (package `org.apache.seata.common.pool`)**  
   - **`ConnectionPoolConfig`** & **`ConnectionPoolMetrics`**: plain‐old‐Java objects representing connection‐pool metrics and config.  
   - **`PoolManager`**: interface defining methods `getConfig()`, `getMetrics()`, `updateConfig()`.  
   - **`PoolManagerRegistry`**: simple lookup/factory returning a `PoolManager` instance by `DataSource` type. 
3. Concrete Connection Pool Implementation
   - Adds actual implementation of **`PoolManager`** for supported pool types (e.g., **Druid/Hikari**) using reflection.
4. Unit Tests
   - **`SqlMonitorTest`**: Covers core monitor behaviors (recording, slow query detection, eviction, clear/reset)
   - **Connection Pool Tests**: Verifies the correctness of `PoolManager` implementations, metric reporting, and configuration updating.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
No — this is a new feature for the common module and rm-datasource module, including features about SQL monitor for Druid, connection‐pool metrics config, and the implementation of the connection-pool.


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
**Unit tests** are included for all core behaviors of `SqlMonitor`.
Connection pool implementation (config, metrics, update)

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

