### PR TITLE
bugfix: fix NPE when server-side filter is disabled and filter chain is null.

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -28,6 +28,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7538](https://github.com/apache/incubator-seata/pull/7538)] unify DmdbTimestamp comparison via UTC Instant to prevent rollback failure
 - [[#7546](https://github.com/seata/seata/pull/7546)] fix client spring version compatible
 - [[#7505](https://github.com/apache/incubator-seata/pull/7505)] prevent Netty I/O thread blocking by async channel release via reconnectExecutor
+- [[#7563](https://github.com/apache/incubator-seata/pull/7563)] Fix NPE when server-side filter is disabled and filter chain is null.
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -28,6 +28,7 @@
 - [[#7538](https://github.com/apache/incubator-seata/pull/7538)] 统一DmdbTimestamp比较方式，通过UTC比较，以防止回滚失败
 - [[#7546](https://github.com/seata/seata/pull/7546)] 修复客户端spring版本兼容
 - [[#7505](https://github.com/apache/incubator-seata/pull/7505)] 通过使用 reconnectExecutor 异步释放 channel，防止阻塞 Netty I/O 线程
+- [[#7563](https://github.com/apache/incubator-seata/pull/7563)] 修复在未开启服务端过滤器的状态下导致的过滤器链空指针异常
 
 
 

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/http/filter/HttpRequestFilterManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/http/filter/HttpRequestFilterManager.java
@@ -44,10 +44,9 @@ public class HttpRequestFilterManager {
                     HTTP_REQUEST_FILTERS.add(filter);
                 }
             }
-
             HTTP_REQUEST_FILTERS.sort(Comparator.comparingInt(HttpRequestFilter::getOrder));
-            HTTP_REQUEST_FILTER_CHAIN = new HttpRequestFilterChain(HTTP_REQUEST_FILTERS);
         }
+        HTTP_REQUEST_FILTER_CHAIN = new HttpRequestFilterChain(HTTP_REQUEST_FILTERS);
         initialized = true;
     }
 

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/http/filter/HttpRequestFilterManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/http/filter/HttpRequestFilterManagerTest.java
@@ -119,6 +119,24 @@ class HttpRequestFilterManagerTest {
     }
 
     @Test
+    void testInitializeFilters_filterEnabledFalse() {
+        MockFilter filter = mock(MockFilter.class);
+        when(filter.shouldApply()).thenReturn(true);
+
+        try (MockedStatic<ConfigurationFactory> configMock = mockStatic(ConfigurationFactory.class)) {
+            Configuration mockConfig = mock(Configuration.class);
+            when(mockConfig.getBoolean(ConfigurationKeys.SERVER_HTTP_FILTER_ENABLE, true))
+                    .thenReturn(false);
+            configMock.when(ConfigurationFactory::getInstance).thenReturn(mockConfig);
+            HttpRequestFilterManager.initializeFilters();
+
+            HttpRequestFilterChain chain = HttpRequestFilterManager.getFilterChain();
+            assertNotNull(chain);
+            assertTrue(chain.getFilters().isEmpty(), "Filters list should be empty when filter config is false");
+        }
+    }
+
+    @Test
     void testGetFilterChain_beforeInitialization_shouldThrow() {
         IllegalStateException exception =
                 assertThrows(IllegalStateException.class, HttpRequestFilterManager::getFilterChain);


### PR DESCRIPTION

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

the NullPointerException caused by the filter chain being null when the server-side filter is disabled.
<img width="1381" height="823" alt="image" src="https://github.com/user-attachments/assets/1b1120a6-bd80-4d4f-8012-76800038ceb1" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

