### PR TITLE
feature: support shentongdatabase xa mode

### DIFF
--- a/.github/workflows/test-druid.yml
+++ b/.github/workflows/test-druid.yml
@@ -42,6 +42,11 @@ jobs:
       fail-fast: false
       matrix:
         druid: [
+          1.2.25,
+#          1.2.24, #The source code depends on guava, resulting in a class not found, see the commit https://github.com/alibaba/druid/commit/f060c2701587948380bd0d07d5baf4f774c06e8a#diff-5200f514252efbc0c4b2dc51ebad5d840b4b3065b9556eb4368bd3476d4c220eR25
+          1.2.23,
+          1.2.22,
+          1.2.21,
           1.2.20,
           1.2.19,
           #1.2.18, # Unit test triggered a bug in Druid, see the commit https://github.com/alibaba/druid/commit/6c493f852852fb287ed5fd31ee16c27ead0ea5cf

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -25,6 +25,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7492](https://github.com/apache/incubator-seata/pull/7492)] upgrade HTTP client in common module to support HTTP/2
 - [[#7551](https://github.com/apache/incubator-seata/pull/7551)] XAUtils add support for DM Database
 - [[#7559](https://github.com/apache/incubator-seata/pull/7559)] Introduce Cleanup API for TableMetaRefreshHolder Instance
+- [[#7664](https://github.com/apache/incubator-seata/pull/7664)] support shentongdatabase XA mode
 
 ### bugfix:
 
@@ -97,6 +98,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [WangzJi](https://github.com/WangzJi)
 - [Asuka-star](https://github.com/Asuka-star)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
+- [dsomehan](https://github.com/dsomehan)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -100,6 +100,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [WangzJi](https://github.com/WangzJi)
 - [Asuka-star](https://github.com/Asuka-star)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
-
+- [dsomehan](https://github.com/dsomehan)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -25,6 +25,7 @@
 - [[#7492](https://github.com/apache/incubator-seata/pull/7492)] 升级 common 模块中的 HTTP 客户端以支持 HTTP/2
 - [[#7551](https://github.com/apache/incubator-seata/pull/7551)] XAUtils支持达梦数据库
 - [[#7559](https://github.com/apache/incubator-seata/pull/7559)] 为 TableMetaRefreshHolder 实例引入清理 API
+- [[#7664](https://github.com/apache/incubator-seata/pull/7565)] 支持神通数据库的XA模式
 
 
 ### bugfix:
@@ -98,6 +99,7 @@
 - [WangzJi](https://github.com/WangzJi)
 - [Asuka-star](https://github.com/Asuka-star)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
+- [dsomehan](https://github.com/dsomehan)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/compatible/src/test/java/io/seata/rm/datasource/xa/DataSourceProxyXATest.java
+++ b/compatible/src/test/java/io/seata/rm/datasource/xa/DataSourceProxyXATest.java
@@ -17,6 +17,7 @@
 package io.seata.rm.datasource.xa;
 
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.mysql.jdbc.JDBC4MySQLConnection;
 import com.mysql.jdbc.jdbc2.optional.JDBC4ConnectionWrapper;
 import io.seata.core.context.RootContext;
@@ -66,6 +67,7 @@ public class DataSourceProxyXATest {
 
         DruidDataSource druidDataSource = new DruidDataSource();
         druidDataSource.setDriver(driver);
+        druidDataSource.setUrl("jdbc:mysql:xxx");
         DataSourceProxyXA dataSourceProxyXA = new DataSourceProxyXA(druidDataSource);
         RootContext.unbind();
         Connection connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
@@ -79,6 +81,9 @@ public class DataSourceProxyXATest {
         Assertions.assertTrue(wrappedConnection instanceof PooledConnection);
 
         Connection wrappedPhysicalConn = ((PooledConnection) wrappedConnection).getConnection();
+        if (wrappedPhysicalConn instanceof DruidStatementConnection) {
+            wrappedPhysicalConn = ((DruidStatementConnection) wrappedPhysicalConn).getConnection();
+        }
         Assertions.assertSame(wrappedPhysicalConn, connection);
 
         XAConnection xaConnection = connectionProxyXA.getWrappedXAConnection();
@@ -101,6 +106,7 @@ public class DataSourceProxyXATest {
 
         DruidDataSource druidDataSource = new DruidDataSource();
         druidDataSource.setDriver(driver);
+        druidDataSource.setUrl("jdbc:mariadb:xxx");
         DataSourceProxyXA dataSourceProxyXA = new DataSourceProxyXA(druidDataSource);
         RootContext.unbind();
         Connection connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
@@ -115,6 +121,9 @@ public class DataSourceProxyXATest {
         Assertions.assertTrue(wrappedConnection instanceof PooledConnection);
 
         Connection wrappedPhysicalConn = ((PooledConnection) wrappedConnection).getConnection();
+        if (wrappedPhysicalConn instanceof DruidStatementConnection) {
+            wrappedPhysicalConn = ((DruidStatementConnection) wrappedPhysicalConn).getConnection();
+        }
         Assertions.assertSame(wrappedPhysicalConn, connection);
 
         XAConnection xaConnection = connectionProxyXA.getWrappedXAConnection();

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -114,8 +114,9 @@
         <h2.version>1.4.181</h2.version>
         <mariadb.version>2.7.2</mariadb.version>
         <kingbase.version>9.0.0</kingbase.version>
+        <oscar.version>4.1.152</oscar.version>
         <!-- db connection pool -->
-        <druid.version>1.2.20</druid.version>
+        <druid.version>1.2.25</druid.version>
         <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
         <hikari.version>3.4.3</hikari.version>
         <caffeine.version>2.9.3</caffeine.version>
@@ -923,6 +924,11 @@
                 <groupId>cn.com.kingbase</groupId>
                 <artifactId>kingbase8</artifactId>
                 <version>${kingbase.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.shentongdata</groupId>
+                <artifactId>oscarJDBC8</artifactId>
+                <version>${oscar.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/distribution/LICENSE
+++ b/distribution/LICENSE
@@ -221,7 +221,7 @@ Apache-2.0 licenses
     com.alibaba.nacos:nacos-api 1.4.6 Apache-2.0
     com.alibaba.nacos:nacos-client 1.4.6 Apache-2.0
     com.alibaba.nacos:nacos-common 1.4.6 Apache-2.0
-    com.alibaba:druid 1.2.20 Apache-2.0
+    com.alibaba:druid 1.2.25 Apache-2.0
     com.alibaba:fastjson 1.2.83 Apache-2.0
     com.alibaba.fastjson2:fastjson2 2.0.52 Apache-2.0
     com.alipay.sofa.common:sofa-common-tools 1.0.12 Apache-2.0

--- a/distribution/LICENSE-server
+++ b/distribution/LICENSE-server
@@ -243,7 +243,7 @@ Apache-2.0 licenses
     org.apache.curator:curator-test 5.1.0 Apache-2.0
     com.lmax:disruptor 3.3.7 Apache-2.0
     com.dameng:DmJdbcDriver18 8.1.2.192 Apache-2.0
-    com.alibaba:druid 1.2.20 Apache-2.0
+    com.alibaba:druid 1.2.25 Apache-2.0
     com.google.errorprone:error_prone_annotations 2.21.1 Apache-2.0
     com.netflix.eureka:eureka-client 1.10.18 Apache-2.0
     net.jodah:failsafe 2.3.3 Apache-2.0

--- a/distribution/NOTICE.md
+++ b/distribution/NOTICE.md
@@ -562,7 +562,7 @@ Please copy database driver dependencies, such as `mysql-connector-java.jar`, to
     │   ├── curator-test-5.1.0.jar
     │   ├── dexx-collections-0.2.jar
     │   ├── disruptor-3.3.7.jar
-    │   ├── druid-1.2.20.jar
+    │   ├── druid-1.2.25.jar
     │   ├── error_prone_annotations-2.21.1.jar
     │   ├── eureka-client-1.10.18.jar
     │   ├── failsafe-2.3.3.jar
@@ -1719,7 +1719,7 @@ Please copy database driver dependencies, such as `mysql-connector-java.jar`, to
     │   ├── curator-test-5.1.0.jar
     │   ├── dexx-collections-0.2.jar
     │   ├── disruptor-3.3.7.jar
-    │   ├── druid-1.2.20.jar
+    │   ├── druid-1.2.25.jar
     │   ├── error_prone_annotations-2.21.1.jar
     │   ├── eureka-client-1.10.18.jar
     │   ├── failsafe-2.3.3.jar

--- a/rm-datasource/pom.xml
+++ b/rm-datasource/pom.xml
@@ -154,5 +154,10 @@
             <artifactId>kingbase8</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.shentongdata</groupId>
+            <artifactId>oscarJDBC8</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/util/XAUtils.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/util/XAUtils.java
@@ -70,6 +70,8 @@ public class XAUtils {
                         return PGUtils.createXAConnection(physicalConn);
                     case JdbcConstants.KINGBASE:
                         return createXAConnection(physicalConn, "com.kingbase8.xa.KBXAConnection", dbType);
+                    case JdbcConstants.OSCAR:
+                        return createXAConnection(physicalConn, "com.oscar.xa.Jdbc3XAConnection", dbType);
                     case JdbcConstants.DM:
                         return createXAConnection(physicalConn, "dm.jdbc.driver.DmdbXAConnection", dbType);
                     default:
@@ -118,6 +120,8 @@ public class XAUtils {
                     return xaConnectionClass.getConstructor(kingbaseConnectionClass);
                 case JdbcConstants.DM:
                     return xaConnectionClass.getConstructor(Connection.class);
+                case JdbcConstants.OSCAR:
+                    return xaConnectionClass.getConstructor(Connection.class);
                 default:
                     throw new SQLException("xa reflect not support dbType: " + dbType);
             }
@@ -141,6 +145,9 @@ public class XAUtils {
                     result.add(params[0]);
                     return result;
                 case JdbcConstants.KINGBASE:
+                    result.add(params[0]);
+                    return result;
+                case JdbcConstants.OSCAR:
                     result.add(params[0]);
                     return result;
                 case JdbcConstants.MARIADB:

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/PreparedStatementProxyTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/PreparedStatementProxyTest.java
@@ -21,6 +21,7 @@ import com.alibaba.druid.mock.MockNClob;
 import com.alibaba.druid.mock.MockRef;
 import com.alibaba.druid.mock.MockSQLXML;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.rm.datasource.mock.MockBlob;
@@ -43,6 +44,7 @@ import java.io.CharArrayReader;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.Connection;
 import java.sql.Date;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
@@ -123,13 +125,17 @@ public class PreparedStatementProxyTest {
         dataSource.setDriver(mockDriver);
         DataSourceProxy dataSourceProxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
-        ConnectionProxy connectionProxy =
-                new ConnectionProxy(dataSourceProxy, dataSource.getConnection().getConnection());
+        ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
 
         String sql = "update prepared_statement_proxy set name = ?";
 
-        PreparedStatement preparedStatement = mockDriver.createSeataMockPreparedStatement(
-                (MockConnection) connectionProxy.getTargetConnection(), sql);
+        Connection targetConnection = connectionProxy.getTargetConnection();
+        if (targetConnection instanceof DruidStatementConnection) {
+            targetConnection = ((DruidStatementConnection) targetConnection).getConnection();
+        }
+
+        PreparedStatement preparedStatement =
+                mockDriver.createSeataMockPreparedStatement((MockConnection) targetConnection, sql);
 
         preparedStatementProxy = new PreparedStatementProxy(connectionProxy, preparedStatement, sql);
         unusedConstructorPreparedStatementProxy =
@@ -140,6 +146,14 @@ public class PreparedStatementProxyTest {
                 SQLOperateRecognizerHolderFactory.class.getClassLoader());
         DruidDelegatingSQLRecognizerFactory recognizerFactory = (DruidDelegatingSQLRecognizerFactory)
                 EnhancedServiceLoader.load(SQLRecognizerFactory.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
+    }
+
+    private static Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/StatementProxyTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/StatementProxyTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource;
 import com.alibaba.druid.mock.MockResultSet;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.util.jdbc.ResultSetMetaDataBase;
 import com.google.common.collect.Lists;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
@@ -111,10 +113,14 @@ public class StatementProxyTest {
 
         DataSourceProxy dataSourceProxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
-        ConnectionProxy connectionProxy =
-                new ConnectionProxy(dataSourceProxy, dataSource.getConnection().getConnection());
+        ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
 
-        Statement statement = mockDriver.createMockStatement((MockConnection) connectionProxy.getTargetConnection());
+        Connection targetConnection = connectionProxy.getTargetConnection();
+        if (targetConnection instanceof DruidStatementConnection) {
+            targetConnection = ((DruidStatementConnection) targetConnection).getConnection();
+        }
+
+        Statement statement = mockDriver.createMockStatement((MockConnection) targetConnection);
 
         MockResultSet mockResultSet = new MockResultSet(statement);
         ((ResultSetMetaDataBase) mockResultSet.getMetaData())
@@ -129,6 +135,14 @@ public class StatementProxyTest {
                 SQLOperateRecognizerHolderFactory.class.getClassLoader());
         DruidDelegatingSQLRecognizerFactory recognizerFactory = (DruidDelegatingSQLRecognizerFactory)
                 EnhancedServiceLoader.load(SQLRecognizerFactory.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
+    }
+
+    private static Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @AfterEach

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/DeleteExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/DeleteExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.exec;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.util.JdbcConstants;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
@@ -108,10 +110,8 @@ public class DeleteExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(dataSourceProxy, "mysql");
-            ConnectionProxy connectionProxy = new ConnectionProxy(
-                    dataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             statementProxy = new StatementProxy(connectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");
@@ -125,6 +125,14 @@ public class DeleteExecutorTest {
                     return null;
                 },
                 recognizer);
+    }
+
+    private static Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/MariadbInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/MariadbInsertExecutorTest.java
@@ -208,10 +208,9 @@ public class MariadbInsertExecutorTest extends MySQLInsertExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(newDataSourceProxy, "mysql");
-            ConnectionProxy newConnectionProxy = new ConnectionProxy(
-                    newDataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            ConnectionProxy newConnectionProxy =
+                    new ConnectionProxy(newDataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             newStatementProxy = new StatementProxy(newConnectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/MultiExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/MultiExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.exec;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.rm.datasource.ConnectionProxy;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
@@ -117,14 +119,20 @@ public class MultiExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(dataSourceProxy, "mysql");
-            connectionProxy = new ConnectionProxy(
-                    dataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             statementProxy = new StatementProxy(connectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");
         }
+    }
+
+    private static Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.exec;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.google.common.collect.Lists;
@@ -51,6 +52,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -249,14 +251,21 @@ public class MySQLInsertExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(newDataSourceProxy, "mysql");
-            ConnectionProxy newConnectionProxy = new ConnectionProxy(
-                    newDataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            ConnectionProxy newConnectionProxy =
+                    new ConnectionProxy(newDataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             newStatementProxy = new StatementProxy(newConnectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");
         }
+    }
+
+    protected Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/PlainExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/PlainExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.exec;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import org.apache.seata.rm.datasource.ConnectionProxy;
 import org.apache.seata.rm.datasource.DataSourceProxy;
@@ -28,6 +29,7 @@ import org.apache.seata.rm.datasource.mock.MockDriver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
@@ -96,13 +98,19 @@ public class PlainExecutorTest {
 
         DataSourceProxy dataSourceProxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
-        ConnectionProxy connectionProxy =
-                new ConnectionProxy(dataSourceProxy, dataSource.getConnection().getConnection());
-        MockStatementBase mockStatement =
-                new MockStatement(dataSource.getConnection().getConnection());
+        ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
+        MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
         StatementProxy statementProxy = new StatementProxy(connectionProxy, mockStatement);
 
         plainExecutor = new PlainExecutor(statementProxy, (statement, args) -> null);
+    }
+
+    private Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/PolarDBXInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/PolarDBXInsertExecutorTest.java
@@ -214,10 +214,9 @@ public class PolarDBXInsertExecutorTest extends MySQLInsertExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(newDataSourceProxy, "mysql");
-            ConnectionProxy newConnectionProxy = new ConnectionProxy(
-                    newDataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            ConnectionProxy newConnectionProxy =
+                    new ConnectionProxy(newDataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             newStatementProxy = new StatementProxy(newConnectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/SelectForUpdateExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/SelectForUpdateExecutorTest.java
@@ -18,6 +18,7 @@ package org.apache.seata.rm.datasource.exec;
 
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.util.JdbcConstants;
@@ -36,6 +37,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
 
@@ -112,11 +115,9 @@ public class SelectForUpdateExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(dataSourceProxy, "mysql");
-            connectionProxy = new MockConnectionProxy(
-                    dataSourceProxy, dataSource.getConnection().getConnection());
+            connectionProxy = new MockConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
             connectionProxy.bind("xid");
-            MockStatement mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            MockStatement mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             statementProxy = new StatementProxy(connectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");
@@ -131,6 +132,14 @@ public class SelectForUpdateExecutorTest {
                     return null;
                 },
                 recognizer);
+    }
+
+    private static Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/UpdateExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/UpdateExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.exec;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.util.JdbcConstants;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
@@ -158,10 +160,8 @@ public class UpdateExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(dataSourceProxy, "mysql");
-            ConnectionProxy connectionProxy = new ConnectionProxy(
-                    dataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             statementProxy = new StatementProxy(connectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");
@@ -175,6 +175,14 @@ public class UpdateExecutorTest {
                     return null;
                 },
                 recognizer);
+    }
+
+    private static Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/UpdateJoinExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/UpdateJoinExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.exec;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.util.JdbcConstants;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
@@ -211,13 +213,19 @@ public class UpdateJoinExecutorTest {
             Field field = dataSourceProxy.getClass().getDeclaredField("dbType");
             field.setAccessible(true);
             field.set(dataSourceProxy, "mysql");
-            ConnectionProxy connectionProxy = new ConnectionProxy(
-                    dataSourceProxy, dataSource.getConnection().getConnection());
-            MockStatementBase mockStatement =
-                    new MockStatement(dataSource.getConnection().getConnection());
+            ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
+            MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
             return new StatementProxy(connectionProxy, mockStatement);
         } catch (Exception e) {
             throw new RuntimeException("init failed");
         }
+    }
+
+    private Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/TableRecordsTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/TableRecordsTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.rm.datasource.sql.struct;
 import com.alibaba.druid.mock.MockStatement;
 import com.alibaba.druid.mock.MockStatementBase;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import org.apache.seata.common.exception.ShouldNeverHappenException;
 import org.apache.seata.rm.datasource.DataSourceProxy;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -218,8 +220,7 @@ public class TableRecordsTest {
         dataSource.setUrl("jdbc:mock:xxx");
         dataSource.setDriver(mockDriver);
 
-        MockStatementBase mockStatement =
-                new MockStatement(dataSource.getConnection().getConnection());
+        MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
         DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
         TableMeta tableMeta = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.MYSQL)
@@ -232,14 +233,21 @@ public class TableRecordsTest {
         Assertions.assertEquals(returnValue.length, tableRecords.pkRows().size());
     }
 
+    private Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
+    }
+
     @Test
     public void testBuildRecords() throws SQLException {
         MockDriver mockDriver = new MockDriver(returnValueColumnLabels, returnValue, columnMetas, indexMetas);
         DruidDataSource dataSource = new DruidDataSource();
         dataSource.setUrl("jdbc:mock:xxx");
         dataSource.setDriver(mockDriver);
-        MockStatementBase mockStatement =
-                new MockStatement(dataSource.getConnection().getConnection());
+        MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
         DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
         TableMeta tableMeta = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.MYSQL)
@@ -258,8 +266,7 @@ public class TableRecordsTest {
         DruidDataSource dataSource = new DruidDataSource();
         dataSource.setUrl("jdbc:mock:xxx");
         dataSource.setDriver(mockDriver);
-        MockStatementBase mockStatement =
-                new MockStatement(dataSource.getConnection().getConnection());
+        MockStatementBase mockStatement = new MockStatement(getPhysicsConnection(dataSource));
         DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
         TableMeta tableMeta = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.MYSQL)

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/mariadb/MariadbUndoLogManagerTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/mariadb/MariadbUndoLogManagerTest.java
@@ -17,6 +17,7 @@
 package org.apache.seata.rm.datasource.undo.mariadb;
 
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
@@ -50,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -138,11 +140,18 @@ public class MariadbUndoLogManagerTest {
 
         dataSourceProxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
-        connectionProxy =
-                new ConnectionProxy(dataSourceProxy, dataSource.getConnection().getConnection());
+        connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
         undoLogManager = new MariadbUndoLogManager();
         tableMeta = new TableMeta();
         tableMeta.setTableName("table_plain_executor_test");
+    }
+
+    private Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/mysql/MySQLUndoLogManagerTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/mysql/MySQLUndoLogManagerTest.java
@@ -17,6 +17,7 @@
 package org.apache.seata.rm.datasource.undo.mysql;
 
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -135,11 +137,18 @@ public class MySQLUndoLogManagerTest {
 
         dataSourceProxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
 
-        connectionProxy =
-                new ConnectionProxy(dataSourceProxy, dataSource.getConnection().getConnection());
+        connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
         undoLogManager = new MySQLUndoLogManager();
         tableMeta = new TableMeta();
         tableMeta.setTableName("table_plain_executor_test");
+    }
+
+    private Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/polardbx/PolarDBXUndoLogManagerTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/polardbx/PolarDBXUndoLogManagerTest.java
@@ -17,6 +17,7 @@
 package org.apache.seata.rm.datasource.undo.polardbx;
 
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -135,11 +137,18 @@ public class PolarDBXUndoLogManagerTest {
         dataSource.setDriver(mockDriver);
 
         dataSourceProxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
-        connectionProxy =
-                new ConnectionProxy(dataSourceProxy, dataSource.getConnection().getConnection());
+        connectionProxy = new ConnectionProxy(dataSourceProxy, getPhysicsConnection(dataSource));
         undoLogManager = new PolarDBXUndoLogManager();
         tableMeta = new TableMeta();
         tableMeta.setTableName("table_plain_executor_test");
+    }
+
+    private Connection getPhysicsConnection(DruidDataSource dataSource) throws SQLException {
+        Connection connection = dataSource.getConnection().getConnection();
+        if (connection instanceof DruidStatementConnection) {
+            return ((DruidStatementConnection) connection).getConnection();
+        }
+        return connection;
     }
 
     @Test

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/util/XAUtilsTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/util/XAUtilsTest.java
@@ -112,4 +112,9 @@ public class XAUtilsTest {
     public void testCreateXAConnectionDM() throws SQLException, ClassNotFoundException {
         testCreateXAConnectionForDbType(DM, "dm.jdbc.driver.DmdbConnection", "dm.jdbc.driver.DmdbXAConnection");
     }
+
+    @Test
+    public void testCreateXAConnectionOscar() throws SQLException, ClassNotFoundException {
+        testCreateXAConnectionForDbType(OSCAR, "com.oscar.jdbc.OscarJdbc2Connection", "com.oscar.xa.Jdbc3XAConnection");
+    }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/util/XAUtilsTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/util/XAUtilsTest.java
@@ -110,13 +110,11 @@ public class XAUtilsTest {
 
     @Test
     public void testCreateXAConnectionDM() throws SQLException, ClassNotFoundException {
-        testCreateXAConnectionForDbType(
-                DM, "dm.jdbc.driver.DmdbConnection", "dm.jdbc.driver.DmdbXAConnection");
+        testCreateXAConnectionForDbType(DM, "dm.jdbc.driver.DmdbConnection", "dm.jdbc.driver.DmdbXAConnection");
     }
 
     @Test
     public void testCreateXAConnectionOscar() throws SQLException, ClassNotFoundException {
-        testCreateXAConnectionForDbType(
-                OSCAR, "com.oscar.jdbc.OscarJdbc2Connection", "com.oscar.xa.Jdbc3XAConnection");
+        testCreateXAConnectionForDbType(OSCAR, "com.oscar.jdbc.OscarJdbc2Connection", "com.oscar.xa.Jdbc3XAConnection");
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/util/XAUtilsTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/util/XAUtilsTest.java
@@ -110,11 +110,13 @@ public class XAUtilsTest {
 
     @Test
     public void testCreateXAConnectionDM() throws SQLException, ClassNotFoundException {
-        testCreateXAConnectionForDbType(DM, "dm.jdbc.driver.DmdbConnection", "dm.jdbc.driver.DmdbXAConnection");
+        testCreateXAConnectionForDbType(
+                DM, "dm.jdbc.driver.DmdbConnection", "dm.jdbc.driver.DmdbXAConnection");
     }
 
     @Test
     public void testCreateXAConnectionOscar() throws SQLException, ClassNotFoundException {
-        testCreateXAConnectionForDbType(OSCAR, "com.oscar.jdbc.OscarJdbc2Connection", "com.oscar.xa.Jdbc3XAConnection");
+        testCreateXAConnectionForDbType(
+                OSCAR, "com.oscar.jdbc.OscarJdbc2Connection", "com.oscar.xa.Jdbc3XAConnection");
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/DataSourceProxyXATest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/DataSourceProxyXATest.java
@@ -17,9 +17,12 @@
 package org.apache.seata.rm.datasource.xa;
 
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidStatementConnection;
 import com.kingbase8.xa.KBXAConnection;
 import com.mysql.jdbc.JDBC4MySQLConnection;
 import com.mysql.jdbc.jdbc2.optional.JDBC4ConnectionWrapper;
+import com.mysql.jdbc.jdbc2.optional.MysqlXAConnection;
+import com.oscar.xa.Jdbc3XAConnection;
 import org.apache.seata.core.context.RootContext;
 import org.apache.seata.rm.datasource.combine.CombineConnectionHolder;
 import org.apache.seata.rm.datasource.mock.MockDataSource;
@@ -28,6 +31,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.mariadb.jdbc.MariaXaConnection;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -67,34 +71,9 @@ public class DataSourceProxyXATest {
     }
 
     @Test
-    public void testGetConnection() throws SQLException {
-        // Mock
-        Driver driver = mock(Driver.class);
-        JDBC4MySQLConnection connection = mock(JDBC4MySQLConnection.class);
-        Mockito.when(connection.getAutoCommit()).thenReturn(true);
-        DatabaseMetaData metaData = mock(DatabaseMetaData.class);
-        Mockito.when(metaData.getURL()).thenReturn("jdbc:mysql:xxx");
-        Mockito.when(connection.getMetaData()).thenReturn(metaData);
-        Mockito.when(driver.connect(any(), any())).thenReturn(connection);
-
-        DruidDataSource druidDataSource = new DruidDataSource();
-        druidDataSource.setDriver(driver);
-        DataSourceProxyXA dataSourceProxyXA = new DataSourceProxyXA(druidDataSource);
-        Connection connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
-        Assertions.assertFalse(connFromDataSourceProxyXA instanceof ConnectionProxyXA);
-        RootContext.bind("test");
-        connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
-
-        Assertions.assertTrue(connFromDataSourceProxyXA instanceof ConnectionProxyXA);
-        ConnectionProxyXA connectionProxyXA = (ConnectionProxyXA) dataSourceProxyXA.getConnection();
-
-        Connection wrappedConnection = connectionProxyXA.getWrappedConnection();
-        Assertions.assertTrue(wrappedConnection instanceof PooledConnection);
-
-        Connection wrappedPhysicalConn = ((PooledConnection) wrappedConnection).getConnection();
-        Assertions.assertSame(wrappedPhysicalConn, connection);
-
-        XAConnection xaConnection = connectionProxyXA.getWrappedXAConnection();
+    public void testGetConnection() throws SQLException, ClassNotFoundException {
+        XAConnection xaConnection =
+                testGetXaConnection(MysqlXAConnection.class, "jdbc:mysql:xxx", JDBC4MySQLConnection.class.getName());
         Connection connectionInXA = xaConnection.getConnection();
         Assertions.assertTrue(connectionInXA instanceof JDBC4ConnectionWrapper);
         tearDown();
@@ -102,34 +81,8 @@ public class DataSourceProxyXATest {
 
     @Test
     public void testGetMariaXaConnection() throws SQLException, ClassNotFoundException {
-        // Mock
-        Driver driver = mock(Driver.class);
-        Class clazz = Class.forName("org.mariadb.jdbc.MariaDbConnection");
-        Connection connection = (Connection) (mock(clazz));
-        Mockito.when(connection.getAutoCommit()).thenReturn(true);
-        DatabaseMetaData metaData = mock(DatabaseMetaData.class);
-        Mockito.when(metaData.getURL()).thenReturn("jdbc:mariadb:xxx");
-        Mockito.when(connection.getMetaData()).thenReturn(metaData);
-        Mockito.when(driver.connect(any(), any())).thenReturn(connection);
-
-        DruidDataSource druidDataSource = new DruidDataSource();
-        druidDataSource.setDriver(driver);
-        DataSourceProxyXA dataSourceProxyXA = new DataSourceProxyXA(druidDataSource);
-        Connection connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
-        Assertions.assertFalse(connFromDataSourceProxyXA instanceof ConnectionProxyXA);
-        RootContext.bind("test");
-        connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
-
-        Assertions.assertTrue(connFromDataSourceProxyXA instanceof ConnectionProxyXA);
-        ConnectionProxyXA connectionProxyXA = (ConnectionProxyXA) dataSourceProxyXA.getConnection();
-
-        Connection wrappedConnection = connectionProxyXA.getWrappedConnection();
-        Assertions.assertTrue(wrappedConnection instanceof PooledConnection);
-
-        Connection wrappedPhysicalConn = ((PooledConnection) wrappedConnection).getConnection();
-        Assertions.assertSame(wrappedPhysicalConn, connection);
-
-        XAConnection xaConnection = connectionProxyXA.getWrappedXAConnection();
+        XAConnection xaConnection =
+                testGetXaConnection(MariaXaConnection.class, "jdbc:mariadb:xxx", "org.mariadb.jdbc.MariaDbConnection");
         Connection connectionInXA = xaConnection.getConnection();
         Assertions.assertEquals(
                 "org.mariadb.jdbc.MariaDbConnection", connectionInXA.getClass().getName());
@@ -142,18 +95,36 @@ public class DataSourceProxyXATest {
             matches = "[0-1].[1-2].[0-7]",
             disabledReason = "druid 1.2.8 correct support kingbase")
     public void testGetKingbaseXaConnection() throws SQLException, ClassNotFoundException {
+        testGetXaConnection(KBXAConnection.class, "jdbc:kingbase8:xxx", "com.kingbase8.jdbc.KbConnection");
+        tearDown();
+    }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "druid.version",
+            matches = "[0-1].[1-2].[0-24]",
+            disabledReason = "druid 1.2.24 correct support oscar")
+    public void testGetOscarXaConnection() throws SQLException, ClassNotFoundException {
+        testGetXaConnection(Jdbc3XAConnection.class, "jdbc:oscar:xxx", "com.oscar.jdbc.OscarJdbc2Connection");
+        tearDown();
+    }
+
+    private XAConnection testGetXaConnection(
+            Class<? extends XAConnection> xaConnectionClass, String mockJdbcUrl, String connectionClassName)
+            throws SQLException, ClassNotFoundException {
         // Mock
         Driver driver = mock(Driver.class);
-        Class clazz = Class.forName("com.kingbase8.jdbc.KbConnection");
+        Class clazz = Class.forName(connectionClassName);
         Connection connection = (Connection) (mock(clazz));
         Mockito.when(connection.getAutoCommit()).thenReturn(true);
         DatabaseMetaData metaData = mock(DatabaseMetaData.class);
-        Mockito.when(metaData.getURL()).thenReturn("jdbc:kingbase8:xxx");
+        Mockito.when(metaData.getURL()).thenReturn(mockJdbcUrl);
         Mockito.when(connection.getMetaData()).thenReturn(metaData);
         Mockito.when(driver.connect(any(), any())).thenReturn(connection);
 
         DruidDataSource druidDataSource = new DruidDataSource();
         druidDataSource.setDriver(driver);
+        druidDataSource.setUrl(mockJdbcUrl);
         DataSourceProxyXA dataSourceProxyXA = new DataSourceProxyXA(druidDataSource);
         Connection connFromDataSourceProxyXA = dataSourceProxyXA.getConnection();
         Assertions.assertFalse(connFromDataSourceProxyXA instanceof ConnectionProxyXA);
@@ -167,11 +138,14 @@ public class DataSourceProxyXATest {
         Assertions.assertTrue(wrappedConnection instanceof PooledConnection);
 
         Connection wrappedPhysicalConn = ((PooledConnection) wrappedConnection).getConnection();
+        if (wrappedPhysicalConn instanceof DruidStatementConnection) {
+            wrappedPhysicalConn = ((DruidStatementConnection) wrappedPhysicalConn).getConnection();
+        }
         Assertions.assertSame(wrappedPhysicalConn, connection);
 
         XAConnection xaConnection = connectionProxyXA.getWrappedXAConnection();
-        Assertions.assertEquals(xaConnection.getClass(), KBXAConnection.class);
-        tearDown();
+        Assertions.assertEquals(xaConnection.getClass(), xaConnectionClass);
+        return xaConnection;
     }
 
     @Test
@@ -196,6 +170,7 @@ public class DataSourceProxyXATest {
 
             DruidDataSource realDataSource = new DruidDataSource();
             realDataSource.setDriver(driver);
+            realDataSource.setUrl("jdbc:mysql:xxx");
             DataSourceProxyXA proxyDataSource = new DataSourceProxyXA(realDataSource);
 
             Connection result = proxyDataSource.getConnection();

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
@@ -54,8 +54,7 @@ public class OscarOperateRecognizerHolder implements SQLOperateRecognizerHolder 
                 if (selectStatement.getSelect().getFirstQueryBlock() != null) {
                     OscarSelectQueryBlock queryBlock =
                             (OscarSelectQueryBlock) selectStatement.getSelect().getFirstQueryBlock();
-                    if (queryBlock.getForClause() != null
-                            && queryBlock.getForClause().getOption() != null) {
+                    if (queryBlock.getForClause() != null) {
                         if (queryBlock.getForClause().getOption() == OscarSelectQueryBlock.ForClause.Option.UPDATE) {
                             return new OscarSelectForUpdateRecognizer(sql, ast);
                         }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
@@ -48,10 +48,24 @@ public class OscarOperateRecognizerHolder implements SQLOperateRecognizerHolder 
 
     @Override
     public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast) {
-        if (((OscarSelectQueryBlock) ((SQLSelectStatement) ast).getSelect().getFirstQueryBlock())
-                        .getForClause()
-                        .getOption()
-                == OscarSelectQueryBlock.ForClause.Option.UPDATE) {
+        if (!(ast instanceof SQLSelectStatement)) {
+            return null;
+        }
+        SQLSelectStatement selectStatement = (SQLSelectStatement) ast;
+        if (selectStatement.getSelect() == null) {
+            return null;
+        }
+        if (selectStatement.getSelect().getFirstQueryBlock() == null) {
+            return null;
+        }
+        OscarSelectQueryBlock queryBlock = (OscarSelectQueryBlock) selectStatement.getSelect().getFirstQueryBlock();
+        if (queryBlock.getForClause() == null) {
+            return null;
+        }
+        if (queryBlock.getForClause().getOption() == null) {
+            return null;
+        }
+        if (queryBlock.getForClause().getOption() == OscarSelectQueryBlock.ForClause.Option.UPDATE) {
             return new OscarSelectForUpdateRecognizer(sql, ast);
         }
         return null;

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
@@ -48,25 +48,20 @@ public class OscarOperateRecognizerHolder implements SQLOperateRecognizerHolder 
 
     @Override
     public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast) {
-        if (!(ast instanceof SQLSelectStatement)) {
-            return null;
-        }
-        SQLSelectStatement selectStatement = (SQLSelectStatement) ast;
-        if (selectStatement.getSelect() == null) {
-            return null;
-        }
-        if (selectStatement.getSelect().getFirstQueryBlock() == null) {
-            return null;
-        }
-        OscarSelectQueryBlock queryBlock = (OscarSelectQueryBlock) selectStatement.getSelect().getFirstQueryBlock();
-        if (queryBlock.getForClause() == null) {
-            return null;
-        }
-        if (queryBlock.getForClause().getOption() == null) {
-            return null;
-        }
-        if (queryBlock.getForClause().getOption() == OscarSelectQueryBlock.ForClause.Option.UPDATE) {
-            return new OscarSelectForUpdateRecognizer(sql, ast);
+        if ((ast instanceof SQLSelectStatement)) {
+            SQLSelectStatement selectStatement = (SQLSelectStatement) ast;
+            if (selectStatement.getSelect() != null) {
+                if (selectStatement.getSelect().getFirstQueryBlock() != null) {
+                    OscarSelectQueryBlock queryBlock =
+                            (OscarSelectQueryBlock) selectStatement.getSelect().getFirstQueryBlock();
+                    if (queryBlock.getForClause() != null
+                            && queryBlock.getForClause().getOption() != null) {
+                        if (queryBlock.getForClause().getOption() == OscarSelectQueryBlock.ForClause.Option.UPDATE) {
+                            return new OscarSelectForUpdateRecognizer(sql, ast);
+                        }
+                    }
+                }
+            }
         }
         return null;
     }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolder.java
@@ -18,6 +18,7 @@ package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.dialect.oscar.ast.stmt.OscarSelectQueryBlock;
 import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.sqlparser.SQLRecognizer;
 import org.apache.seata.sqlparser.druid.SQLOperateRecognizerHolder;
@@ -47,7 +48,10 @@ public class OscarOperateRecognizerHolder implements SQLOperateRecognizerHolder 
 
     @Override
     public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast) {
-        if (((SQLSelectStatement) ast).getSelect().getFirstQueryBlock().isForUpdate()) {
+        if (((OscarSelectQueryBlock) ((SQLSelectStatement) ast).getSelect().getFirstQueryBlock())
+                        .getForClause()
+                        .getOption()
+                == OscarSelectQueryBlock.ForClause.Option.UPDATE) {
             return new OscarSelectForUpdateRecognizer(sql, ast);
         }
         return null;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmInsertRecognizerTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.sqlparser.druid.dm;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
@@ -84,7 +85,7 @@ public class DmInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
+            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
             DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
             dmInsertRecognizer.getInsertColumns();

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/dm/DmInsertRecognizerTest.java
@@ -19,7 +19,7 @@ package org.apache.seata.sqlparser.druid.dm;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
@@ -84,7 +84,7 @@ public class DmInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
 
             DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
             dmInsertRecognizer.getInsertColumns();
@@ -107,7 +107,7 @@ public class DmInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleIntervalExpr());
 
             DmInsertRecognizer dmInsertRecognizer = new DmInsertRecognizer(s, sqlInsertStatement);
             dmInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseInsertRecognizerTest.java
@@ -19,7 +19,7 @@ package org.apache.seata.sqlparser.druid.kingbase;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
@@ -84,7 +84,7 @@ public class KingbaseInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
 
             KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
             kingbaseInsertRecognizer.getInsertColumns();
@@ -107,7 +107,7 @@ public class KingbaseInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleIntervalExpr());
 
             KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
             kingbaseInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/kingbase/KingbaseInsertRecognizerTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.sqlparser.druid.kingbase;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
@@ -84,7 +85,7 @@ public class KingbaseInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
+            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
             KingbaseInsertRecognizer kingbaseInsertRecognizer = new KingbaseInsertRecognizer(s, sqlInsertStatement);
             kingbaseInsertRecognizer.getInsertColumns();

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oceanbase/OceanBaseInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oceanbase/OceanBaseInsertRecognizerTest.java
@@ -19,7 +19,7 @@ package org.apache.seata.sqlparser.druid.oceanbase;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
@@ -84,7 +84,7 @@ public class OceanBaseInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
 
             OceanBaseInsertRecognizer OceanBaseInsertRecognizer = new OceanBaseInsertRecognizer(s, sqlInsertStatement);
             OceanBaseInsertRecognizer.getInsertColumns();
@@ -107,7 +107,7 @@ public class OceanBaseInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleIntervalExpr());
 
             OceanBaseInsertRecognizer OceanBaseInsertRecognizer = new OceanBaseInsertRecognizer(s, sqlInsertStatement);
             OceanBaseInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oceanbase/OceanBaseInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oceanbase/OceanBaseInsertRecognizerTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.sqlparser.druid.oceanbase;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
@@ -84,7 +85,7 @@ public class OceanBaseInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
+            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
             OceanBaseInsertRecognizer OceanBaseInsertRecognizer = new OceanBaseInsertRecognizer(s, sqlInsertStatement);
             OceanBaseInsertRecognizer.getInsertColumns();

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
@@ -19,7 +19,7 @@ package org.apache.seata.sqlparser.druid.oracle;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
@@ -84,7 +84,7 @@ public class OracleInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
 
             OracleInsertRecognizer oracleInsertRecognizer = new OracleInsertRecognizer(s, sqlInsertStatement);
             oracleInsertRecognizer.getInsertColumns();
@@ -107,7 +107,7 @@ public class OracleInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleIntervalExpr());
 
             OracleInsertRecognizer oracleInsertRecognizer = new OracleInsertRecognizer(s, sqlInsertStatement);
             oracleInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.sqlparser.druid.oracle;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleInsertRecognizerTest.java
@@ -19,7 +19,6 @@ package org.apache.seata.sqlparser.druid.oracle;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/AbstractOscarRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/AbstractOscarRecognizerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.sqlparser.druid.oscar;
+
+import org.apache.seata.sqlparser.druid.AbstractRecognizerTest;
+import org.apache.seata.sqlparser.util.JdbcConstants;
+
+/**
+ * Base Test for recognizer of Oscar
+ *
+ **/
+public class AbstractOscarRecognizerTest extends AbstractRecognizerTest {
+    @Override
+    public String getDbType() {
+        return JdbcConstants.OSCAR;
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarDeleteRecognizerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.sqlparser.druid.oscar;
 
-import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleArgumentExpr;
@@ -27,65 +26,57 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
  * The type Oscar delete recognizer test.
  */
-public class OscarDeleteRecognizerTest {
-
-    private static final String DB_TYPE = "oscar";
+public class OscarDeleteRecognizerTest extends AbstractOscarRecognizerTest {
 
     @Test
     public void testGetSqlType() {
         String sql = "delete from t where id = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.DELETE);
     }
 
     @Test
     public void testGetTableAlias() {
         String sql = "delete from t where id = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "delete from t where id = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "delete from t";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         String whereCondition = recognizer.getWhereCondition(
-                new ParametersHolder() {
-                    @Override
-                    public Map<Integer, ArrayList<Object>> getParameters() {
-                        return null;
-                    }
-                },
+                () -> null,
                 new ArrayList<>());
 
         // test for no condition
         Assertions.assertEquals("", whereCondition);
 
         sql = "delete from t where id = ?";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        sqlStatement = getSQLStatement(sql);
 
-        recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         whereCondition = recognizer.getWhereCondition(
                 new ParametersHolder() {
                     @Override
@@ -103,8 +94,8 @@ public class OscarDeleteRecognizerTest {
         Assertions.assertEquals("id = ?", whereCondition);
 
         sql = "delete from t where id in (?)";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        sqlStatement = getSQLStatement(sql);
+        recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         whereCondition = recognizer.getWhereCondition(
                 new ParametersHolder() {
                     @Override
@@ -122,8 +113,8 @@ public class OscarDeleteRecognizerTest {
         Assertions.assertEquals("id IN (?)", whereCondition);
 
         sql = "delete from t where id between ? and ?";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        sqlStatement = getSQLStatement(sql);
+        recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         whereCondition = recognizer.getWhereCondition(
                 new ParametersHolder() {
                     @Override
@@ -145,17 +136,11 @@ public class OscarDeleteRecognizerTest {
         // test for exception
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             String s = "delete from t where id in (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLDeleteStatement deleteAst = (SQLDeleteStatement) sqlStatements.get(0);
+            SQLDeleteStatement deleteAst = (SQLDeleteStatement) getSQLStatement(s);
             deleteAst.setWhere(new OracleArgumentExpr());
             new OscarDeleteRecognizer(s, deleteAst)
                     .getWhereCondition(
-                            new ParametersHolder() {
-                                @Override
-                                public Map<Integer, ArrayList<Object>> getParameters() {
-                                    return new HashMap<>();
-                                }
-                            },
+                            () -> new HashMap<>(),
                             new ArrayList<>());
         });
     }
@@ -164,34 +149,34 @@ public class OscarDeleteRecognizerTest {
     public void testGetWhereCondition_1() {
 
         String sql = "delete from t";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         String whereCondition = recognizer.getWhereCondition();
 
         // test for no condition
         Assertions.assertEquals("", whereCondition);
 
         sql = "delete from t where id = 1";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        sqlStatement = getSQLStatement(sql);
 
-        recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         whereCondition = recognizer.getWhereCondition();
 
         // test for normal sql
         Assertions.assertEquals("id = 1", whereCondition);
 
         sql = "delete from t where id in (1)";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        sqlStatement = getSQLStatement(sql);
+        recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         whereCondition = recognizer.getWhereCondition();
 
         // test for sql with in
         Assertions.assertEquals("id IN (1)", whereCondition);
 
         sql = "delete from t where id between 1 and 2";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarDeleteRecognizer(sql, asts.get(0));
+        sqlStatement = getSQLStatement(sql);
+        recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
         whereCondition = recognizer.getWhereCondition();
         // test for sql with in
         Assertions.assertEquals("id BETWEEN 1 AND 2", whereCondition);
@@ -199,8 +184,7 @@ public class OscarDeleteRecognizerTest {
         // test for exception
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             String s = "delete from t where id in (1)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLDeleteStatement deleteAst = (SQLDeleteStatement) sqlStatements.get(0);
+            SQLDeleteStatement deleteAst = (SQLDeleteStatement) getSQLStatement(s);
             deleteAst.setWhere(new OracleArgumentExpr());
             new OscarDeleteRecognizer(s, deleteAst).getWhereCondition();
         });

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarDeleteRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarDeleteRecognizerTest.java
@@ -66,9 +66,7 @@ public class OscarDeleteRecognizerTest extends AbstractOscarRecognizerTest {
         SQLStatement sqlStatement = getSQLStatement(sql);
 
         OscarDeleteRecognizer recognizer = new OscarDeleteRecognizer(sql, sqlStatement);
-        String whereCondition = recognizer.getWhereCondition(
-                () -> null,
-                new ArrayList<>());
+        String whereCondition = recognizer.getWhereCondition(() -> null, new ArrayList<>());
 
         // test for no condition
         Assertions.assertEquals("", whereCondition);
@@ -138,10 +136,7 @@ public class OscarDeleteRecognizerTest extends AbstractOscarRecognizerTest {
             String s = "delete from t where id in (?)";
             SQLDeleteStatement deleteAst = (SQLDeleteStatement) getSQLStatement(s);
             deleteAst.setWhere(new OracleArgumentExpr());
-            new OscarDeleteRecognizer(s, deleteAst)
-                    .getWhereCondition(
-                            () -> new HashMap<>(),
-                            new ArrayList<>());
+            new OscarDeleteRecognizer(s, deleteAst).getWhereCondition(() -> new HashMap<>(), new ArrayList<>());
         });
     }
 

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.sqlparser.druid.oscar;
 
-import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
@@ -33,34 +32,32 @@ import java.util.List;
 /**
  * The type Oscar insert recognizer test.
  */
-public class OscarInsertRecognizerTest {
-
-    private static final String DB_TYPE = "oscar";
+public class OscarInsertRecognizerTest extends AbstractOscarRecognizerTest {
 
     @Test
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
     @Test
     public void testGetTableAlias() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, sqlStatement);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "insert into t(id) values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -69,25 +66,24 @@ public class OscarInsertRecognizerTest {
 
         // test for no column
         String sql = "insert into t values (?)";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, sqlStatement);
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
         // test for normal
         sql = "insert into t(a) values (?)";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        sqlStatement = getSQLStatement(sql);
 
-        recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        recognizer = new OscarInsertRecognizer(sql, sqlStatement);
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
         // test for exception
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
+            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) getSQLStatement(s);
             sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
             OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
@@ -100,17 +96,16 @@ public class OscarInsertRecognizerTest {
         final int pkIndex = 0;
         // test for null value
         String sql = "insert into t(id, no, name, age, time) values (id_seq.nextval, null, 'a', ?, now())";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, asts.get(0));
+        OscarInsertRecognizer recognizer = new OscarInsertRecognizer(sql, sqlStatement);
         List<List<Object>> insertRows = recognizer.getInsertRows(Collections.singletonList(pkIndex));
         Assertions.assertEquals(1, insertRows.size());
 
         // test for exception
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "insert into t(a) values (?)";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
+            SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) getSQLStatement(s);
             sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleIntervalExpr());
 
             OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
@@ -121,9 +116,9 @@ public class OscarInsertRecognizerTest {
     @Test
     public void testNotPlaceholder_giveValidPkIndex() {
         String sql = "insert into test(create_time) values(sysdate)";
-        List<SQLStatement> sqlStatements = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarInsertRecognizer oscar = new OscarInsertRecognizer(sql, sqlStatements.get(0));
+        OscarInsertRecognizer oscar = new OscarInsertRecognizer(sql, sqlStatement);
         List<List<Object>> insertRows = oscar.getInsertRows(Collections.singletonList(-1));
         Assertions.assertTrue(insertRows.get(0).get(0) instanceof NotPlaceholderExpr);
     }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.sqlparser.druid.oscar;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
 import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
@@ -87,7 +88,7 @@ public class OscarInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
+            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
 
             OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
             oscarInsertRecognizer.getInsertColumns();

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarInsertRecognizerTest.java
@@ -19,7 +19,7 @@ package org.apache.seata.sqlparser.druid.oscar;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
-import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleBinaryDoubleExpr;
+import com.alibaba.druid.sql.dialect.oracle.ast.expr.OracleIntervalExpr;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
@@ -87,7 +87,7 @@ public class OscarInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getColumns().add(new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getColumns().add(new OracleIntervalExpr());
 
             OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
             oscarInsertRecognizer.getInsertColumns();
@@ -110,7 +110,7 @@ public class OscarInsertRecognizerTest {
             String s = "insert into t(a) values (?)";
             List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
             SQLInsertStatement sqlInsertStatement = (SQLInsertStatement) sqlStatements.get(0);
-            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleBinaryDoubleExpr());
+            sqlInsertStatement.getValuesList().get(0).getValues().set(pkIndex, new OracleIntervalExpr());
 
             OscarInsertRecognizer oscarInsertRecognizer = new OscarInsertRecognizer(s, sqlInsertStatement);
             oscarInsertRecognizer.getInsertRows(Collections.singletonList(pkIndex));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
@@ -68,7 +68,7 @@ public class OscarOperateRecognizerHolderTest extends AbstractOscarRecognizerTes
         selectStatement.setSelect(null);
         Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
 
-        // set select field query is null
+        // set select query is null
         selectStatement = (SQLSelectStatement) getSQLStatement(sql);
         selectStatement.getSelect().setQuery(null);
         Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.sqlparser.druid.oscar;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Test cases for recognizer holder of Oscar
+ *
+ */
+public class OscarOperateRecognizerHolderTest extends AbstractOscarRecognizerTest {
+    @Test
+    public void getDeleteRecognizerTest() {
+        String sql = "DELETE FROM t WHERE id = 1";
+        List<SQLStatement> stats = SQLUtils.parseStatements(sql, getDbType());
+        SQLStatement sqlStatement = stats.get(0);
+        Assertions.assertNotNull(new OscarOperateRecognizerHolder().getDeleteRecognizer(sql, sqlStatement));
+    }
+
+    @Test
+    public void getInsertRecognizerTest() {
+        String sql = "INSERT INTO t (name) VALUES ('test')";
+        SQLStatement sqlStatement = getSQLStatement(sql);
+        Assertions.assertNotNull(new OscarOperateRecognizerHolder().getInsertRecognizer(sql, sqlStatement));
+    }
+
+    @Test
+    public void getUpdateRecognizerTest() {
+        String sql = "UPDATE t SET name = 'test' WHERE id = 1";
+        SQLStatement sqlStatement = getSQLStatement(sql);
+        Assertions.assertNotNull(new OscarOperateRecognizerHolder().getUpdateRecognizer(sql, sqlStatement));
+    }
+
+    @Test
+    public void getSelectForUpdateTest() {
+        // common select without lock
+        String sql = "SELECT name FROM t1 WHERE id = 1";
+        SQLStatement sqlStatement = getSQLStatement(sql);
+        Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
+
+        // select for update
+        sql += " FOR UPDATE";
+        sqlStatement = getSQLStatement(sql);
+        Assertions.assertNotNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
@@ -18,6 +18,7 @@ package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -52,9 +53,24 @@ public class OscarOperateRecognizerHolderTest extends AbstractOscarRecognizerTes
 
     @Test
     public void getSelectForUpdateTest() {
-        // common select without lock
-        String sql = "SELECT name FROM t1 WHERE id = 1";
+        // not select clause
+        String sql = "DELETE FROM t WHERE id = 1";
         SQLStatement sqlStatement = getSQLStatement(sql);
+        Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
+
+        // common select without lock
+        sql = "SELECT name FROM t1 WHERE id = 1";
+        sqlStatement = getSQLStatement(sql);
+        Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
+
+        // set select is null
+        SQLSelectStatement selectStatement = (SQLSelectStatement) getSQLStatement(sql);
+        selectStatement.setSelect(null);
+        Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
+
+        // set select field query is null
+        selectStatement = (SQLSelectStatement) getSQLStatement(sql);
+        selectStatement.getSelect().setQuery(null);
         Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
 
         // select for update

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarOperateRecognizerHolderTest.java
@@ -19,6 +19,7 @@ package org.apache.seata.sqlparser.druid.oscar;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.alibaba.druid.sql.dialect.oscar.ast.stmt.OscarSelectQueryBlock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +76,13 @@ public class OscarOperateRecognizerHolderTest extends AbstractOscarRecognizerTes
 
         // select for update
         sql += " FOR UPDATE";
-        sqlStatement = getSQLStatement(sql);
-        Assertions.assertNotNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, sqlStatement));
+        selectStatement = (SQLSelectStatement) getSQLStatement(sql);
+        Assertions.assertNotNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, selectStatement));
+
+        // set getForClause is null
+        OscarSelectQueryBlock queryBlock =
+                (OscarSelectQueryBlock) selectStatement.getSelect().getFirstQueryBlock();
+        queryBlock.setForClause(null);
+        Assertions.assertNull(new OscarOperateRecognizerHolder().getSelectForUpdateRecognizer(sql, selectStatement));
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarSelectForUpdateRecognizerTest.java
@@ -18,20 +18,18 @@ package org.apache.seata.sqlparser.druid.oscar;
 
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
-import org.apache.seata.sqlparser.ParametersHolder;
 import org.apache.seata.sqlparser.SQLParsingException;
 import org.apache.seata.sqlparser.SQLType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 /**
  * The type Oscar select for update recognizer test.
  */
 public class OscarSelectForUpdateRecognizerTest extends AbstractOscarRecognizerTest {
-    
+
     @Test
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
@@ -47,9 +45,7 @@ public class OscarSelectForUpdateRecognizerTest extends AbstractOscarRecognizerT
         SQLStatement sqlStatement = getSQLStatement(sql);
 
         OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, sqlStatement);
-        String whereCondition = recognizer.getWhereCondition(
-                () -> null,
-                new ArrayList<>());
+        String whereCondition = recognizer.getWhereCondition(() -> null, new ArrayList<>());
         Assertions.assertEquals("", whereCondition);
     }
 

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarSelectForUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarSelectForUpdateRecognizerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.sqlparser.druid.oscar;
 
-import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import org.apache.seata.sqlparser.ParametersHolder;
@@ -26,38 +25,30 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /**
  * The type Oscar select for update recognizer test.
  */
-public class OscarSelectForUpdateRecognizerTest {
-
-    private static final String DB_TYPE = "oscar";
-
+public class OscarSelectForUpdateRecognizerTest extends AbstractOscarRecognizerTest {
+    
     @Test
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
 
     @Test
     public void testGetWhereCondition_0() {
         String sql = "select * from t for update";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, sqlStatement);
         String whereCondition = recognizer.getWhereCondition(
-                new ParametersHolder() {
-                    @Override
-                    public Map<Integer, ArrayList<Object>> getParameters() {
-                        return null;
-                    }
-                },
+                () -> null,
                 new ArrayList<>());
         Assertions.assertEquals("", whereCondition);
     }
@@ -65,9 +56,9 @@ public class OscarSelectForUpdateRecognizerTest {
     @Test
     public void testGetWhereCondition_1() {
         String sql = "select * from t for update";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, sqlStatement);
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -75,8 +66,7 @@ public class OscarSelectForUpdateRecognizerTest {
         // test for select was null
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "select * from t for update";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
+            SQLSelectStatement selectAst = (SQLSelectStatement) getSQLStatement(s);
             selectAst.setSelect(null);
             new OscarSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
@@ -84,8 +74,7 @@ public class OscarSelectForUpdateRecognizerTest {
         // test for query was null
         Assertions.assertThrows(SQLParsingException.class, () -> {
             String s = "select * from t";
-            List<SQLStatement> sqlStatements = SQLUtils.parseStatements(s, DB_TYPE);
-            SQLSelectStatement selectAst = (SQLSelectStatement) sqlStatements.get(0);
+            SQLSelectStatement selectAst = (SQLSelectStatement) getSQLStatement(s);
             selectAst.getSelect().setQuery(null);
             new OscarSelectForUpdateRecognizer(s, selectAst).getWhereCondition();
         });
@@ -94,18 +83,18 @@ public class OscarSelectForUpdateRecognizerTest {
     @Test
     public void testGetTableAlias() {
         String sql = "select * from t where id = ? for update";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, sqlStatement);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "select * from t where id = ? for update";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, asts.get(0));
+        OscarSelectForUpdateRecognizer recognizer = new OscarSelectForUpdateRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarUpdateRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oscar/OscarUpdateRecognizerTest.java
@@ -34,16 +34,16 @@ import java.util.Map;
 /**
  * The Oscar Update Recognizer Test.
  */
-public class OscarUpdateRecognizerTest {
+public class OscarUpdateRecognizerTest extends AbstractOscarRecognizerTest {
 
     private static final String DB_TYPE = "oscar";
 
     @Test
     public void testGetSqlType() {
         String sql = "update t set n = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.UPDATE);
     }
 
@@ -51,15 +51,15 @@ public class OscarUpdateRecognizerTest {
     public void testGetUpdateColumns() {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        SQLStatement sqlStatement = getSQLStatement(sql);
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         List<String> updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         // test with alias
         sql = "update t set a.a = ?, a.b = ?, a.c = ?";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        sqlStatement = getSQLStatement(sql);
+        recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
@@ -81,15 +81,15 @@ public class OscarUpdateRecognizerTest {
     public void testGetUpdateValues() {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        SQLStatement sqlStatement = getSQLStatement(sql);
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         List<Object> updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with values
         sql = "update t set a = 1, b = 2, c = 3";
-        asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        sqlStatement = getSQLStatement(sql);
+        recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
@@ -111,9 +111,9 @@ public class OscarUpdateRecognizerTest {
     public void testGetWhereCondition_0() {
 
         String sql = "update t set a = 1";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         String whereCondition = recognizer.getWhereCondition(
                 new ParametersHolder() {
                     @Override
@@ -130,9 +130,9 @@ public class OscarUpdateRecognizerTest {
     public void testGetWhereCondition_1() {
 
         String sql = "update t set a = 1";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -141,18 +141,18 @@ public class OscarUpdateRecognizerTest {
     @Test
     public void testGetTableAlias() {
         String sql = "update t set a = ?, b = ?, c = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "update t set a = ?, b = ?, c = ?";
-        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        SQLStatement sqlStatement = getSQLStatement(sql);
 
-        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, asts.get(0));
+        OscarUpdateRecognizer recognizer = new OscarUpdateRecognizer(sql, sqlStatement);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }


### PR DESCRIPTION
2. Upgrade depends on druid version 1.2.25
3. Modify test cases that fail after upgrading druid

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
1. Support shentongdatabase xa mode
2. Upgrade depends on druid version 1.2.25
3. Modify test cases that fail after upgrading druid


> 1. 支持神通数据库XA模式
> 2. 升级依赖druid版本到1.2.25
> 3. 修改升级druid导致的测试用例错误

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7665 
### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

