### PR TITLE
feature: support Oracle Batch Insert

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -27,6 +27,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7559](https://github.com/apache/incubator-seata/pull/7559)] Introduce Cleanup API for TableMetaRefreshHolder Instance
 - [[#7669](https://github.com/apache/incubator-seata/pull/7669)] add support for Jackson serialization and deserialization of PostgreSQL array types
 - [[#7664](https://github.com/apache/incubator-seata/pull/7664)] support shentongdatabase XA mode
+- [[#7675](https://github.com/apache/incubator-seata/pull/7675)] support Oracle Batch Insert
 
 ### bugfix:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,6 +27,7 @@
 - [[#7559](https://github.com/apache/incubator-seata/pull/7559)] 为 TableMetaRefreshHolder 实例引入清理 API
 - [[#7669](https://github.com/apache/incubator-seata/pull/7669)] 添加对 Jackson 序列化和反序列化 PostgreSQL 数组类型的支持
 - [[#7664](https://github.com/apache/incubator-seata/pull/7565)] 支持神通数据库的XA模式
+- [[#7675](https://github.com/apache/incubator-seata/pull/7675)] 支持Oracle批量插入
 
 
 ### bugfix:

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
@@ -29,7 +29,6 @@ import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.sqlparser.SQLRecognizer;
 import org.apache.seata.sqlparser.SQLRecognizerFactory;
 import org.apache.seata.sqlparser.druid.oracle.OracleOperateRecognizerHolder;
-import org.apache.seata.sqlparser.util.JdbcConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,15 +74,10 @@ class DruidSQLRecognizerFactoryImpl implements SQLRecognizerFactory {
                 recognizer = recognizerHolder.getDeleteRecognizer(sql, sqlStatement);
             } else if (sqlStatement instanceof SQLSelectStatement) {
                 recognizer = recognizerHolder.getSelectForUpdateRecognizer(sql, sqlStatement);
-            }else if (sqlStatement instanceof OracleMultiInsertStatement) {
-                // 使用专门的方法处理 Oracle 批量插入
-                if (JdbcConstants.ORACLE.equals(dbType.toLowerCase())) {
-                    recognizer = ((OracleOperateRecognizerHolder) recognizerHolder)
-                            .getMultiInsertRecognizer(sql, sqlStatement);
-                } else {
-                    throw new NotSupportYetException(
-                            "OracleMultiInsertStatement is only supported for Oracle database: " + sql);
-                }
+            } else if (sqlStatement instanceof OracleMultiInsertStatement) {
+                // Use specialized methods to handle Oracle bulk inserts
+                recognizer =
+                        ((OracleOperateRecognizerHolder) recognizerHolder).getMultiInsertRecognizer(sql, sqlStatement);
             }
 
             // When recognizer is null, it indicates that recognizerHolder cannot allocate unsupported syntax, like

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
@@ -76,7 +76,7 @@ class DruidSQLRecognizerFactoryImpl implements SQLRecognizerFactory {
                 recognizer = recognizerHolder.getSelectForUpdateRecognizer(sql, sqlStatement);
             } else if (sqlStatement instanceof OracleMultiInsertStatement) {
                 OracleMultiInsertStatement stmt = (OracleMultiInsertStatement) sqlStatement;
-                if (stmt.getOption() == OracleMultiInsertStatement.Option.FIRST){
+                if (stmt.getOption() == OracleMultiInsertStatement.Option.FIRST) {
                     throw new NotSupportYetException("INSERT FIRST not supported yet");
                 }
                 // Use specialized methods to handle Oracle bulk inserts

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
@@ -23,10 +23,13 @@ import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.ast.statement.SQLReplaceStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.stmt.OracleMultiInsertStatement;
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.sqlparser.SQLRecognizer;
 import org.apache.seata.sqlparser.SQLRecognizerFactory;
+import org.apache.seata.sqlparser.druid.oracle.OracleOperateRecognizerHolder;
+import org.apache.seata.sqlparser.util.JdbcConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +75,15 @@ class DruidSQLRecognizerFactoryImpl implements SQLRecognizerFactory {
                 recognizer = recognizerHolder.getDeleteRecognizer(sql, sqlStatement);
             } else if (sqlStatement instanceof SQLSelectStatement) {
                 recognizer = recognizerHolder.getSelectForUpdateRecognizer(sql, sqlStatement);
+            }else if (sqlStatement instanceof OracleMultiInsertStatement) {
+                // 使用专门的方法处理 Oracle 批量插入
+                if (JdbcConstants.ORACLE.equals(dbType.toLowerCase())) {
+                    recognizer = ((OracleOperateRecognizerHolder) recognizerHolder)
+                            .getMultiInsertRecognizer(sql, sqlStatement);
+                } else {
+                    throw new NotSupportYetException(
+                            "OracleMultiInsertStatement is only supported for Oracle database: " + sql);
+                }
             }
 
             // When recognizer is null, it indicates that recognizerHolder cannot allocate unsupported syntax, like

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
@@ -75,6 +75,10 @@ class DruidSQLRecognizerFactoryImpl implements SQLRecognizerFactory {
             } else if (sqlStatement instanceof SQLSelectStatement) {
                 recognizer = recognizerHolder.getSelectForUpdateRecognizer(sql, sqlStatement);
             } else if (sqlStatement instanceof OracleMultiInsertStatement) {
+                OracleMultiInsertStatement stmt = (OracleMultiInsertStatement) sqlStatement;
+                if (stmt.getOption() == OracleMultiInsertStatement.Option.FIRST){
+                    throw new NotSupportYetException("INSERT FIRST not supported yet");
+                }
                 // Use specialized methods to handle Oracle bulk inserts
                 recognizer =
                         ((OracleOperateRecognizerHolder) recognizerHolder).getMultiInsertRecognizer(sql, sqlStatement);

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -60,7 +60,13 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
     }
 
     /**
-     * Verify that all entries are in the same table and have consistent column definitions.
+     * Verifies that all entries are in the same table and have consistent column definitions.
+     * <p>
+     * If validation fails (e.g., conditional clauses are present, or table/column consistency is violated),
+     * this method throws a {@link NotSupportYetException}.
+     * <p>
+     * Upon successful validation, initializes {@code validatedTableName} and {@code validatedColumns}
+     * with the consistent table name and column definitions.
      */
     private void validateSingleTableConsistency() {
         if (CollectionUtils.isEmpty(ast.getEntries())) {

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -1,0 +1,194 @@
+package org.apache.seata.sqlparser.druid.oracle;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.ast.expr.SQLNullExpr;
+import com.alibaba.druid.sql.ast.expr.SQLSequenceExpr;
+import com.alibaba.druid.sql.ast.expr.SQLValuableExpr;
+import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.stmt.OracleMultiInsertStatement;
+import com.alibaba.druid.sql.dialect.oracle.visitor.OracleOutputVisitor;
+import org.apache.seata.common.util.CollectionUtils;
+import org.apache.seata.sqlparser.SQLInsertRecognizer;
+import org.apache.seata.sqlparser.SQLType;
+import org.apache.seata.sqlparser.struct.NotPlaceholderExpr;
+import org.apache.seata.sqlparser.struct.Null;
+import org.apache.seata.sqlparser.struct.SqlMethodExpr;
+import org.apache.seata.sqlparser.struct.SqlSequenceExpr;
+import org.apache.seata.sqlparser.util.ColumnUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Oracle Multi Insert Recognizer for INSERT ALL statements
+ */
+public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements SQLInsertRecognizer {
+
+    private final OracleMultiInsertStatement ast;
+
+    public OracleMultiInsertRecognizer(String originalSQL, SQLStatement ast) {
+        super(originalSQL);
+        this.ast = (OracleMultiInsertStatement) ast;
+    }
+
+    @Override
+    public SQLType getSQLType() {
+        return SQLType.INSERT;
+    }
+
+    @Override
+    public String getTableAlias() {
+        // Oracle Multi Insert 通常只涉及一个表，取第一个插入项的表别名
+        if (!CollectionUtils.isEmpty(ast.getEntries())) {
+            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
+            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
+                OracleMultiInsertStatement.InsertIntoClause insertClause = 
+                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                if (insertClause.getTableSource() != null) {
+                    return insertClause.getTableSource().getAlias();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getTableName() {
+        // Oracle Multi Insert 通常只涉及一个表，取第一个插入项的表名
+        if (!CollectionUtils.isEmpty(ast.getEntries())) {
+            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
+            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
+                OracleMultiInsertStatement.InsertIntoClause insertClause = 
+                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                if (insertClause.getTableSource() != null) {
+                    StringBuilder sb = new StringBuilder();
+                    OracleOutputVisitor visitor = new OracleOutputVisitor(sb) {
+                        @Override
+                        public boolean visit(SQLExprTableSource x) {
+                            printTableSourceExpr(x.getExpr());
+                            return false;
+                        }
+                    };
+                    visitor.visit(insertClause.getTableSource());
+                    return sb.toString();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean insertColumnsIsEmpty() {
+        if (!CollectionUtils.isEmpty(ast.getEntries())) {
+            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
+            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
+                OracleMultiInsertStatement.InsertIntoClause insertClause = 
+                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                return CollectionUtils.isEmpty(insertClause.getColumns());
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> getInsertColumns() {
+        if (!CollectionUtils.isEmpty(ast.getEntries())) {
+            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
+            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
+                OracleMultiInsertStatement.InsertIntoClause insertClause = 
+                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                if (!CollectionUtils.isEmpty(insertClause.getColumns())) {
+                    List<SQLExpr> columnSQLExprs = insertClause.getColumns();
+                    List<String> list = new ArrayList<>(columnSQLExprs.size());
+                    for (SQLExpr expr : columnSQLExprs) {
+                        if (expr instanceof SQLIdentifierExpr) {
+                            list.add(((SQLIdentifierExpr) expr).getName());
+                        } else {
+                            wrapSQLParsingException(expr);
+                        }
+                    }
+                    return list;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<List<Object>> getInsertRows(Collection<Integer> primaryKeyIndex) {
+        List<List<Object>> allRows = new ArrayList<>();
+
+        if (!CollectionUtils.isEmpty(ast.getEntries())) {
+            for (OracleMultiInsertStatement.Entry entry : ast.getEntries()) {
+                if (entry instanceof OracleMultiInsertStatement.InsertIntoClause) {
+                    OracleMultiInsertStatement.InsertIntoClause insertClause = 
+                        (OracleMultiInsertStatement.InsertIntoClause) entry;
+                    
+                    if (!CollectionUtils.isEmpty(insertClause.getValuesList())) {
+                        for (SQLInsertStatement.ValuesClause valuesClause : insertClause.getValuesList()) {
+                            List<SQLExpr> exprs = valuesClause.getValues();
+                            List<Object> row = new ArrayList<>(exprs.size());
+                            allRows.add(row);
+
+                            for (int i = 0, len = exprs.size(); i < len; i++) {
+                                SQLExpr expr = exprs.get(i);
+                                if (expr instanceof SQLNullExpr) {
+                                    row.add(Null.get());
+                                } else if (expr instanceof SQLValuableExpr) {
+                                    row.add(((SQLValuableExpr) expr).getValue());
+                                } else if (expr instanceof SQLVariantRefExpr) {
+                                    row.add(((SQLVariantRefExpr) expr).getName());
+                                } else if (expr instanceof SQLMethodInvokeExpr) {
+                                    row.add(SqlMethodExpr.get());
+                                } else if (expr instanceof SQLSequenceExpr) {
+                                    SQLSequenceExpr sequenceExpr = (SQLSequenceExpr) expr;
+                                    String sequence = sequenceExpr.getSequence().getSimpleName();
+                                    String function = sequenceExpr.getFunction().name;
+                                    row.add(new SqlSequenceExpr(sequence, function));
+                                } else {
+                                    if (primaryKeyIndex.contains(i)) {
+                                        wrapSQLParsingException(expr);
+                                    }
+                                    row.add(NotPlaceholderExpr.get());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return allRows;
+    }
+
+    @Override
+    public List<String> getInsertParamsValue() {
+        return null;
+    }
+
+    @Override
+    public List<String> getDuplicateKeyUpdate() {
+        return null;
+    }
+
+    @Override
+    public List<String> getInsertColumnsUnEscape() {
+        List<String> insertColumns = getInsertColumns();
+        return ColumnUtils.delEscape(insertColumns, getDbType());
+    }
+
+    @Override
+    protected SQLStatement getAst() {
+        return ast;
+    }
+
+    @Override
+    public boolean isSqlSyntaxSupports() {
+        return true;
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.seata.sqlparser.druid.oracle;
 
 import com.alibaba.druid.sql.ast.SQLExpr;

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -60,7 +60,7 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
     }
 
     /**
-     * 验证所有entries都是同一张表，并且列定义一致
+     * Verify that all entries are in the same table and have consistent column definitions.
      */
     private void validateSingleTableConsistency() {
         if (CollectionUtils.isEmpty(ast.getEntries())) {
@@ -71,42 +71,42 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
         List<String> firstColumns = null;
 
         for (OracleMultiInsertStatement.Entry entry : ast.getEntries()) {
-            // 检查是否包含条件插入，暂时不支持
+            // Check whether conditional insertion is included. It is not supported yet.
             if (entry instanceof OracleMultiInsertStatement.ConditionalInsertClause) {
                 throw new NotSupportYetException(
-                        "Oracle Multi Insert with conditional clauses (WHEN...THEN) is not supported yet. " +
-                                "SQL: " + getOriginalSQL());
+                        "Oracle Multi Insert with conditional clauses (WHEN...THEN) is not supported yet. " + "SQL: "
+                                + getOriginalSQL());
             }
             if (entry instanceof OracleMultiInsertStatement.InsertIntoClause) {
                 OracleMultiInsertStatement.InsertIntoClause insertClause =
                         (OracleMultiInsertStatement.InsertIntoClause) entry;
 
-                // 获取当前表名
+                // Get the current table name
                 String currentTableName = getTableNameFromClause(insertClause);
                 if (currentTableName == null) {
                     continue;
                 }
 
-                // 获取当前列信息
+                // Get current column information
                 List<String> currentColumns = getColumnsFromClause(insertClause);
 
                 if (firstTableName == null) {
                     firstTableName = currentTableName;
                     firstColumns = currentColumns;
                 } else {
-                    // 检查表名是否一致
+                    // Check whether the table names are consistent
                     if (!firstTableName.equalsIgnoreCase(currentTableName)) {
                         throw new NotSupportYetException(
-                                "Oracle Multi Insert with different tables is not supported yet. " +
-                                        "Found tables: " + firstTableName + " and " + currentTableName +
-                                        ". SQL: " + getOriginalSQL());
+                                "Oracle Multi Insert with different tables is not supported yet. " + "Found tables: "
+                                        + firstTableName + " and " + currentTableName + ". SQL: "
+                                        + getOriginalSQL());
                     }
 
-                    // 检查列定义是否一致
+                    // Check that column definitions are consistent
                     if (!Objects.equals(firstColumns, currentColumns)) {
                         throw new NotSupportYetException(
-                                "Oracle Multi Insert with different column definitions is not supported yet. " +
-                                        "Table: " + firstTableName + ". SQL: " + getOriginalSQL());
+                                "Oracle Multi Insert with different column definitions is not supported yet. "
+                                        + "Table: " + firstTableName + ". SQL: " + getOriginalSQL());
                     }
                 }
             }
@@ -142,7 +142,7 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
             if (expr instanceof SQLIdentifierExpr) {
                 columns.add(((SQLIdentifierExpr) expr).getName());
             } else {
-                // 处理非标准列名的情况
+                // Handling non-standard column names
                 wrapSQLParsingException(expr);
             }
         }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -44,12 +44,12 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
 
     @Override
     public String getTableAlias() {
-        // Oracle Multi Insert 通常只涉及一个表，取第一个插入项的表别名
+        // Oracle Multi Insert usually only one table is involved, take the table alias of the first inserted item
         if (!CollectionUtils.isEmpty(ast.getEntries())) {
             OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
             if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause = 
-                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                OracleMultiInsertStatement.InsertIntoClause insertClause =
+                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
                 if (insertClause.getTableSource() != null) {
                     return insertClause.getTableSource().getAlias();
                 }
@@ -60,12 +60,12 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
 
     @Override
     public String getTableName() {
-        // Oracle Multi Insert 通常只涉及一个表，取第一个插入项的表名
+        // Oracle Multi Insert usually only one table is involved, take the table alias of the first inserted item
         if (!CollectionUtils.isEmpty(ast.getEntries())) {
             OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
             if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause = 
-                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                OracleMultiInsertStatement.InsertIntoClause insertClause =
+                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
                 if (insertClause.getTableSource() != null) {
                     StringBuilder sb = new StringBuilder();
                     OracleOutputVisitor visitor = new OracleOutputVisitor(sb) {
@@ -88,8 +88,8 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
         if (!CollectionUtils.isEmpty(ast.getEntries())) {
             OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
             if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause = 
-                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                OracleMultiInsertStatement.InsertIntoClause insertClause =
+                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
                 return CollectionUtils.isEmpty(insertClause.getColumns());
             }
         }
@@ -101,8 +101,8 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
         if (!CollectionUtils.isEmpty(ast.getEntries())) {
             OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
             if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause = 
-                    (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
+                OracleMultiInsertStatement.InsertIntoClause insertClause =
+                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
                 if (!CollectionUtils.isEmpty(insertClause.getColumns())) {
                     List<SQLExpr> columnSQLExprs = insertClause.getColumns();
                     List<String> list = new ArrayList<>(columnSQLExprs.size());
@@ -127,9 +127,9 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
         if (!CollectionUtils.isEmpty(ast.getEntries())) {
             for (OracleMultiInsertStatement.Entry entry : ast.getEntries()) {
                 if (entry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                    OracleMultiInsertStatement.InsertIntoClause insertClause = 
-                        (OracleMultiInsertStatement.InsertIntoClause) entry;
-                    
+                    OracleMultiInsertStatement.InsertIntoClause insertClause =
+                            (OracleMultiInsertStatement.InsertIntoClause) entry;
+
                     if (!CollectionUtils.isEmpty(insertClause.getValuesList())) {
                         for (SQLInsertStatement.ValuesClause valuesClause : insertClause.getValuesList()) {
                             List<SQLExpr> exprs = valuesClause.getValues();

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -28,6 +28,7 @@ import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.ast.stmt.OracleMultiInsertStatement;
 import com.alibaba.druid.sql.dialect.oracle.visitor.OracleOutputVisitor;
+import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.sqlparser.SQLInsertRecognizer;
 import org.apache.seata.sqlparser.SQLType;
@@ -39,7 +40,9 @@ import org.apache.seata.sqlparser.util.ColumnUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Oracle Multi Insert Recognizer for INSERT ALL statements
@@ -47,10 +50,94 @@ import java.util.List;
 public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements SQLInsertRecognizer {
 
     private final OracleMultiInsertStatement ast;
+    private String validatedTableName;
+    private List<String> validatedColumns;
 
     public OracleMultiInsertRecognizer(String originalSQL, SQLStatement ast) {
         super(originalSQL);
         this.ast = (OracleMultiInsertStatement) ast;
+        validateSingleTableConsistency();
+    }
+
+    /**
+     * 验证所有entries都是同一张表，并且列定义一致
+     */
+    private void validateSingleTableConsistency() {
+        if (CollectionUtils.isEmpty(ast.getEntries())) {
+            return;
+        }
+
+        String firstTableName = null;
+        List<String> firstColumns = null;
+
+        for (OracleMultiInsertStatement.Entry entry : ast.getEntries()) {
+            if (entry instanceof OracleMultiInsertStatement.InsertIntoClause) {
+                OracleMultiInsertStatement.InsertIntoClause insertClause =
+                        (OracleMultiInsertStatement.InsertIntoClause) entry;
+
+                // 获取当前表名
+                String currentTableName = getTableNameFromClause(insertClause);
+                if (currentTableName == null) {
+                    continue;
+                }
+
+                // 获取当前列信息
+                List<String> currentColumns = getColumnsFromClause(insertClause);
+
+                if (firstTableName == null) {
+                    firstTableName = currentTableName;
+                    firstColumns = currentColumns;
+                } else {
+                    // 检查表名是否一致
+                    if (!firstTableName.equalsIgnoreCase(currentTableName)) {
+                        throw new NotSupportYetException(
+                                "Oracle Multi Insert with different tables is not supported yet. " +
+                                        "Found tables: " + firstTableName + " and " + currentTableName +
+                                        ". SQL: " + getOriginalSQL());
+                    }
+
+                    // 检查列定义是否一致
+                    if (!Objects.equals(firstColumns, currentColumns)) {
+                        throw new NotSupportYetException(
+                                "Oracle Multi Insert with different column definitions is not supported yet. " +
+                                        "Table: " + firstTableName + ". SQL: " + getOriginalSQL());
+                    }
+                }
+            }
+        }
+
+        this.validatedTableName = firstTableName;
+        this.validatedColumns = firstColumns;
+    }
+
+    private String getTableNameFromClause(OracleMultiInsertStatement.InsertIntoClause insertClause) {
+        if (insertClause.getTableSource() != null) {
+            StringBuilder sb = new StringBuilder();
+            OracleOutputVisitor visitor = new OracleOutputVisitor(sb) {
+                @Override
+                public boolean visit(SQLExprTableSource x) {
+                    printTableSourceExpr(x.getExpr());
+                    return false;
+                }
+            };
+            visitor.visit(insertClause.getTableSource());
+            return sb.toString();
+        }
+        return null;
+    }
+
+    private List<String> getColumnsFromClause(OracleMultiInsertStatement.InsertIntoClause insertClause) {
+        if (CollectionUtils.isEmpty(insertClause.getColumns())) {
+            return Collections.emptyList();
+        }
+
+        List<String> columns = new ArrayList<>();
+        for (SQLExpr expr : insertClause.getColumns()) {
+            if (expr instanceof SQLIdentifierExpr) {
+                columns.add(((SQLIdentifierExpr) expr).getName());
+            }
+        }
+        return columns;
     }
 
     @Override
@@ -59,8 +146,12 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
     }
 
     @Override
+    public String getTableName() {
+        return validatedTableName;
+    }
+
+    @Override
     public String getTableAlias() {
-        // Oracle Multi Insert usually only one table is involved, take the table alias of the first inserted item
         if (!CollectionUtils.isEmpty(ast.getEntries())) {
             OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
             if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
@@ -75,65 +166,13 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
     }
 
     @Override
-    public String getTableName() {
-        // Oracle Multi Insert usually only one table is involved, take the table alias of the first inserted item
-        if (!CollectionUtils.isEmpty(ast.getEntries())) {
-            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
-            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause =
-                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
-                if (insertClause.getTableSource() != null) {
-                    StringBuilder sb = new StringBuilder();
-                    OracleOutputVisitor visitor = new OracleOutputVisitor(sb) {
-                        @Override
-                        public boolean visit(SQLExprTableSource x) {
-                            printTableSourceExpr(x.getExpr());
-                            return false;
-                        }
-                    };
-                    visitor.visit(insertClause.getTableSource());
-                    return sb.toString();
-                }
-            }
-        }
-        return null;
+    public List<String> getInsertColumns() {
+        return validatedColumns;
     }
 
     @Override
     public boolean insertColumnsIsEmpty() {
-        if (!CollectionUtils.isEmpty(ast.getEntries())) {
-            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
-            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause =
-                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
-                return CollectionUtils.isEmpty(insertClause.getColumns());
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public List<String> getInsertColumns() {
-        if (!CollectionUtils.isEmpty(ast.getEntries())) {
-            OracleMultiInsertStatement.Entry firstEntry = ast.getEntries().get(0);
-            if (firstEntry instanceof OracleMultiInsertStatement.InsertIntoClause) {
-                OracleMultiInsertStatement.InsertIntoClause insertClause =
-                        (OracleMultiInsertStatement.InsertIntoClause) firstEntry;
-                if (!CollectionUtils.isEmpty(insertClause.getColumns())) {
-                    List<SQLExpr> columnSQLExprs = insertClause.getColumns();
-                    List<String> list = new ArrayList<>(columnSQLExprs.size());
-                    for (SQLExpr expr : columnSQLExprs) {
-                        if (expr instanceof SQLIdentifierExpr) {
-                            list.add(((SQLIdentifierExpr) expr).getName());
-                        } else {
-                            wrapSQLParsingException(expr);
-                        }
-                    }
-                    return list;
-                }
-            }
-        }
-        return null;
+        return CollectionUtils.isEmpty(validatedColumns);
     }
 
     @Override

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizer.java
@@ -71,6 +71,12 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
         List<String> firstColumns = null;
 
         for (OracleMultiInsertStatement.Entry entry : ast.getEntries()) {
+            // 检查是否包含条件插入，暂时不支持
+            if (entry instanceof OracleMultiInsertStatement.ConditionalInsertClause) {
+                throw new NotSupportYetException(
+                        "Oracle Multi Insert with conditional clauses (WHEN...THEN) is not supported yet. " +
+                                "SQL: " + getOriginalSQL());
+            }
             if (entry instanceof OracleMultiInsertStatement.InsertIntoClause) {
                 OracleMultiInsertStatement.InsertIntoClause insertClause =
                         (OracleMultiInsertStatement.InsertIntoClause) entry;
@@ -135,6 +141,9 @@ public class OracleMultiInsertRecognizer extends BaseOracleRecognizer implements
         for (SQLExpr expr : insertClause.getColumns()) {
             if (expr instanceof SQLIdentifierExpr) {
                 columns.add(((SQLIdentifierExpr) expr).getName());
+            } else {
+                // 处理非标准列名的情况
+                wrapSQLParsingException(expr);
             }
         }
         return columns;

--- a/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/org/apache/seata/sqlparser/druid/oracle/OracleOperateRecognizerHolder.java
@@ -52,4 +52,8 @@ public class OracleOperateRecognizerHolder implements SQLOperateRecognizerHolder
         }
         return null;
     }
+
+    public SQLRecognizer getMultiInsertRecognizer(String sql, SQLStatement ast) {
+        return new OracleMultiInsertRecognizer(sql, ast);
+    }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryTest.java
@@ -208,4 +208,21 @@ public class DruidSQLRecognizerFactoryTest {
         Assertions.assertThrows(
                 NotSupportYetException.class, () -> recognizerFactory.create(sql9, JdbcConstants.KINGBASE));
     }
+
+    @Test
+    public void testInsertFirstNotSupported() {
+        SQLRecognizerFactory recognizerFactory =
+                EnhancedServiceLoader.load(SQLRecognizerFactory.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
+        // Test that INSERT FIRST syntax should be rejected at the Factory level
+        String sql = "INSERT FIRST " +
+                "WHEN salary > 1000 THEN INTO high_earners (id, name, salary) VALUES (1, 'John', 2000) " +
+                "WHEN salary <= 1000 THEN INTO low_earners (id, name, salary) VALUES (1, 'John', 800) " +
+                "SELECT 1 FROM DUAL";
+
+        NotSupportYetException exception = Assertions.assertThrows(
+                NotSupportYetException.class,
+                () -> recognizerFactory.create(sql, JdbcConstants.ORACLE));
+
+        Assertions.assertTrue(exception.getMessage().contains("INSERT FIRST not supported yet"));
+    }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryTest.java
@@ -16,104 +16,116 @@
  */
 package org.apache.seata.sqlparser.druid;
 
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.dialect.oracle.ast.stmt.OracleMultiInsertStatement;
 import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.sqlparser.SQLRecognizer;
 import org.apache.seata.sqlparser.SQLRecognizerFactory;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.SqlParserType;
+import org.apache.seata.sqlparser.druid.oracle.OracleOperateRecognizerHolder;
 import org.apache.seata.sqlparser.util.JdbcConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 public class DruidSQLRecognizerFactoryTest {
     @Test
     public void testSqlRecognizerCreation() {
         SQLRecognizerFactory recognizerFactory =
                 EnhancedServiceLoader.load(SQLRecognizerFactory.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
-        Assertions.assertNotNull(recognizerFactory);
+        assertNotNull(recognizerFactory);
         List<SQLRecognizer> recognizers = recognizerFactory.create("delete from t1", JdbcConstants.MYSQL);
-        Assertions.assertNotNull(recognizers);
+        assertNotNull(recognizers);
         Assertions.assertEquals(recognizers.size(), 1);
         Assertions.assertEquals(SQLType.DELETE, recognizers.get(0).getSQLType());
 
         recognizers = recognizerFactory.create("delete from t1", JdbcConstants.MARIADB);
-        Assertions.assertNotNull(recognizers);
+        assertNotNull(recognizers);
         Assertions.assertEquals(recognizers.size(), 1);
         Assertions.assertEquals(SQLType.DELETE, recognizers.get(0).getSQLType());
 
         recognizers = recognizerFactory.create("delete from t1", JdbcConstants.POLARDBX);
-        Assertions.assertNotNull(recognizers);
+        assertNotNull(recognizers);
         Assertions.assertEquals(recognizers.size(), 1);
         Assertions.assertEquals(SQLType.DELETE, recognizers.get(0).getSQLType());
 
         recognizers = recognizerFactory.create("delete from t1", JdbcConstants.DM);
-        Assertions.assertNotNull(recognizers);
+        assertNotNull(recognizers);
         Assertions.assertEquals(recognizers.size(), 1);
         Assertions.assertEquals(SQLType.DELETE, recognizers.get(0).getSQLType());
 
         recognizers = recognizerFactory.create("delete from t1", JdbcConstants.KINGBASE);
-        Assertions.assertNotNull(recognizers);
+        assertNotNull(recognizers);
         Assertions.assertEquals(recognizers.size(), 1);
         Assertions.assertEquals(SQLType.DELETE, recognizers.get(0).getSQLType());
 
         recognizers = recognizerFactory.create("delete from t1", JdbcConstants.OSCAR);
-        Assertions.assertNotNull(recognizers);
+        assertNotNull(recognizers);
         Assertions.assertEquals(recognizers.size(), 1);
         Assertions.assertEquals(SQLType.DELETE, recognizers.get(0).getSQLType());
 
         // test sql syntax
         String sql = "update d.t set d.t.a = ?, d.t.b = ?, d.t.c = ?";
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.MYSQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.MARIADB));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.POLARDBX));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.ORACLE));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.POSTGRESQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.DM));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.KINGBASE));
-        Assertions.assertNotNull(recognizerFactory.create(sql, JdbcConstants.OSCAR));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.MYSQL));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.MARIADB));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.POLARDBX));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.ORACLE));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.POSTGRESQL));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.DM));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.KINGBASE));
+        assertNotNull(recognizerFactory.create(sql, JdbcConstants.OSCAR));
 
         String sql5 = "insert into a values (1, 2)";
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.MYSQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.MARIADB));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.POLARDBX));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.ORACLE));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.POSTGRESQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.DM));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.KINGBASE));
-        Assertions.assertNotNull(recognizerFactory.create(sql5, JdbcConstants.OSCAR));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.MYSQL));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.MARIADB));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.POLARDBX));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.ORACLE));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.POSTGRESQL));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.DM));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.KINGBASE));
+        assertNotNull(recognizerFactory.create(sql5, JdbcConstants.OSCAR));
 
         String sql6 = "insert into a (id, name) values (1, 2), (3, 4)";
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.MYSQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.MARIADB));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.POLARDBX));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.ORACLE));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.POSTGRESQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.DM));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.KINGBASE));
-        Assertions.assertNotNull(recognizerFactory.create(sql6, JdbcConstants.OSCAR));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.MYSQL));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.MARIADB));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.POLARDBX));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.ORACLE));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.POSTGRESQL));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.DM));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.KINGBASE));
+        assertNotNull(recognizerFactory.create(sql6, JdbcConstants.OSCAR));
 
         String sql8 = "delete from t where id = ?";
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.MYSQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.MARIADB));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.POLARDBX));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.ORACLE));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.POSTGRESQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.DM));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.KINGBASE));
-        Assertions.assertNotNull(recognizerFactory.create(sql8, JdbcConstants.OSCAR));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.MYSQL));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.MARIADB));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.POLARDBX));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.ORACLE));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.POSTGRESQL));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.DM));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.KINGBASE));
+        assertNotNull(recognizerFactory.create(sql8, JdbcConstants.OSCAR));
 
         String sql10 = "select * from t for update";
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.MYSQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.MARIADB));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.POLARDBX));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.ORACLE));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.POSTGRESQL));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.KINGBASE));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.DM));
-        Assertions.assertNotNull(recognizerFactory.create(sql10, JdbcConstants.OSCAR));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.MYSQL));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.MARIADB));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.POLARDBX));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.ORACLE));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.POSTGRESQL));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.KINGBASE));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.DM));
+        assertNotNull(recognizerFactory.create(sql10, JdbcConstants.OSCAR));
     }
 
     @Test
