### PR TITLE
doc: add the type of registry as seata in application.yml

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -67,6 +67,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 - [[#7531](https://github.com/seata/seata/pull/7531)] Optimize the Readme and change documents
 - [[#7569](https://github.com/seata/seata/pull/7569)] Add hyperlink to CONTRIBUTING.md in pull request template
+- [[#7605](https://github.com/apache/incubator-seata/pull/7605)] Add the type of registry as seata in application.yml
 
 
 Thanks to these contributors for their code commits. Please report an unintended omission.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -65,6 +65,7 @@
 
 - [[#7531](https://github.com/seata/seata/pull/7531)] 优化 Readme 和 change 文档
 - [[#7569](https://github.com/seata/seata/pull/7569)] 在拉取请求模板中添加 CONTRIBUTING.md 超链接
+- [[#7605](https://github.com/apache/incubator-seata/pull/7605)] 在application.yml中增加了seata作为注册中心的注释
 
 
 非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。

--- a/server/src/main/resources/application.raft.example.yml
+++ b/server/src/main/resources/application.raft.example.yml
@@ -79,7 +79,7 @@ seata:
       server-addr: http://localhost:2379
       key: seata.properties
   registry:
-    # support: nacos 、 eureka 、 redis 、 zk  、 consul 、 etcd3 、 sofa
+    # support: nacos 、 eureka 、 redis 、 zk  、 consul 、 etcd3 、 sofa 、 seata
     type: file
     preferred-networks: 30.240.*
     seata:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -48,7 +48,7 @@ seata:
     # support: nacos, consul, apollo, zk, etcd3
     type: file
   registry:
-    # support: nacos, eureka, redis, zk, consul, etcd3, sofa
+    # support: nacos, eureka, redis, zk, consul, etcd3, sofa, seata
     type: file
   store:
     # support: file 、 db 、 redis 、 raft


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
A very small optimization：In the `application.yml` and `application.raft.example.yml` on the server side, the type of `seata` registry has been supplemented in the comments

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

