### PR TITLE
bugfix: fix memory leak in MySQL XA mode

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -44,7 +44,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] fix the compatibility issue of yml configuration files
 - [[#7644](https://github.com/apache/incubator-seata/pull/7644)] fix the compatibility issue of spotless when java 25
 - [[#7662](https://github.com/apache/incubator-seata/pull/7662)] ensure visibility of rm and The methods in MockTest are executed in order
-- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] Override XABranchXid equals() and hashCode() to fix memory leak in com.mysql.cj.jdbc.SuspendableXAConnection.XIDS_TO_PHYSICAL_CONNECTIONS
+- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] Override XABranchXid equals() and hashCode() to fix memory leak in mysql driver
 
 
 ### optimize:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -44,7 +44,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] fix the compatibility issue of yml configuration files
 - [[#7644](https://github.com/apache/incubator-seata/pull/7644)] fix the compatibility issue of spotless when java 25
 - [[#7662](https://github.com/apache/incubator-seata/pull/7662)] ensure visibility of rm and The methods in MockTest are executed in order
-- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] Override XABranchXid equals() and hashCode() to fix memory leak in mysql driver
+- [[#7683](https://github.com/apache/incubator-seata/pull/7683)] Override XABranchXid equals() and hashCode() to fix memory leak in mysql driver
 
 
 ### optimize:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -44,6 +44,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] fix the compatibility issue of yml configuration files
 - [[#7644](https://github.com/apache/incubator-seata/pull/7644)] fix the compatibility issue of spotless when java 25
 - [[#7662](https://github.com/apache/incubator-seata/pull/7662)] ensure visibility of rm and The methods in MockTest are executed in order
+- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] Override XABranchXid equals() and hashCode() to fix memory leak in com.mysql.cj.jdbc.SuspendableXAConnection.XIDS_TO_PHYSICAL_CONNECTIONS
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -44,7 +44,7 @@
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] 修复yml配置文件中对于整数的兼容问题
 - [[#7644](https://github.com/apache/incubator-seata/pull/7644)] 修复JAVA25时spotless的兼容性问题
 - [[#7662](https://github.com/apache/incubator-seata/pull/7662)] 确保 rm 的可见性，并且 MockTest 中的方法按顺序执行
-- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] 重写 XABranchXid的equals和hashCode,解决mysql driver内存泄漏问题
+- [[#7683](https://github.com/apache/incubator-seata/pull/7683)] 重写 XABranchXid的equals和hashCode,解决mysql driver内存泄漏问题
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -44,7 +44,7 @@
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] 修复yml配置文件中对于整数的兼容问题
 - [[#7644](https://github.com/apache/incubator-seata/pull/7644)] 修复JAVA25时spotless的兼容性问题
 - [[#7662](https://github.com/apache/incubator-seata/pull/7662)] 确保 rm 的可见性，并且 MockTest 中的方法按顺序执行
-- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] 重写 XABranchXid 的 equals() 和 hashCode()，解决 com.mysql.cj.jdbc.SuspendableXAConnection.XIDS_TO_PHYSICAL_CONNECTIONS 内存泄漏问题
+- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] 重写 XABranchXid的equals和hashCode,解决mysql driver内存泄漏问题
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -44,6 +44,7 @@
 - [[#7624](https://github.com/apache/incubator-seata/pull/7624)] 修复yml配置文件中对于整数的兼容问题
 - [[#7644](https://github.com/apache/incubator-seata/pull/7644)] 修复JAVA25时spotless的兼容性问题
 - [[#7662](https://github.com/apache/incubator-seata/pull/7662)] 确保 rm 的可见性，并且 MockTest 中的方法按顺序执行
+- [[#7682](https://github.com/apache/incubator-seata/pull/7682)] 重写 XABranchXid 的 equals() 和 hashCode()，解决 com.mysql.cj.jdbc.SuspendableXAConnection.XIDS_TO_PHYSICAL_CONNECTIONS 内存泄漏问题
 
 
 ### optimize:

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/XABranchXid.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/XABranchXid.java
@@ -127,6 +127,9 @@ public class XABranchXid implements XAXid {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/XABranchXid.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/xa/XABranchXid.java
@@ -17,6 +17,7 @@
 package org.apache.seata.rm.datasource.xa;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Objects;
 
 /**
  * Xid in XA Protocol. Wrap info of Seata xid and branchId.
@@ -122,5 +123,19 @@ public class XABranchXid implements XAXid {
     @Override
     public String toString() {
         return xid + BRANCH_ID_PREFIX + branchId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        XABranchXid that = (XABranchXid) o;
+        return branchId == that.branchId && Objects.equals(xid, that.xid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(xid, branchId);
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/XABranchXidTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/XABranchXidTest.java
@@ -1,0 +1,32 @@
+package org.apache.seata.rm.datasource.xa;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for XABranchXid
+ */
+public class XABranchXidTest {
+    @Test
+    void testEquals() throws Exception {
+        XABranchXid xid1 = new XABranchXid("xid1", 1);
+        XABranchXid xid2 = new XABranchXid("xid1", 1);
+        XABranchXid xid3 = new XABranchXid("xid2", 2);
+        XABranchXid xid4 = null;
+
+        Assertions.assertEquals(xid1, xid2);
+        Assertions.assertNotEquals(xid1, xid3);
+        Assertions.assertNotEquals(xid1, xid4);
+        Assertions.assertNotEquals(xid1, new Object());
+    }
+
+    @Test
+    void testHashCode() throws Exception {
+        XABranchXid xid1 = new XABranchXid("xid1", 1);
+        XABranchXid xid2 = new XABranchXid("xid1", 1);
+        XABranchXid xid3 = new XABranchXid("xid2", 2);
+
+        Assertions.assertEquals(xid1.hashCode(), xid2.hashCode());
+        Assertions.assertNotEquals(xid1.hashCode(), xid3.hashCode());
+    }
+}

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/XABranchXidTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/XABranchXidTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.seata.rm.datasource.xa;
 
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
…ak in com.mysql.cj.jdbc.SuspendableXAConnection.XIDS_TO_PHYSICAL_CONNECTIONS

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Override XABranchXid equals() and hashCode() to fix memory leak in com.mysql.cj.jdbc.SuspendableXAConnection.XIDS_TO_PHYSICAL_CONNECTIONS

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7682

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

