### PR TITLE
bugfix:fix the compatibility issue of yml configuration files

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -35,6 +35,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7568](https://github.com/apache/incubator-seata/pull/7568)] Fix order() behavior in GlobalTransactionalInterceptorHandler to ensure correct sorting of invocation handlers
 - [[#7596](https://github.com/apache/incubator-seata/pull/7596)] Fixed the issue where deserialization failed when the xss filter obtained the default keyword
 - [[#7613](https://github.com/apache/incubator-seata/pull/7613)] Fixed the SQL error in the datetime format time query in the global lock query
+- [[#7624](https://github.com/apache/incubator-seata/pull/7624)] fix the compatibility issue of yml configuration files
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -36,6 +36,7 @@
 - [[#7568](https://github.com/apache/incubator-seata/pull/7568)] 修复 GlobalTransactionalInterceptorHandler 中的 order() 方法行为，确保拦截器的正确排序
 - [[#7596](https://github.com/apache/incubator-seata/pull/7596)] 修复xss过滤器获取默认关键字时反序列化失败的问题
 - [[#7613](https://github.com/apache/incubator-seata/pull/7613)] 修复全局锁查询中的datetime时间格式时间查询sql错误
+- [[#7624](https://github.com/apache/incubator-seata/pull/7624)] 修复yml配置文件中对于整数的兼容问题
 
 
 ### optimize:

--- a/config/seata-config-core/src/main/java/org/apache/seata/config/processor/ProcessorYaml.java
+++ b/config/seata-config-core/src/main/java/org/apache/seata/config/processor/ProcessorYaml.java
@@ -22,6 +22,7 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -36,7 +37,11 @@ public class ProcessorYaml implements Processor {
     public Properties processor(String config) {
         Properties properties = new Properties();
         Map<String, Object> configMap = MapUtil.asMap(new Yaml(new SafeConstructor(new LoaderOptions())).load(config));
-        properties.putAll(MapUtil.getFlattenedMap(configMap));
+        Map<String, String> stringConfigMap = new LinkedHashMap<>();
+        MapUtil.getFlattenedMap(configMap).forEach((k, v) -> {
+            stringConfigMap.put(k, v == null ? null : String.valueOf(v));
+        });
+        properties.putAll(stringConfigMap);
         return properties;
     }
 }

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/processor/ProcessorYamlTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/processor/ProcessorYamlTest.java
@@ -38,8 +38,7 @@ public class ProcessorYamlTest {
         ProcessorYaml processorYaml = new ProcessorYaml();
         Properties props = processorYaml.processor(yamlConfig);
 
-        assertEquals(8080, props.get("server.port"));
-        assertEquals("", props.getProperty("server.port", ""));
+        assertEquals("8080", props.getProperty("server.port", ""));
         assertEquals("localhost", props.getProperty("server.host"));
         assertEquals("jdbc:mysql://localhost:3306/test", props.getProperty("spring.datasource.url"));
         assertEquals("root", props.getProperty("spring.datasource.username"));


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
fixed the issue where integer values in YAML configuration files could not be retrieved from the configuration center(eg : `nacos`)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix  #7582 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

