### PR TITLE
bugfix: fix the datetime format time query error in the global lock query

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -34,6 +34,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7563](https://github.com/apache/incubator-seata/pull/7563)] Fix NPE when server-side filter is disabled and filter chain is null.
 - [[#7568](https://github.com/apache/incubator-seata/pull/7568)] Fix order() behavior in GlobalTransactionalInterceptorHandler to ensure correct sorting of invocation handlers
 - [[#7596](https://github.com/apache/incubator-seata/pull/7596)] Fixed the issue where deserialization failed when the xss filter obtained the default keyword
+- [[#7613](https://github.com/apache/incubator-seata/pull/7613)] Fixed the SQL error in the datetime format time query in the global lock query
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -34,6 +34,7 @@
 - [[#7563](https://github.com/apache/incubator-seata/pull/7563)] 修复在未开启服务端过滤器的状态下导致的过滤器链空指针异常
 - [[#7568](https://github.com/apache/incubator-seata/pull/7568)] 修复 GlobalTransactionalInterceptorHandler 中的 order() 方法行为，确保拦截器的正确排序
 - [[#7596](https://github.com/apache/incubator-seata/pull/7596)] 修复xss过滤器获取默认关键字时反序列化失败的问题
+- [[#7613](https://github.com/apache/incubator-seata/pull/7613)] 修复全局锁查询中的datetime时间格式时间查询sql错误
 
 
 ### optimize:

--- a/common/src/main/java/org/apache/seata/common/util/PageUtil.java
+++ b/common/src/main/java/org/apache/seata/common/util/PageUtil.java
@@ -230,7 +230,7 @@ public class PageUtil {
     public static String getDateTimeStartSql(String dbType, String timeColumnName) {
         switch (dbType.toLowerCase()) {
             case "mysql":
-                return " and " + timeColumnName + " >= FROM_UNIXTIME(?) ";
+                return " and UNIX_TIMESTAMP(" + timeColumnName + ") >= ? ";
             case "postgresql":
                 return " and " + timeColumnName + " >= TO_TIMESTAMP(?) ";
             case "oracle":
@@ -255,7 +255,7 @@ public class PageUtil {
     public static String getDateTimeEndSql(String dbType, String timeColumnName) {
         switch (dbType.toLowerCase()) {
             case "mysql":
-                return " and " + timeColumnName + " <= FROM_UNIXTIME(?) ";
+                return " and UNIX_TIMESTAMP(" + timeColumnName + ") <= ? ";
             case "postgresql":
                 return " and " + timeColumnName + " <= TO_TIMESTAMP(?) ";
             case "oracle":

--- a/common/src/main/java/org/apache/seata/common/util/PageUtil.java
+++ b/common/src/main/java/org/apache/seata/common/util/PageUtil.java
@@ -220,4 +220,54 @@ public class PageUtil {
                 throw new IllegalArgumentException("The DB type :" + dbType + " is not supported yet");
         }
     }
+
+    /**
+     * get sql for time start (The database fields is of type datetime)
+     * @param dbType
+     * @param timeColumnName
+     * @return java.lang.String
+     */
+    public static String getDateTimeStartSql(String dbType, String timeColumnName) {
+        switch (dbType.toLowerCase()) {
+            case "mysql":
+                return " and " + timeColumnName + " >= FROM_UNIXTIME(?) ";
+            case "postgresql":
+                return " and " + timeColumnName + " >= TO_TIMESTAMP(?) ";
+            case "oracle":
+                return " and " + timeColumnName + " >= TO_TIMESTAMP('1970-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') + NUMTODSINTERVAL(?, 'SECOND') ";
+            case "sqlserver":
+                return " and " + timeColumnName + " >= DATEADD(SECOND, ?, '1970-01-01 00:00:00') ";
+            case "dm":
+            case "oscar":
+                // Compatible with Oracle syntax
+                return " and " + timeColumnName + " >= TO_TIMESTAMP('1970-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') + NUMTODSINTERVAL(?, 'SECOND') ";
+            default:
+                throw new IllegalArgumentException("Unsupported DB type: " + dbType);
+        }
+    }
+
+    /**
+     * get sql for time end (The database fields is of type datetime)
+     * @param dbType
+     * @param timeColumnName
+     * @return java.lang.String
+     */
+    public static String getDateTimeEndSql(String dbType, String timeColumnName) {
+        switch (dbType.toLowerCase()) {
+            case "mysql":
+                return " and " + timeColumnName + " <= FROM_UNIXTIME(?) ";
+            case "postgresql":
+                return " and " + timeColumnName + " <= TO_TIMESTAMP(?) ";
+            case "oracle":
+                return " and " + timeColumnName + " <= TO_TIMESTAMP('1970-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') + NUMTODSINTERVAL(?, 'SECOND') ";
+            case "sqlserver":
+                return " and " + timeColumnName + " <= DATEADD(SECOND, ?, '1970-01-01 00:00:00') ";
+            case "dm":
+            case "oscar":
+                // Compatible with Oracle syntax
+                return " and " + timeColumnName + " <= TO_TIMESTAMP('1970-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') + NUMTODSINTERVAL(?, 'SECOND') ";
+            default:
+                throw new IllegalArgumentException("Unsupported DB type: " + dbType);
+        }
+    }
 }

--- a/server/src/main/java/org/apache/seata/server/console/impl/db/GlobalLockDBServiceImpl.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/db/GlobalLockDBServiceImpl.java
@@ -171,11 +171,11 @@ public class GlobalLockDBServiceImpl extends AbstractLockService implements Glob
             sqlParamList.add(param.getBranchId());
         }
         if (param.getTimeStart() != null) {
-            whereConditionBuilder.append(PageUtil.getTimeStartSql(this.dbType, "gmt_create"));
+            whereConditionBuilder.append(PageUtil.getDateTimeStartSql(this.dbType, "gmt_create"));
             sqlParamList.add(param.getTimeStart() / 1000);
         }
         if (param.getTimeEnd() != null) {
-            whereConditionBuilder.append(PageUtil.getTimeEndSql(this.dbType, "gmt_create"));
+            whereConditionBuilder.append(PageUtil.getDateTimeEndSql(this.dbType, "gmt_create"));
             sqlParamList.add(param.getTimeEnd() / 1000);
         }
         String whereCondition = whereConditionBuilder.toString();


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

- In the PageUtil, add two methods, getDateTimeStartSql and getDateTimeEndSql, to implement the query of the datetime type field in the table by second-level timestamp.

- Among the above two methods, for the database types currently supported by the server, write the respective query SQL statements, conforming as much as possible to the syntax rules of different databases, and implement the default time zone query of the database.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7612 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

- Query the relevant global lock information by specifying the global lock creation time (ensuring that the incoming time is in timestamp format)

### Ⅴ. Special notes for reviews

