### PR TITLE
optimize: bump @babel/runtime to ^7.27.0

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -101,6 +101,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [WangzJi](https://github.com/WangzJi)
 - [Asuka-star](https://github.com/Asuka-star)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
-
+- [jihun4452](https://github.com/jihun4452)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -55,6 +55,8 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7614](https://github.com/seata/seata/pull/7614)] update README.md
 - [[#7443](https://github.com/seata/seata/pull/7443)] Replace @LocalTCC with @SagaTransactional in the saga annotation pattern
 - [[#7645](https://github.com/seata/seata/pull/7645)] simplifying the relevant transport.* configuration types
+- [[#7673](https://github.com/apache/incubator-seata/pull/7673)] bump @babel/runtime from ^7.26.10 to ^7.27.0
+
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -102,6 +102,6 @@
 - [WangzJi](https://github.com/WangzJi)
 - [Asuka-star](https://github.com/Asuka-star)
 - [YoWuwuuuw](https://github.com/YoWuwuuuw)
-
+- [jihun4452](https://github.com/jihun4452)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -54,6 +54,8 @@
 - [[#7614](https://github.com/seata/seata/pull/7614)] 更新 README.md
 - [[#7443](https://github.com/seata/seata/pull/7443)] 将saga注释模式中的@LocalTCC替换为@SagaTransactional
 - [[#7645](https://github.com/seata/seata/pull/7645)] 简化相关的 transport.* 配置项类型
+- [[#7673](https://github.com/apache/incubator-seata/pull/7673)] 升级 @babel/runtime ^7.26.10 到 ^7.27.0
+
 
 ### security:
 

--- a/console/src/main/resources/static/console-fe/package-lock.json
+++ b/console/src/main/resources/static/console-fe/package-lock.json
@@ -41,7 +41,7 @@
         "@babel/plugin-proposal-decorators": "^7.23.7",
         "@babel/preset-env": "^7.23.8",
         "@babel/preset-typescript": "^7.23.3",
-        "@babel/runtime": "^7.26.10",
+        "@babel/runtime": "^7.27.0",
         "@types/lodash": "^4.14.202",
         "@types/node": "^13.1.4",
         "@types/react": "^16.14.56",
@@ -2221,12 +2221,10 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -6554,16 +6552,6 @@
         "redux": "3.x"
       }
     },
-    "node_modules/dva-core/node_modules/@babel/runtime": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
-      "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
-      "peer": true,
-      "dependencies": {
-        "core-js": "^2.5.3",
-        "regenerator-runtime": "^0.11.1"
-      }
-    },
     "node_modules/dva-core/node_modules/redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmmirror.com/redux/-/redux-3.7.2.tgz",
@@ -6576,12 +6564,6 @@
         "symbol-observable": "^1.0.3"
       }
     },
-    "node_modules/dva-core/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "peer": true
-    },
     "node_modules/dva-core/node_modules/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/warning/-/warning-3.0.0.tgz",
@@ -6589,16 +6571,6 @@
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/dva/node_modules/@babel/runtime": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
-      "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
-      "peer": true,
-      "dependencies": {
-        "core-js": "^2.5.3",
-        "regenerator-runtime": "^0.11.1"
       }
     },
     "node_modules/dva/node_modules/@types/react-router-dom": {
@@ -6697,12 +6669,6 @@
         "loose-envify": "^1.1.0",
         "symbol-observable": "^1.0.3"
       }
-    },
-    "node_modules/dva/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "peer": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -14322,11 +14288,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/console/src/main/resources/static/console-fe/package.json
+++ b/console/src/main/resources/static/console-fe/package.json
@@ -31,7 +31,7 @@
     "@babel/plugin-proposal-decorators": "^7.23.7",
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-typescript": "^7.23.3",
-    "@babel/runtime": "^7.26.10",
+    "@babel/runtime": "^7.27.0",
     "@types/lodash": "^4.14.202",
     "@types/node": "^13.1.4",
     "@types/react": "^16.14.56",

--- a/console/src/main/resources/static/console-fe/package.json
+++ b/console/src/main/resources/static/console-fe/package.json
@@ -106,6 +106,7 @@
     "nanoid": "3.1.31",
     "ip": "2.0.1",
     "sha.js": "2.4.12",
-    "cipher-base": "1.0.6"
+    "cipher-base": "1.0.6",
+    "@babel/runtime": "^7.27.0"
   }
 }


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.  
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).  

### Ⅰ. Describe what this PR did  
Update `console-fe/package.json` to bump `@babel/runtime` from `^7.26.10` to `^7.27.0`.  

This aligns the direct dependency with the already resolved version in `package-lock.json` and addresses the potential security risk (CVE-2025-27789).  

### Ⅱ. Does this pull request fix one issue?  
fixes #7660  

### Ⅲ. Why don't you add test cases (unit test/integration test)?  
Not applicable. This PR only updates a dependency version in `package.json`.  

### Ⅳ. Describe how to verify it  
1. Run `npm install` under `console-fe`.  
2. Confirm that `node_modules/@babel/runtime` is installed at version `7.27.0`.  
3. Build and run `console-fe` successfully without errors.  

### Ⅴ. Special notes for reviews  
None.  