@@ -223,6 +235,30 @@ public class DruidSQLRecognizerFactoryTest {
                 NotSupportYetException.class,
                 () -> recognizerFactory.create(sql, JdbcConstants.ORACLE));
 
-        Assertions.assertTrue(exception.getMessage().contains("INSERT FIRST not supported yet"));
+        assertTrue(exception.getMessage().contains("INSERT FIRST not supported yet"));
+    }
+
+    @Test
+    void testGetMultiInsertRecognizerDelegation() {
+        // 1. 构造 INSERT ALL SQL
+        String sql = "INSERT ALL INTO a(id) VALUES(1) INTO a(id) VALUES(2) SELECT 1 FROM dual";
+
+        SQLStatement stmt = SQLUtils.parseSingleStatement(sql, "oracle");
+        assertTrue(stmt instanceof OracleMultiInsertStatement);
+
+        // 2. mock recognizerHolder and recognizer
+        OracleOperateRecognizerHolder recognizerHolder = mock(OracleOperateRecognizerHolder.class);
+        SQLRecognizer mockRecognizer = mock(SQLRecognizer.class);
+
+        // 3. stub getMultiInsertRecognizer
+        when(recognizerHolder.getMultiInsertRecognizer(sql, stmt)).thenReturn(mockRecognizer);
+
+        SQLRecognizer recognizer =
+                ((OracleOperateRecognizerHolder) recognizerHolder).getMultiInsertRecognizer(sql, stmt);
+
+        assertNotNull(recognizer);
+        assertSame(mockRecognizer, recognizer);
+
+        verify(recognizerHolder, times(1)).getMultiInsertRecognizer(sql, stmt);
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/DruidSQLRecognizerFactoryTest.java
@@ -226,21 +226,20 @@ public class DruidSQLRecognizerFactoryTest {
         SQLRecognizerFactory recognizerFactory =
                 EnhancedServiceLoader.load(SQLRecognizerFactory.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
         // Test that INSERT FIRST syntax should be rejected at the Factory level
-        String sql = "INSERT FIRST " +
-                "WHEN salary > 1000 THEN INTO high_earners (id, name, salary) VALUES (1, 'John', 2000) " +
-                "WHEN salary <= 1000 THEN INTO low_earners (id, name, salary) VALUES (1, 'John', 800) " +
-                "SELECT 1 FROM DUAL";
+        String sql = "INSERT FIRST "
+                + "WHEN salary > 1000 THEN INTO high_earners (id, name, salary) VALUES (1, 'John', 2000) "
+                + "WHEN salary <= 1000 THEN INTO low_earners (id, name, salary) VALUES (1, 'John', 800) "
+                + "SELECT 1 FROM DUAL";
 
         NotSupportYetException exception = Assertions.assertThrows(
-                NotSupportYetException.class,
-                () -> recognizerFactory.create(sql, JdbcConstants.ORACLE));
+                NotSupportYetException.class, () -> recognizerFactory.create(sql, JdbcConstants.ORACLE));
 
         assertTrue(exception.getMessage().contains("INSERT FIRST not supported yet"));
     }
 
     @Test
     void testGetMultiInsertRecognizerDelegation() {
-        // 1. 构造 INSERT ALL SQL
+        // 1.sql
         String sql = "INSERT ALL INTO a(id) VALUES(1) INTO a(id) VALUES(2) SELECT 1 FROM dual";
 
         SQLStatement stmt = SQLUtils.parseSingleStatement(sql, "oracle");

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
@@ -202,126 +202,127 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testMultipleTablesInsert() {
-        // 现在这个应该抛出异常，因为涉及不同的表
+        // Now this should throw an exception since different tables are involved
         String sql =
                 "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO orders (id, user_id) VALUES (101, 1) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 应该抛出 NotSupportYetException
+        // should throw NotSupportYetException
         NotSupportYetException exception = Assertions.assertThrows(
-                NotSupportYetException.class,
-                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
-        
-        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different tables is not supported yet"));
+                NotSupportYetException.class, () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains("Oracle Multi Insert with different tables is not supported yet"));
         Assertions.assertTrue(exception.getMessage().contains("users"));
         Assertions.assertTrue(exception.getMessage().contains("orders"));
     }
 
     @Test
     public void testMultipleTablesWithDifferentColumns() {
-        // 测试同表但不同列定义的情况
+        // Testing the same table but different column definitions
         String sql =
                 "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 应该抛出 NotSupportYetException
+        // should throw NotSupportYetException
         NotSupportYetException exception = Assertions.assertThrows(
-                NotSupportYetException.class,
-                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
-        
-        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different column definitions is not supported yet"));
+                NotSupportYetException.class, () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+
+        Assertions.assertTrue(exception
+                .getMessage()
+                .contains("Oracle Multi Insert with different column definitions is not supported yet"));
         Assertions.assertTrue(exception.getMessage().contains("users"));
     }
 
     @Test
     public void testSameTableMultipleInserts() {
-        // 测试同表同列的正常情况（应该成功）
+        // Test the normal situation of the same table and column
         String sql =
                 "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 这个应该成功，不抛异常
+        // success
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
+
         Assertions.assertEquals("users", recognizer.getTableName());
         Assertions.assertEquals(2, recognizer.getInsertColumns().size());
         Assertions.assertEquals("id", recognizer.getInsertColumns().get(0));
         Assertions.assertEquals("name", recognizer.getInsertColumns().get(1));
-        
+
         List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
         Assertions.assertEquals(2, rows.size());
     }
 
     @Test
     public void testEmptyColumnsConsistency() {
-        // 测试空列定义的一致性
-        String sql =
-                "INSERT ALL INTO users VALUES (1, 'Tom') INTO users VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        // Tests the consistency of empty column definitions
+        String sql = "INSERT ALL INTO users VALUES (1, 'Tom') INTO users VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 这个应该成功，因为两个entry都没有指定列
+        // This should succeed since neither entry specifies a column.
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
+
         Assertions.assertEquals("users", recognizer.getTableName());
         Assertions.assertTrue(recognizer.insertColumnsIsEmpty());
     }
 
     @Test
     public void testMixedColumnDefinitions() {
-        // 测试一个有列定义，一个没有列定义的情况
+        // Test one case with column definition and one case without column definition
         String sql =
                 "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 应该抛出异常，因为列定义不一致
+        // An exception should be thrown because the column definitions are inconsistent
         NotSupportYetException exception = Assertions.assertThrows(
-                NotSupportYetException.class,
-                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
-        
-        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different column definitions is not supported yet"));
+                NotSupportYetException.class, () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+
+        Assertions.assertTrue(exception
+                .getMessage()
+                .contains("Oracle Multi Insert with different column definitions is not supported yet"));
     }
 
     @Test
     public void testCaseInsensitiveTableNames() {
-        // 测试表名大小写敏感性
+        // Test table name case sensitivity
         String sql =
                 "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO USERS (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 这个应该成功，因为使用了 equalsIgnoreCase
+        // This should succeed because equalsIgnoreCase is used
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
+
         Assertions.assertEquals("users", recognizer.getTableName());
         Assertions.assertEquals(2, recognizer.getInsertColumns().size());
     }
 
     @Test
     public void testTableWithSchema() {
-        // 测试带Schema的表名
+        // Test table name with Schema
         String sql =
                 "INSERT ALL INTO schema1.users (id, name) VALUES (1, 'Tom') INTO schema1.users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 这个应该成功
+        // success
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
+
         Assertions.assertEquals("schema1.users", recognizer.getTableName());
         Assertions.assertEquals(2, recognizer.getInsertColumns().size());
     }
 
     @Test
     public void testDifferentSchemas() {
-        // 测试不同Schema的同名表
+        // Testing tables with the same name in different schemas
         String sql =
                 "INSERT ALL INTO schema1.users (id, name) VALUES (1, 'Tom') INTO schema2.users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 应该抛出异常，因为是不同的表
+        // An exception should be thrown because they are different tables
         NotSupportYetException exception = Assertions.assertThrows(
-                NotSupportYetException.class,
-                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
-        
-        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different tables is not supported yet"));
+                NotSupportYetException.class, () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains("Oracle Multi Insert with different tables is not supported yet"));
         Assertions.assertTrue(exception.getMessage().contains("schema1.users"));
         Assertions.assertTrue(exception.getMessage().contains("schema2.users"));
     }
@@ -387,17 +388,15 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testConditionalInsertNotSupported() {
-        // 测试带条件的插入语句
-        String sql = "INSERT ALL " +
-                "INTO users (id, name) VALUES (1, 'Tom') " +
-                "WHEN salary > 1000 THEN INTO employees (id, name) VALUES (2, 'Jerry') " +
-                "SELECT 1 FROM DUAL";
+        // Testing conditional insert statements
+        String sql = "INSERT ALL " + "INTO users (id, name) VALUES (1, 'Tom') "
+                + "WHEN salary > 1000 THEN INTO employees (id, name) VALUES (2, 'Jerry') "
+                + "SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // 应该抛出 NotSupportYetException
+        // Should throw NotSupportYetException
         NotSupportYetException exception = Assertions.assertThrows(
-                NotSupportYetException.class,
-                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+                NotSupportYetException.class, () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
 
         Assertions.assertTrue(exception.getMessage().contains("conditional clauses"));
         Assertions.assertTrue(exception.getMessage().contains("WHEN...THEN"));

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.sqlparser.druid.oracle;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import org.apache.seata.sqlparser.SQLType;
+import org.apache.seata.sqlparser.struct.Null;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Oracle Multi Insert Recognizer Test
+ *
+ */
+public class OracleMultiInsertRecognizerTest {
+
+    private static final String DB_TYPE = "oracle";
+
+    @Test
+    public void testGetSqlType() {
+        String sql = "INSERT ALL INTO a (id) VALUES (1) INTO a (id) VALUES (2) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        Assertions.assertEquals(SQLType.INSERT, recognizer.getSQLType());
+    }
+
+    @Test
+    public void testGetTableName() {
+        String sql = "INSERT ALL INTO users (id) VALUES (1) INTO users (id) VALUES (2) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        Assertions.assertEquals("users", recognizer.getTableName());
+    }
+
+    @Test
+    public void testGetTableAlias() {
+        // 测试无别名的情况
+        String sql = "INSERT ALL INTO users (id) VALUES (1) INTO users (id) VALUES (2) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        Assertions.assertNull(recognizer.getTableAlias());
+    }
+
+    @Test
+    public void testGetInsertColumns() {
+        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        List<String> columns = recognizer.getInsertColumns();
+        
+        Assertions.assertNotNull(columns);
+        Assertions.assertEquals(3, columns.size());
+        Assertions.assertEquals("id", columns.get(0));
+        Assertions.assertEquals("name", columns.get(1));
+        Assertions.assertEquals("age", columns.get(2));
+    }
+
+    @Test
+    public void testInsertColumnsIsEmpty() {
+        // 测试有列的情况
+        String sqlWithColumns = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sqlWithColumns, DB_TYPE);
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sqlWithColumns, asts.get(0));
+        Assertions.assertFalse(recognizer.insertColumnsIsEmpty());
+
+        // 测试没有列的情况（虽然在实际的 INSERT ALL 中很少见）
+        // 这里主要测试边界情况
+    }
+
+    @Test
+    public void testGetInsertRows() {
+        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
+        
+        Assertions.assertNotNull(rows);
+        Assertions.assertEquals(2, rows.size());
+        
+        // 验证第一行数据
+        List<Object> firstRow = rows.get(0);
+        Assertions.assertEquals(3, firstRow.size());
+        Assertions.assertEquals(1, firstRow.get(0));
+        Assertions.assertEquals("Tom", firstRow.get(1));
+        Assertions.assertEquals(20, firstRow.get(2));
+        
+        // 验证第二行数据
+        List<Object> secondRow = rows.get(1);
+        Assertions.assertEquals(3, secondRow.size());
+        Assertions.assertEquals(2, secondRow.get(0));
+        Assertions.assertEquals("Jerry", secondRow.get(1));
+        Assertions.assertEquals(25, secondRow.get(2));
+    }
+
+    @Test
+    public void testGetInsertRowsWithNullValues() {
+        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', NULL) INTO users (id, name, age) VALUES (2, NULL, 25) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
+        
+        Assertions.assertNotNull(rows);
+        Assertions.assertEquals(2, rows.size());
+        
+        // 验证第一行数据（age 为 NULL）
+        List<Object> firstRow = rows.get(0);
+        Assertions.assertEquals(3, firstRow.size());
+        Assertions.assertEquals(1, firstRow.get(0));
+        Assertions.assertEquals("Tom", firstRow.get(1));
+        Assertions.assertEquals(Null.get(), firstRow.get(2));
+        
+        // 验证第二行数据（name 为 NULL）
+        List<Object> secondRow = rows.get(1);
+        Assertions.assertEquals(3, secondRow.size());
+        Assertions.assertEquals(2, secondRow.get(0));
+        Assertions.assertEquals(Null.get(), secondRow.get(1));
+        Assertions.assertEquals(25, secondRow.get(2));
+    }
+
+    @Test
+    public void testGetInsertRowsWithParameters() {
+        String sql = "INSERT ALL INTO users (id, name) VALUES (?, ?) INTO users (id, name) VALUES (?, ?) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
+        
+        Assertions.assertNotNull(rows);
+        Assertions.assertEquals(2, rows.size());
+        
+        // 验证参数占位符
+        for (List<Object> row : rows) {
+            Assertions.assertEquals(2, row.size());
+            for (Object value : row) {
+                Assertions.assertTrue(value instanceof String);
+                Assertions.assertEquals("?", value);
+            }
+        }
+    }
+
+    @Test
+    public void testGetInsertParamsValue() {
+        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        List<String> paramsValue = recognizer.getInsertParamsValue();
+        
+        Assertions.assertNull(paramsValue);
+    }
+
+    @Test
+    public void testGetDuplicateKeyUpdate() {
+        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        List<String> duplicateKeyUpdate = recognizer.getDuplicateKeyUpdate();
+        
+        Assertions.assertNull(duplicateKeyUpdate);
+    }
+
+    @Test
+    public void testIsSqlSyntaxSupports() {
+        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        Assertions.assertTrue(recognizer.isSqlSyntaxSupports());
+    }
+
+    @Test
+    public void testMultipleTablesInsert() {
+        // 测试插入到多个不同表的情况
+        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO orders (id, user_id) VALUES (101, 1) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        // 应该返回第一个表的信息
+        Assertions.assertEquals("users", recognizer.getTableName());
+        
+        List<String> columns = recognizer.getInsertColumns();
+        Assertions.assertNotNull(columns);
+        Assertions.assertEquals(2, columns.size());
+        Assertions.assertEquals("id", columns.get(0));
+        Assertions.assertEquals("name", columns.get(1));
+        
+        // 验证所有插入行数据
+        List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
+        Assertions.assertEquals(2, rows.size());
+        
+        // 第一行：users 表数据
+        List<Object> firstRow = rows.get(0);
+        Assertions.assertEquals(2, firstRow.size());
+        Assertions.assertEquals(1, firstRow.get(0));
+        Assertions.assertEquals("Tom", firstRow.get(1));
+        
+        // 第二行：orders 表数据
+        List<Object> secondRow = rows.get(1);
+        Assertions.assertEquals(2, secondRow.size());
+        Assertions.assertEquals(101, secondRow.get(0));
+        Assertions.assertEquals(1, secondRow.get(1));
+    }
+
+    @Test
+    public void testComplexInsertAllStatement() {
+        // 测试更复杂的 INSERT ALL 语句
+        String sql = "INSERT ALL " +
+                     "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date, sales_sun) " +
+                     "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date+1, sales_mon) " +
+                     "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date+2, sales_tue) " +
+                     "SELECT product_id, customer_id, weekly_start_date, sales_sun, sales_mon, sales_tue FROM sales_input_table";
+        
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        Assertions.assertEquals("sales", recognizer.getTableName());
+        Assertions.assertEquals(SQLType.INSERT, recognizer.getSQLType());
+        
+        List<String> columns = recognizer.getInsertColumns();
+        Assertions.assertNotNull(columns);
+        Assertions.assertEquals(4, columns.size());
+        Assertions.assertEquals("prod_id", columns.get(0));
+        Assertions.assertEquals("cust_id", columns.get(1));
+        Assertions.assertEquals("time_id", columns.get(2));
+        Assertions.assertEquals("amount", columns.get(3));
+    }
+
+    @Test
+    public void testEmptyEntriesHandling() {
+        // 这个测试主要是为了保证在边界情况下不会出现异常
+        // 虽然实际上不太可能出现空的 entries，但我们需要确保代码的健壮性
+        
+        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+        
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        // 基本功能应该正常工作
+        Assertions.assertEquals(SQLType.INSERT, recognizer.getSQLType());
+        Assertions.assertEquals("users", recognizer.getTableName());
+        Assertions.assertTrue(recognizer.isSqlSyntaxSupports());
+    }
+
+    @Test
+    public void testGetInsertRowsWithPrimaryKeyIndex() {
+        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        // 测试当指定主键索引时的行为
+        List<List<Object>> rows = recognizer.getInsertRows(Arrays.asList(0)); // id 字段是主键
+        
+        Assertions.assertNotNull(rows);
+        Assertions.assertEquals(2, rows.size());
+        
+        // 验证主键字段的值
+        for (List<Object> row : rows) {
+            Assertions.assertEquals(3, row.size());
+            Assertions.assertTrue(row.get(0) instanceof Integer); // 主键应该是整数
+        }
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
@@ -55,7 +55,7 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testGetTableAlias() {
-        // 测试无别名的情况
+        // Test the case without alias
         String sql = "INSERT ALL INTO users (id) VALUES (1) INTO users (id) VALUES (2) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
@@ -65,12 +65,13 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testGetInsertColumns() {
-        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
         List<String> columns = recognizer.getInsertColumns();
-        
+
         Assertions.assertNotNull(columns);
         Assertions.assertEquals(3, columns.size());
         Assertions.assertEquals("id", columns.get(0));
@@ -80,35 +81,34 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testInsertColumnsIsEmpty() {
-        // 测试有列的情况
-        String sqlWithColumns = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        // Test the case with columns
+        String sqlWithColumns =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sqlWithColumns, DB_TYPE);
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sqlWithColumns, asts.get(0));
         Assertions.assertFalse(recognizer.insertColumnsIsEmpty());
-
-        // 测试没有列的情况（虽然在实际的 INSERT ALL 中很少见）
-        // 这里主要测试边界情况
     }
 
     @Test
     public void testGetInsertRows() {
-        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
         List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
-        
+
         Assertions.assertNotNull(rows);
         Assertions.assertEquals(2, rows.size());
-        
-        // 验证第一行数据
+
+        // Verify the first row of data
         List<Object> firstRow = rows.get(0);
         Assertions.assertEquals(3, firstRow.size());
         Assertions.assertEquals(1, firstRow.get(0));
         Assertions.assertEquals("Tom", firstRow.get(1));
         Assertions.assertEquals(20, firstRow.get(2));
-        
-        // 验证第二行数据
+
+        // Verify the second row of data
         List<Object> secondRow = rows.get(1);
         Assertions.assertEquals(3, secondRow.size());
         Assertions.assertEquals(2, secondRow.get(0));
@@ -118,23 +118,24 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testGetInsertRowsWithNullValues() {
-        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', NULL) INTO users (id, name, age) VALUES (2, NULL, 25) SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', NULL) INTO users (id, name, age) VALUES (2, NULL, 25) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
         List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
-        
+
         Assertions.assertNotNull(rows);
         Assertions.assertEquals(2, rows.size());
-        
-        // 验证第一行数据（age 为 NULL）
+
+        // Verify the first row of data (age is NULL)
         List<Object> firstRow = rows.get(0);
         Assertions.assertEquals(3, firstRow.size());
         Assertions.assertEquals(1, firstRow.get(0));
         Assertions.assertEquals("Tom", firstRow.get(1));
         Assertions.assertEquals(Null.get(), firstRow.get(2));
-        
-        // 验证第二行数据（name 为 NULL）
+
+        // Verify the second row of data (name is NULL)
         List<Object> secondRow = rows.get(1);
         Assertions.assertEquals(3, secondRow.size());
         Assertions.assertEquals(2, secondRow.get(0));
@@ -144,16 +145,17 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testGetInsertRowsWithParameters() {
-        String sql = "INSERT ALL INTO users (id, name) VALUES (?, ?) INTO users (id, name) VALUES (?, ?) SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (?, ?) INTO users (id, name) VALUES (?, ?) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
         List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
-        
+
         Assertions.assertNotNull(rows);
         Assertions.assertEquals(2, rows.size());
-        
-        // 验证参数占位符
+
+        // Validation parameter placeholders
         for (List<Object> row : rows) {
             Assertions.assertEquals(2, row.size());
             for (Object value : row) {
@@ -165,29 +167,32 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testGetInsertParamsValue() {
-        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
         List<String> paramsValue = recognizer.getInsertParamsValue();
-        
+
         Assertions.assertNull(paramsValue);
     }
 
     @Test
     public void testGetDuplicateKeyUpdate() {
-        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
         List<String> duplicateKeyUpdate = recognizer.getDuplicateKeyUpdate();
-        
+
         Assertions.assertNull(duplicateKeyUpdate);
     }
 
     @Test
     public void testIsSqlSyntaxSupports() {
-        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
@@ -196,32 +201,33 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testMultipleTablesInsert() {
-        // 测试插入到多个不同表的情况
-        String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO orders (id, user_id) VALUES (101, 1) SELECT 1 FROM DUAL";
+        // Testing inserts into multiple different tables
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO orders (id, user_id) VALUES (101, 1) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
-        // 应该返回第一个表的信息
+
+        // The information of the first table should be returned
         Assertions.assertEquals("users", recognizer.getTableName());
-        
+
         List<String> columns = recognizer.getInsertColumns();
         Assertions.assertNotNull(columns);
         Assertions.assertEquals(2, columns.size());
         Assertions.assertEquals("id", columns.get(0));
         Assertions.assertEquals("name", columns.get(1));
-        
-        // 验证所有插入行数据
+
+        // Verify all inserted row data
         List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
         Assertions.assertEquals(2, rows.size());
-        
-        // 第一行：users 表数据
+
+        // First row: users table data
         List<Object> firstRow = rows.get(0);
         Assertions.assertEquals(2, firstRow.size());
         Assertions.assertEquals(1, firstRow.get(0));
         Assertions.assertEquals("Tom", firstRow.get(1));
-        
-        // 第二行：orders 表数据
+
+        // Second row: orders table data
         List<Object> secondRow = rows.get(1);
         Assertions.assertEquals(2, secondRow.size());
         Assertions.assertEquals(101, secondRow.get(0));
@@ -230,19 +236,19 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testComplexInsertAllStatement() {
-        // 测试更复杂的 INSERT ALL 语句
-        String sql = "INSERT ALL " +
-                     "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date, sales_sun) " +
-                     "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date+1, sales_mon) " +
-                     "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date+2, sales_tue) " +
-                     "SELECT product_id, customer_id, weekly_start_date, sales_sun, sales_mon, sales_tue FROM sales_input_table";
-        
+        // Testing a more complex INSERT ALL statement
+        String sql = "INSERT ALL "
+                + "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date, sales_sun) "
+                + "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date+1, sales_mon) "
+                + "INTO sales (prod_id, cust_id, time_id, amount) VALUES (product_id, customer_id, weekly_start_date+2, sales_tue) "
+                + "SELECT product_id, customer_id, weekly_start_date, sales_sun, sales_mon, sales_tue FROM sales_input_table";
+
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
+
         Assertions.assertEquals("sales", recognizer.getTableName());
         Assertions.assertEquals(SQLType.INSERT, recognizer.getSQLType());
-        
+
         List<String> columns = recognizer.getInsertColumns();
         Assertions.assertNotNull(columns);
         Assertions.assertEquals(4, columns.size());
@@ -254,15 +260,13 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testEmptyEntriesHandling() {
-        // 这个测试主要是为了保证在边界情况下不会出现异常
-        // 虽然实际上不太可能出现空的 entries，但我们需要确保代码的健壮性
-        
+        // This test is mainly to ensure that no exceptions occur in boundary conditions
+
         String sql = "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
-        
+
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
-        // 基本功能应该正常工作
+
         Assertions.assertEquals(SQLType.INSERT, recognizer.getSQLType());
         Assertions.assertEquals("users", recognizer.getTableName());
         Assertions.assertTrue(recognizer.isSqlSyntaxSupports());
@@ -270,21 +274,22 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testGetInsertRowsWithPrimaryKeyIndex() {
-        String sql = "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        String sql =
+                "INSERT ALL INTO users (id, name, age) VALUES (1, 'Tom', 20) INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-        
-        // 测试当指定主键索引时的行为
-        List<List<Object>> rows = recognizer.getInsertRows(Arrays.asList(0)); // id 字段是主键
-        
+
+        // Test behavior when primary key index is specified
+        List<List<Object>> rows = recognizer.getInsertRows(Arrays.asList(0));
+
         Assertions.assertNotNull(rows);
         Assertions.assertEquals(2, rows.size());
-        
-        // 验证主键字段的值
+
+        // Validate the value of the primary key field
         for (List<Object> row : rows) {
             Assertions.assertEquals(3, row.size());
-            Assertions.assertTrue(row.get(0) instanceof Integer); // 主键应该是整数
+            Assertions.assertTrue(row.get(0) instanceof Integer);
         }
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
@@ -18,6 +18,7 @@ package org.apache.seata.sqlparser.druid.oracle;
 
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLStatement;
+import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.sqlparser.SQLType;
 import org.apache.seata.sqlparser.struct.Null;
 import org.junit.jupiter.api.Assertions;
@@ -201,37 +202,128 @@ public class OracleMultiInsertRecognizerTest {
 
     @Test
     public void testMultipleTablesInsert() {
-        // Testing inserts into multiple different tables
+        // 现在这个应该抛出异常，因为涉及不同的表
         String sql =
                 "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO orders (id, user_id) VALUES (101, 1) SELECT 1 FROM DUAL";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
+        // 应该抛出 NotSupportYetException
+        NotSupportYetException exception = Assertions.assertThrows(
+                NotSupportYetException.class,
+                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+        
+        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different tables is not supported yet"));
+        Assertions.assertTrue(exception.getMessage().contains("users"));
+        Assertions.assertTrue(exception.getMessage().contains("orders"));
+    }
+
+    @Test
+    public void testMultipleTablesWithDifferentColumns() {
+        // 测试同表但不同列定义的情况
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name, age) VALUES (2, 'Jerry', 25) SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 应该抛出 NotSupportYetException
+        NotSupportYetException exception = Assertions.assertThrows(
+                NotSupportYetException.class,
+                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+        
+        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different column definitions is not supported yet"));
+        Assertions.assertTrue(exception.getMessage().contains("users"));
+    }
+
+    @Test
+    public void testSameTableMultipleInserts() {
+        // 测试同表同列的正常情况（应该成功）
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 这个应该成功，不抛异常
         OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
-
-        // The information of the first table should be returned
+        
         Assertions.assertEquals("users", recognizer.getTableName());
-
-        List<String> columns = recognizer.getInsertColumns();
-        Assertions.assertNotNull(columns);
-        Assertions.assertEquals(2, columns.size());
-        Assertions.assertEquals("id", columns.get(0));
-        Assertions.assertEquals("name", columns.get(1));
-
-        // Verify all inserted row data
+        Assertions.assertEquals(2, recognizer.getInsertColumns().size());
+        Assertions.assertEquals("id", recognizer.getInsertColumns().get(0));
+        Assertions.assertEquals("name", recognizer.getInsertColumns().get(1));
+        
         List<List<Object>> rows = recognizer.getInsertRows(Collections.emptySet());
         Assertions.assertEquals(2, rows.size());
+    }
 
-        // First row: users table data
-        List<Object> firstRow = rows.get(0);
-        Assertions.assertEquals(2, firstRow.size());
-        Assertions.assertEquals(1, firstRow.get(0));
-        Assertions.assertEquals("Tom", firstRow.get(1));
+    @Test
+    public void testEmptyColumnsConsistency() {
+        // 测试空列定义的一致性
+        String sql =
+                "INSERT ALL INTO users VALUES (1, 'Tom') INTO users VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        // Second row: orders table data
-        List<Object> secondRow = rows.get(1);
-        Assertions.assertEquals(2, secondRow.size());
-        Assertions.assertEquals(101, secondRow.get(0));
-        Assertions.assertEquals(1, secondRow.get(1));
+        // 这个应该成功，因为两个entry都没有指定列
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        Assertions.assertEquals("users", recognizer.getTableName());
+        Assertions.assertTrue(recognizer.insertColumnsIsEmpty());
+    }
+
+    @Test
+    public void testMixedColumnDefinitions() {
+        // 测试一个有列定义，一个没有列定义的情况
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO users VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 应该抛出异常，因为列定义不一致
+        NotSupportYetException exception = Assertions.assertThrows(
+                NotSupportYetException.class,
+                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+        
+        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different column definitions is not supported yet"));
+    }
+
+    @Test
+    public void testCaseInsensitiveTableNames() {
+        // 测试表名大小写敏感性
+        String sql =
+                "INSERT ALL INTO users (id, name) VALUES (1, 'Tom') INTO USERS (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 这个应该成功，因为使用了 equalsIgnoreCase
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        Assertions.assertEquals("users", recognizer.getTableName());
+        Assertions.assertEquals(2, recognizer.getInsertColumns().size());
+    }
+
+    @Test
+    public void testTableWithSchema() {
+        // 测试带Schema的表名
+        String sql =
+                "INSERT ALL INTO schema1.users (id, name) VALUES (1, 'Tom') INTO schema1.users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 这个应该成功
+        OracleMultiInsertRecognizer recognizer = new OracleMultiInsertRecognizer(sql, asts.get(0));
+        
+        Assertions.assertEquals("schema1.users", recognizer.getTableName());
+        Assertions.assertEquals(2, recognizer.getInsertColumns().size());
+    }
+
+    @Test
+    public void testDifferentSchemas() {
+        // 测试不同Schema的同名表
+        String sql =
+                "INSERT ALL INTO schema1.users (id, name) VALUES (1, 'Tom') INTO schema2.users (id, name) VALUES (2, 'Jerry') SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 应该抛出异常，因为是不同的表
+        NotSupportYetException exception = Assertions.assertThrows(
+                NotSupportYetException.class,
+                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+        
+        Assertions.assertTrue(exception.getMessage().contains("Oracle Multi Insert with different tables is not supported yet"));
+        Assertions.assertTrue(exception.getMessage().contains("schema1.users"));
+        Assertions.assertTrue(exception.getMessage().contains("schema2.users"));
     }
 
     @Test

--- a/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/org/apache/seata/sqlparser/druid/oracle/OracleMultiInsertRecognizerTest.java
@@ -384,4 +384,22 @@ public class OracleMultiInsertRecognizerTest {
             Assertions.assertTrue(row.get(0) instanceof Integer);
         }
     }
+
+    @Test
+    public void testConditionalInsertNotSupported() {
+        // 测试带条件的插入语句
+        String sql = "INSERT ALL " +
+                "INTO users (id, name) VALUES (1, 'Tom') " +
+                "WHEN salary > 1000 THEN INTO employees (id, name) VALUES (2, 'Jerry') " +
+                "SELECT 1 FROM DUAL";
+        List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
+
+        // 应该抛出 NotSupportYetException
+        NotSupportYetException exception = Assertions.assertThrows(
+                NotSupportYetException.class,
+                () -> new OracleMultiInsertRecognizer(sql, asts.get(0)));
+
+        Assertions.assertTrue(exception.getMessage().contains("conditional clauses"));
+        Assertions.assertTrue(exception.getMessage().contains("WHEN...THEN"));
+    }
 }


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
1. Problem Background
Seata cannot support Oracle's INSERT ALL batch insert statements. For example, `insert all into a (id) values(1) into a (id) values(2) SELECT 1 FROM DUAL` will be parsed as `OracleMultiInsertStatement`, but `DruidSQLRecognizerFactoryImpl` does not support this statement type.

2. Solution
- Extend `DruidSQLRecognizerFactoryImpl` to add support for `OracleMultiInsertStatement`
- Extend `OracleOperateRecognizerHolder` to add methods specifically for handling multiple inserts
- Create `OracleMultiInsertRecognizer` and use `ast.getEntries()` to obtain insert items. It supports parsing multiple INSERT INTO clauses and correctly handles various data types (NULL, parameter placeholders, sequences, etc.)

3. Verification Functionality  -> Created OracleMultiInsertRecognizerTest containing 11 test cases:
- Basic functional testing: SQL type, table name, table alias
- Column processing testing: Insert column retrieval, empty column detection
- Data row testing: Basic data, NULL values, parameter placeholders, primary key processing
- Complex scenario testing: Multi-table inserts, complex statements, edge cases
- Interface consistency testing: Ensures compliance with the Seata interface specification

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7607 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
UT have been added

### Ⅳ. Describe how to verify it
mvn clean test

### Ⅴ. Special notes for reviews
Currently, only single-table Oracle INSERT batching is supported. I don't believe multi-table support is necessary because branching transactions can be useful.❤️
