### PR TITLE
optimize: Optimize default xssFilter config retrieval when no explicit configuration is provided

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -43,6 +43,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7576](https://github.com/seata/seata/pull/7576)] Add empty push protection for Configuration
 - [[#7577](https://github.com/seata/seata/pull/7577)]  remove the 4MB size limit when decompressing with zstd
 - [[#7578](https://github.com/seata/seata/pull/7578)]  zstd decompression is changed from jni to ZstdInputStream
+- [[#7591](https://github.com/seata/seata/pull/7591)]  Optimize default xssFilter config retrieval when no explicit configuration is provided
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -41,6 +41,7 @@
 - [[#7557](https://github.com/seata/seata/pull/7557)] 升级 npmjs 依赖
 - [[#7576](https://github.com/seata/seata/pull/7576)] 针对配置变更增加空推保护
 - [[#7577](https://github.com/seata/seata/pull/7577)]  去除zstd解压时4MB的限制
+- [[#7591](https://github.com/seata/seata/pull/7591)]  当没有显式配置xssFilter相关的配置时，优化获取默认配置的逻辑
 
 ### security:
 

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/org/apache/seata/spring/boot/autoconfigure/StarterConstants.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/org/apache/seata/spring/boot/autoconfigure/StarterConstants.java
@@ -81,6 +81,8 @@ public interface StarterConstants {
 
     String SERVER_HTTP_FILTER_PREFIX = SERVER_HTTP_PREFIX + ".filter";
 
+    String SERVER_HTTP_FILTER_XSS_PREFIX = SERVER_HTTP_FILTER_PREFIX + ".xss";
+
     String METRICS_PREFIX = SEATA_PREFIX + ".metrics";
 
     String STORE_PREFIX = SEATA_PREFIX + ".store";

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataServerEnvironmentPostProcessor.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataServerEnvironmentPostProcessor.java
@@ -22,6 +22,7 @@ import org.apache.seata.spring.boot.autoconfigure.properties.server.ServerRateLi
 import org.apache.seata.spring.boot.autoconfigure.properties.server.ServerRecoveryProperties;
 import org.apache.seata.spring.boot.autoconfigure.properties.server.ServerUndoProperties;
 import org.apache.seata.spring.boot.autoconfigure.properties.server.filter.ServerHttpFilterProperties;
+import org.apache.seata.spring.boot.autoconfigure.properties.server.filter.ServerHttpFilterXssProperties;
 import org.apache.seata.spring.boot.autoconfigure.properties.server.raft.ServerRaftProperties;
 import org.apache.seata.spring.boot.autoconfigure.properties.server.raft.ServerRaftSSLClientProperties;
 import org.apache.seata.spring.boot.autoconfigure.properties.server.raft.ServerRaftSSLProperties;
@@ -46,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.METRICS_PREFIX;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.PROPERTY_BEAN_MAP;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_HTTP_FILTER_PREFIX;
+import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_HTTP_FILTER_XSS_PREFIX;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_PREFIX;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_RAFT_PREFIX;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_RAFT_SSL_CLIENT_KEYSTORE_PREFIX;
@@ -105,6 +107,7 @@ public class SeataServerEnvironmentPostProcessor implements EnvironmentPostProce
             PROPERTY_BEAN_MAP.put(STORE_PREFIX, StoreProperties.class);
             PROPERTY_BEAN_MAP.put(SERVER_RATELIMIT_PREFIX, ServerRateLimitProperties.class);
             PROPERTY_BEAN_MAP.put(SERVER_HTTP_FILTER_PREFIX, ServerHttpFilterProperties.class);
+            PROPERTY_BEAN_MAP.put(SERVER_HTTP_FILTER_XSS_PREFIX, ServerHttpFilterXssProperties.class);
         }
     }
 }

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterProperties.java
@@ -19,9 +19,6 @@ package org.apache.seata.spring.boot.autoconfigure.properties.server.filter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
-import static org.apache.seata.common.DefaultValues.DEFAULT_XSS_KEYWORDS;
 import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_HTTP_FILTER_PREFIX;
 
 @Component
@@ -29,44 +26,11 @@ import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER
 public class ServerHttpFilterProperties {
     private boolean enabled = true;
 
-    private Xss xss = new Xss();
-
     public boolean isEnabled() {
         return enabled;
     }
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-
-    public Xss getXss() {
-        return xss;
-    }
-
-    public void setXss(Xss xss) {
-        this.xss = xss;
-    }
-
-    public static class Xss {
-
-        private boolean enabled = true;
-
-        private List<String> keywords = DEFAULT_XSS_KEYWORDS;
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
-
-        public List<String> getKeywords() {
-            return keywords;
-        }
-
-        public void setKeywords(List<String> keywords) {
-            this.keywords = keywords;
-        }
     }
 }

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterXssProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterXssProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.seata.spring.boot.autoconfigure.properties.server.filter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterXssProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterXssProperties.java
@@ -1,0 +1,33 @@
+package org.apache.seata.spring.boot.autoconfigure.properties.server.filter;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static org.apache.seata.common.DefaultValues.DEFAULT_XSS_KEYWORDS;
+import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_HTTP_FILTER_XSS_PREFIX;
+
+@Component
+@ConfigurationProperties(prefix = SERVER_HTTP_FILTER_XSS_PREFIX)
+public class ServerHttpFilterXssProperties {
+    private boolean enabled = true;
+
+    private List<String> keywords = DEFAULT_XSS_KEYWORDS;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
+    }
+
+    public void setKeywords(List<String> keywords) {
+        this.keywords = keywords;
+    }
+}

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/test/java/org/apache/seata/spring/boot/autoconfigure/SeataServerEnvironmentPostProcessorTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/test/java/org/apache/seata/spring/boot/autoconfigure/SeataServerEnvironmentPostProcessorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.spring.boot.autoconfigure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+
+import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.METRICS_PREFIX;
+import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.PROPERTY_BEAN_MAP;
+import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.SERVER_PREFIX;
+import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.STORE_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SeataServerEnvironmentPostProcessorTest {
+    private SeataServerEnvironmentPostProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new SeataServerEnvironmentPostProcessor();
+        PROPERTY_BEAN_MAP.clear();
+        try {
+            Field field = SeataServerEnvironmentPostProcessor.class.getDeclaredField("INIT");
+            field.setAccessible(true);
+            ((java.util.concurrent.atomic.AtomicBoolean) field.get(null)).set(false);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testPostProcessEnvironmentShouldPopulatePropertyBeanMap() {
+        MockEnvironment environment = new MockEnvironment();
+        SpringApplication application = new SpringApplication();
+
+        processor.postProcessEnvironment(environment, application);
+
+        assertTrue(PROPERTY_BEAN_MAP.containsKey(SERVER_PREFIX));
+        assertTrue(PROPERTY_BEAN_MAP.containsKey(STORE_PREFIX));
+        assertTrue(PROPERTY_BEAN_MAP.containsKey(METRICS_PREFIX));
+    }
+
+    @Test
+    void testInitIsIdempotent() {
+        MockEnvironment environment = new MockEnvironment();
+        SpringApplication application = new SpringApplication();
+
+        // First
+        processor.postProcessEnvironment(environment, application);
+        int firstSize = PROPERTY_BEAN_MAP.size();
+
+        // Second
+        processor.postProcessEnvironment(environment, application);
+        int secondSize = PROPERTY_BEAN_MAP.size();
+
+        assertEquals(firstSize, secondSize, "PROPERTY_BEAN_MAP should keep the same size");
+    }
+
+    @Test
+    void testGetOrderShouldBeHighestPrecedence() {
+        assertEquals(org.springframework.core.Ordered.HIGHEST_PRECEDENCE, processor.getOrder());
+    }
+}

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterXssPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/server/filter/ServerHttpFilterXssPropertiesTest.java
@@ -19,20 +19,28 @@ package org.apache.seata.spring.boot.autoconfigure.properties.server.filter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ServerHttpFilterPropertiesTest {
+import java.util.Collections;
 
+public class ServerHttpFilterXssPropertiesTest {
     @Test
-    public void testServerHttpFilterProperties() {
-        ServerHttpFilterProperties serverHttpFilterProperties = new ServerHttpFilterProperties();
+    public void testServerHttpFilterXssProperties() {
+        ServerHttpFilterXssProperties serverHttpFilterXssProperties = new ServerHttpFilterXssProperties();
 
-        Assertions.assertTrue(serverHttpFilterProperties.isEnabled());
+        Assertions.assertTrue(serverHttpFilterXssProperties.isEnabled());
+        Assertions.assertEquals(
+                "<script>", serverHttpFilterXssProperties.getKeywords().get(0));
     }
 
     @Test
     public void testServerHttpFilterPropertiesUnDefaultValue() {
-        ServerHttpFilterProperties serverHttpFilterProperties = new ServerHttpFilterProperties();
-        serverHttpFilterProperties.setEnabled(false);
+        ServerHttpFilterXssProperties serverHttpFilterXssProperties = new ServerHttpFilterXssProperties();
 
-        Assertions.assertFalse(serverHttpFilterProperties.isEnabled());
+        serverHttpFilterXssProperties.setEnabled(false);
+
+        serverHttpFilterXssProperties.setKeywords(Collections.singletonList("<alert>"));
+
+        Assertions.assertFalse(serverHttpFilterXssProperties.isEnabled());
+        Assertions.assertEquals(
+                "<alert>", serverHttpFilterXssProperties.getKeywords().get(0));
     }
 }

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -23,5 +23,4 @@ seata.metrics.registry-type=compact
 seata.registry.namingserver.server-addr=127.0.0.1:8081
 seata.registry.namingserver.namespace=public
 seata.registry.namingserver.heartbeat-period=5000
-seata.server.http.filter.xss.enabled=true
 seata.server.http.filter.xss.keywords=["<script>", "</script>", "javascript:", "vbscript:"]


### PR DESCRIPTION

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Optimize the logic for obtaining the default configuration of xssFilter

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fix #7589 
### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

