### PR TITLE
bugfix: ensure visibility of rm and The methods in MockTest are executed in order

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -37,6 +37,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7596](https://github.com/apache/incubator-seata/pull/7596)] Fixed the issue where deserialization failed when the xss filter obtained the default keyword
 - [[#7613](https://github.com/apache/incubator-seata/pull/7613)] Fixed the SQL error in the datetime format time query in the global lock query
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] fix the compatibility issue of yml configuration files
+- [[#7662](https://github.com/apache/incubator-seata/pull/7662)] ensure visibility of rm and The methods in MockTest are executed in order
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -38,6 +38,7 @@
 - [[#7596](https://github.com/apache/incubator-seata/pull/7596)] 修复xss过滤器获取默认关键字时反序列化失败的问题
 - [[#7613](https://github.com/apache/incubator-seata/pull/7613)] 修复全局锁查询中的datetime时间格式时间查询sql错误
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] 修复yml配置文件中对于整数的兼容问题
+- [[#7662](https://github.com/apache/incubator-seata/pull/7662)] 确保 rm 的可见性，并且 MockTest 中的方法按顺序执行
 
 
 ### optimize:

--- a/test-old-version/src/test/java/io/seata/MockTest.java
+++ b/test-old-version/src/test/java/io/seata/MockTest.java
@@ -29,16 +29,14 @@ import io.seata.core.rpc.netty.TmRpcClient;
 import io.seata.rm.DefaultResourceManager;
 import org.apache.seata.mockserver.MockCoordinator;
 import org.apache.seata.mockserver.MockServer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * the type MockServerTest
  */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MockTest {
 
     static String RESOURCE_ID = "mock-action-061";
@@ -57,6 +55,7 @@ public class MockTest {
     }
 
     @Test
+    @Order(1)
     public void testCommit() throws Exception {
         String xid = doTestCommit(0);
         Assertions.assertEquals(1, Action1Impl.getCommitTimes(xid));
@@ -64,6 +63,7 @@ public class MockTest {
     }
 
     @Test
+    @Order(2)
     public void testCommitRetry() throws Exception {
         String xid = doTestCommit(2);
         Assertions.assertEquals(3, Action1Impl.getCommitTimes(xid));
@@ -71,6 +71,7 @@ public class MockTest {
     }
 
     @Test
+    @Order(3)
     public void testRollback() throws Exception {
         String xid = doTestRollback(0);
         Assertions.assertEquals(0, Action1Impl.getCommitTimes(xid));
@@ -78,6 +79,7 @@ public class MockTest {
     }
 
     @Test
+    @Order(4)
     public void testRollbackRetry() throws Exception {
         String xid = doTestRollback(2);
         Assertions.assertEquals(0, Action1Impl.getCommitTimes(xid));
@@ -85,11 +87,13 @@ public class MockTest {
     }
 
     @Test
+    @Order(5)
     public void testTm() throws Exception {
         TmClientTest.testTm();
     }
 
     @Test
+    @Order(6)
     public void testRm() throws Exception {
         RmClientTest.testRm("testRM01");
     }

--- a/test-old-version/src/test/java/io/seata/MockTest.java
+++ b/test-old-version/src/test/java/io/seata/MockTest.java
@@ -29,13 +29,13 @@ import io.seata.core.rpc.netty.TmRpcClient;
 import io.seata.rm.DefaultResourceManager;
 import org.apache.seata.mockserver.MockCoordinator;
 import org.apache.seata.mockserver.MockServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Order;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/test-old-version/src/test/java/io/seata/MockTest.java
+++ b/test-old-version/src/test/java/io/seata/MockTest.java
@@ -29,7 +29,13 @@ import io.seata.core.rpc.netty.TmRpcClient;
 import io.seata.rm.DefaultResourceManager;
 import org.apache.seata.mockserver.MockCoordinator;
 import org.apache.seata.mockserver.MockServer;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Order;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/test-old-version/src/test/java/io/seata/core/rpc/netty/RmClientTest.java
+++ b/test-old-version/src/test/java/io/seata/core/rpc/netty/RmClientTest.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public class RmClientTest {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(RmClientTest.class);
-    private static DefaultResourceManager rm = null;
+    private static volatile DefaultResourceManager rm = null;
 
     public static void testRm(String resourceId) throws TransactionException, NoSuchMethodException {
         String xid = "1111";


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
#7585 
With the help of @funky-eyes's analysis, I think it is not a network or port problem, but a visibility problem.
Because the rm member variable in RmClientTest is not declared as volatile, this may cause the rm variable to be modified multiple times during concurrent testing, thus causing this problem。

Here is the fix I made for the problem:
- The volatile keyword ensures that writes to the rm variable are immediately visible to all threads, preventing instruction reordering. 
- Test ordering: The @TestMethodOrder and @Order annotations ensure that tests are executed sequentially, avoiding concurrent access issues. 
- Double-checked locking safety: volatile + synchronized ensures thread-safe lazy loading.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7558 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
mvn clean test

### Ⅴ. Special notes for reviews

