### PR TITLE
test: deflake ConsulConfigurationTest#testInitSeataConfig (#7584)

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -53,7 +53,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7541](https://github.com/seata/seata/pull/7541)] fix jakarta UT failed in jdk17+
 - [[#7540](https://github.com/seata/seata/pull/7540)] fix port of mock server
 - [[#7580](https://github.com/seata/seata/pull/7580)]  fix the exception caused by the disorder of test case execution order
-
+- [[#7584](https://github.com/apache/incubator-seata/pull/7584)] deflake ConsulConfigurationTest#testInitSeataConfig with short await/retry to absorb CI timing delay
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -51,6 +51,7 @@
 - [[#7540](https://github.com/seata/seata/pull/7540)] 修复mock server端口冲突问题
 - [[#7578](https://github.com/seata/seata/pull/7578)]  zstd解压由jni改为ZstdInputStream
 - [[#7580](https://github.com/seata/seata/pull/7580)]  修复测试用例顺序错乱导致的异常
+- [[#7584](https://github.com/seata/seata/pull/7584)] 修复 ConsulConfigurationTest#testInitSeataConfig 在 CI 中由于等待/重试时间过短导致的不稳定问题
 
 ### refactor:
 

--- a/config/seata-config-consul/src/test/java/org/apache/seata/config/consul/ConsulConfigurationTest.java
+++ b/config/seata-config-consul/src/test/java/org/apache/seata/config/consul/ConsulConfigurationTest.java
@@ -118,7 +118,17 @@ class ConsulConfigurationTest {
 
         ConsulConfiguration newInstance = ConsulConfiguration.getInstance();
 
-        assertEquals("val1", newInstance.getLatestConfig("key1", null, 1000));
+        // Short retry loop to absorb potential propagation delay in CI environments
+        String value = null;
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(3); // Max ~3 seconds
+        do {
+            value = newInstance.getLatestConfig("key1", null, 1000);
+            if ("val1".equals(value)) break;
+            Thread.sleep(100);
+        } while (System.nanoTime() < deadline);
+
+        // Verify that the value retrieved matches the expected one
+        assertEquals("val1", value, "KV should be visible after a short await");
     }
 
     // Utility method to set private fields via reflection


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).  
  (N/A for this PR: test-only, no user-facing change)

### Ⅰ. Describe what this PR did
Deflake `ConsulConfigurationTest.testInitSeataConfig` by adding a short await/retry loop (up to ~3s with 100ms backoff).  
This absorbs occasional CI timing/propagation delays when reading the mocked Consul KV so the assertion remains stable.  
**No production code changes — test-only.**

### Ⅱ. Does this pull request fix one issue?
Fixes #7583.

### Ⅲ. Why don't you add test cases (unit test/integration test)?
This PR modifies the failing test itself. The flakiness comes from timing, not functionality, so adding new tests would not add coverage.

### Ⅳ. Describe how to verify it
Run the module tests repeatedly and confirm they pass:

```bash
# run just the consul config module (build deps included)
./mvnw -pl config/seata-config-consul -am test

# or target the single test method
./mvnw -q -pl config/seata-config-consul -am \
  -Dtest=org.apache.seata.config.consul.ConsulConfigurationTest#testInitSeataConfig \
  -Dsurefire.printSummary=true -Dsurefire.useFile=false \
  -DfailIfNoTests=false \
  test
```
### Ⅴ. Special notes for reviews
- Adds a bounded wait (≤3s) only to absorb CI timing; the original assertion remains.
- No production code touched.
- If preferred, we can swap to Awaitility, but avoided adding deps.
