### PR TITLE
docs: add hyperlink to CONTRIBUTING.md and changes directory in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 -->
 <!-- Please make sure you have read and understood the contributing guidelines -->
 
+- [ ] I have read the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
 - [ ] I have registered the PR [changes](../changes).
 
 ### Ⅰ. Describe what this PR did

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 -->
 <!-- Please make sure you have read and understood the contributing guidelines -->
 
-- [ ] I have read the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
+- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
 - [ ] I have registered the PR [changes](../changes).
 
 ### Ⅰ. Describe what this PR did

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@
 -->
 <!-- Please make sure you have read and understood the contributing guidelines -->
 
-- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
-- [ ] I have registered the PR [changes](../changes).
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
+- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).
 
 ### Ⅰ. Describe what this PR did
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -66,6 +66,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [YvCeung](https://github.com/YvCeung)
 - [xjlgod](https://github.com/xjlgod)
 - [YongGoose](https://github.com/YongGoose)
+- [KoKimSS](https://github.com/KoKimSS)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -55,6 +55,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### doc:
 
 - [[#7531](https://github.com/seata/seata/pull/7531)] Optimize the Readme and change documents
+- [[#7569](https://github.com/seata/seata/pull/7569)] Add hyperlink to CONTRIBUTING.md in pull request template
 
 
 Thanks to these contributors for their code commits. Please report an unintended omission.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -65,6 +65,7 @@
 - [YvCeung](https://github.com/YvCeung)
 - [xjlgod](https://github.com/xjlgod)
 - [YongGoose](https://github.com/YongGoose)
+- [KoKimSS](https://github.com/KoKimSS)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -54,6 +54,7 @@
 ### doc:
 
 - [[#7531](https://github.com/seata/seata/pull/7531)] 优化 Readme 和 change 文档
+- [[#7569](https://github.com/seata/seata/pull/7569)] 在拉取请求模板中添加 CONTRIBUTING.md 超链接
 
 
 非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Added checkboxes with hyperlinks to both `CONTRIBUTING.md` and the `changes` directory in the pull request template.  
This improves the contributor experience by making relevant guidelines and changelog location easily accessible.

### Ⅱ. Does this pull request fix one issue?

Fixes #7569

### Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR only modifies documentation templates. No logic or behavior was changed, so tests are not applicable.

### Ⅳ. Describe how to verify it

1. Open the pull request template and check that:
   - The `CONTRIBUTING.md` link correctly navigates to:  
     `https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md`
   - The `changes` link correctly navigates to:  
     `https://github.com/apache/incubator-seata/tree/2.x/changes`
2. Confirm that both links are rendered correctly and are clickable.
3. Ensure the checkbox format matches the existing style in the template.

### Ⅴ. Special notes for reviews

- Simple documentation improvement as requested in issue #7569  
- Updated changelog entries in both `en-us` and `zh-cn` versions to reflect this change  
- Maintains consistency with the existing pull request template structure