### PR TITLE
bugfix: clamp getOrder to avoid tie/overflow

### DIFF
--- a/spring/src/main/java/org/apache/seata/spring/annotation/AdapterSpringSeataInterceptor.java
+++ b/spring/src/main/java/org/apache/seata/spring/annotation/AdapterSpringSeataInterceptor.java
@@ -29,7 +29,10 @@ import javax.annotation.Nullable;
 
 public class AdapterSpringSeataInterceptor implements MethodInterceptor, SeataInterceptor, Ordered {
 
-    private ProxyInvocationHandler proxyInvocationHandler;
+    @Nullable
+    private Integer explicitOrder;
+
+    private final ProxyInvocationHandler proxyInvocationHandler;
 
     public AdapterSpringSeataInterceptor(ProxyInvocationHandler proxyInvocationHandler) {
         Assert.notNull(proxyInvocationHandler, "proxyInvocationHandler must not be null");
@@ -46,12 +49,14 @@ public class AdapterSpringSeataInterceptor implements MethodInterceptor, SeataIn
 
     @Override
     public int getOrder() {
-        return proxyInvocationHandler.getOrder();
+        final int candidate = (explicitOrder != null) ? explicitOrder : proxyInvocationHandler.getOrder();
+        return (candidate >= Ordered.LOWEST_PRECEDENCE) ? (Ordered.LOWEST_PRECEDENCE - 1) : candidate;
     }
 
     @Override
     public void setOrder(int order) {
         proxyInvocationHandler.setOrder(order);
+        this.explicitOrder = order;
     }
 
     @Override

--- a/spring/src/test/java/org/apache/seata/spring/annotation/AdapterSpringSeataInterceptorTest.java
+++ b/spring/src/test/java/org/apache/seata/spring/annotation/AdapterSpringSeataInterceptorTest.java
@@ -26,6 +26,7 @@ import org.apache.seata.spring.tcc.NormalTccActionImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -73,6 +74,21 @@ class AdapterSpringSeataInterceptorTest {
         Assertions.assertTrue((Boolean) adapterSpringSeataInterceptor.invoke(myMockMethodInvocation));
     }
 
+    @Test
+    void order_should_be_less_than_lowest_precedence() {
+        // given
+        adapterSpringSeataInterceptor.setOrder(Ordered.LOWEST_PRECEDENCE);
+
+        // then
+        Assertions.assertEquals(Ordered.LOWEST_PRECEDENCE - 1, adapterSpringSeataInterceptor.getOrder());
+    }
+
+    @Test
+    void order_should_passthrough_when_not_lowest() {
+        adapterSpringSeataInterceptor.setOrder(100);
+        Assertions.assertEquals(100, adapterSpringSeataInterceptor.getOrder());
+    }
+
     static class MyMockMethodInvocation implements MethodInvocation {
 
         private Callable callable;
@@ -110,7 +126,7 @@ class AdapterSpringSeataInterceptorTest {
         @Nonnull
         @Override
         public AccessibleObject getStaticPart() {
-            return null;
+            return method;
         }
     }
 }


### PR DESCRIPTION
Fixes #7579

- [x] I have read the CONTRIBUTING.md guidelines.
- [x] I have registered the PR changes.

### Ⅰ. Describe what this PR did
- Normalize `AdapterSpringSeataInterceptor#getOrder()`:
  - Prefer the explicit order set via `setOrder(...)` to avoid overflow artifacts from the proxy.
  - Clamp values `>= Ordered.LOWEST_PRECEDENCE` to `Integer.MAX_VALUE - 1` to avoid a tie with Spring’s `TransactionInterceptor`.
- No public API change; only edge-case ordering is adjusted.

### Ⅱ. Does this pull request fix one issue?
Yes.

### Ⅲ. Why don't you add test cases (unit test/integration test)?
Added:
- `order_should_be_less_than_lowest_precedence`
- `order_should_passthrough_when_not_lowest`

### Ⅳ. Describe how to verify it
Run: `./mvnw -pl spring -am -Dtest=AdapterSpringSeataInterceptorTest test -DfailIfNoTests=false`  
Env: macOS, JDK 17, Maven 3.9.x → BUILD SUCCESS locally.

### Ⅴ. Special notes for reviews
Some environments return an overflowed (negative) order from `ProxyInvocationHandler#getOrder()`, which broke the UT.  
Preferring the explicit order and clamping the max value stabilizes execution precedence and avoids a tie with `TransactionInterceptor`.
