### PR TITLE
feature(core): add core connection-pool monitoring (implementation, cache)

### DIFF
--- a/core/src/main/java/org/apache/seata/core/protocol/ConnectionPoolInfo.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/ConnectionPoolInfo.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.protocol;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Connection pool information for heartbeat monitoring.
+ *
+ * @since 2.1.0
+ */
+public class ConnectionPoolInfo implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Client application ID
+     */
+    private String applicationId;
+
+    /**
+     * Transaction service group
+     */
+    private String transactionServiceGroup;
+
+    /**
+     * DataSource connection pool metrics (HikariCP/Druid)
+     */
+    private List<Object> dataSourceMetrics = new ArrayList<>();
+
+    /**
+     * Timestamp when this info was collected
+     */
+    private long timestamp;
+
+    public ConnectionPoolInfo() {
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public ConnectionPoolInfo(String applicationId, String transactionServiceGroup) {
+        this();
+        this.applicationId = applicationId;
+        this.transactionServiceGroup = transactionServiceGroup;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getTransactionServiceGroup() {
+        return transactionServiceGroup;
+    }
+
+    public void setTransactionServiceGroup(String transactionServiceGroup) {
+        this.transactionServiceGroup = transactionServiceGroup;
+    }
+
+    public List<Object> getDataSourceMetrics() {
+        return dataSourceMetrics;
+    }
+
+    public void setDataSourceMetrics(List<Object> dataSourceMetrics) {
+        this.dataSourceMetrics = dataSourceMetrics;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionPoolInfo{" + "applicationId='"
+                + applicationId + '\'' + ", transactionServiceGroup='"
+                + transactionServiceGroup + '\'' + ", dataSourceMetrics="
+                + (dataSourceMetrics != null ? dataSourceMetrics.size() + " metrics" : "null") + ", timestamp="
+                + timestamp + '}';
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/protocol/DruidConnectionPoolMetrics.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/DruidConnectionPoolMetrics.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.protocol;
+
+import java.io.Serializable;
+
+/**
+ * Druid connection pool metrics for detailed monitoring.
+ *
+ * @since 2.1.0
+ */
+public class DruidConnectionPoolMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Active connections
+     */
+    private int activeConnections;
+
+    /**
+     * Idle connections
+     */
+    private int idleConnections;
+
+    /**
+     * Total connections
+     */
+    private int totalConnections;
+
+    /**
+     * Max pool size
+     */
+    private int maxPoolSize;
+
+    /**
+     * Min idle connections
+     */
+    private int minIdle;
+
+    /**
+     * Threads awaiting connection
+     */
+    private int waitThreadCount;
+
+    /**
+     * Connection timeout (ms)
+     */
+    private int connectionTimeout;
+
+    /**
+     * Validation timeout (ms)
+     */
+    private long validationTimeout;
+
+    /**
+     * Auto-commit status
+     */
+    private boolean autoCommit;
+
+    /**
+     * Idle timeout (ms)
+     */
+    private long idleTimeout;
+
+    /**
+     * Execute count
+     */
+    private long executeCount;
+
+    /**
+     * Error count
+     */
+    private long errorCount;
+
+    /**
+     * Commit count
+     */
+    private long commitCount;
+
+    /**
+     * Rollback count
+     */
+    private long rollbackCount;
+
+    /**
+     * Logical connections count
+     */
+    private long logicConnectCount;
+
+    /**
+     * Eviction run interval (ms)
+     */
+    private long timeBetweenEvictionRunsMills;
+
+    /**
+     * Max evictable idle time (ms)
+     */
+    private long maxEvictableTimeMills;
+
+    /**
+     * Pool name
+     */
+    private String poolName;
+
+    /**
+     * JDBC URL
+     */
+    private String jdbcUrl;
+
+    /**
+     * DataSource class name
+     */
+    private String dataSourceClassName;
+
+    /**
+     * Metrics collection timestamp
+     */
+    private long timestamp;
+
+    /**
+     * Pool creation time
+     */
+    private long poolCreatedTime;
+
+    /**
+     * Max wait time (ms)
+     */
+    private long maxWaitTime;
+
+    /**
+     * Physical connections created
+     */
+    private long physicalConnectCount;
+
+    /**
+     * Physical connections closed
+     */
+    private long physicalCloseCount;
+
+    public DruidConnectionPoolMetrics() {
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public DruidConnectionPoolMetrics(String poolName) {
+        this();
+        this.poolName = poolName;
+    }
+
+    // Getters and setters
+    public int getActiveConnections() {
+        return activeConnections;
+    }
+
+    public void setActiveConnections(int activeConnections) {
+        this.activeConnections = activeConnections;
+    }
+
+    public int getIdleConnections() {
+        return idleConnections;
+    }
+
+    public void setIdleConnections(int idleConnections) {
+        this.idleConnections = idleConnections;
+    }
+
+    public int getTotalConnections() {
+        return totalConnections;
+    }
+
+    public void setTotalConnections(int totalConnections) {
+        this.totalConnections = totalConnections;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getMinIdle() {
+        return minIdle;
+    }
+
+    public void setMinIdle(int minIdle) {
+        this.minIdle = minIdle;
+    }
+
+    public int getWaitThreadCount() {
+        return waitThreadCount;
+    }
+
+    public void setWaitThreadCount(int waitThreadCount) {
+        this.waitThreadCount = waitThreadCount;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public long getValidationTimeout() {
+        return validationTimeout;
+    }
+
+    public void setValidationTimeout(long validationTimeout) {
+        this.validationTimeout = validationTimeout;
+    }
+
+    public boolean isAutoCommit() {
+        return autoCommit;
+    }
+
+    public void setAutoCommit(boolean autoCommit) {
+        this.autoCommit = autoCommit;
+    }
+
+    public long getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public void setIdleTimeout(long idleTimeout) {
+        this.idleTimeout = idleTimeout;
+    }
+
+    public long getExecuteCount() {
+        return executeCount;
+    }
+
+    public void setExecuteCount(long executeCount) {
+        this.executeCount = executeCount;
+    }
+
+    public long getErrorCount() {
+        return errorCount;
+    }
+
+    public void setErrorCount(long errorCount) {
+        this.errorCount = errorCount;
+    }
+
+    public long getCommitCount() {
+        return commitCount;
+    }
+
+    public void setCommitCount(long commitCount) {
+        this.commitCount = commitCount;
+    }
+
+    public long getRollbackCount() {
+        return rollbackCount;
+    }
+
+    public void setRollbackCount(long rollbackCount) {
+        this.rollbackCount = rollbackCount;
+    }
+
+    public long getLogicConnectCount() {
+        return logicConnectCount;
+    }
+
+    public void setLogicConnectCount(long logicConnectCount) {
+        this.logicConnectCount = logicConnectCount;
+    }
+
+    public long getTimeBetweenEvictionRunsMills() {
+        return timeBetweenEvictionRunsMills;
+    }
+
+    public void setTimeBetweenEvictionRunsMills(long timeBetweenEvictionRunsMills) {
+        this.timeBetweenEvictionRunsMills = timeBetweenEvictionRunsMills;
+    }
+
+    public long getMaxEvictableTimeMills() {
+        return maxEvictableTimeMills;
+    }
+
+    public void setMaxEvictableTimeMills(long maxEvictableTimeMills) {
+        this.maxEvictableTimeMills = maxEvictableTimeMills;
+    }
+
+    public String getPoolName() {
+        return poolName;
+    }
+
+    public void setPoolName(String poolName) {
+        this.poolName = poolName;
+    }
+
+    public String getJdbcUrl() {
+        return jdbcUrl;
+    }
+
+    public void setJdbcUrl(String jdbcUrl) {
+        this.jdbcUrl = jdbcUrl;
+    }
+
+    public String getDataSourceClassName() {
+        return dataSourceClassName;
+    }
+
+    public void setDataSourceClassName(String dataSourceClassName) {
+        this.dataSourceClassName = dataSourceClassName;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public long getPoolCreatedTime() {
+        return poolCreatedTime;
+    }
+
+    public void setPoolCreatedTime(long poolCreatedTime) {
+        this.poolCreatedTime = poolCreatedTime;
+    }
+
+    public long getMaxWaitTime() {
+        return maxWaitTime;
+    }
+
+    public void setMaxWaitTime(long maxWaitTime) {
+        this.maxWaitTime = maxWaitTime;
+    }
+
+    public long getPhysicalConnectCount() {
+        return physicalConnectCount;
+    }
+
+    public void setPhysicalConnectCount(long physicalConnectCount) {
+        this.physicalConnectCount = physicalConnectCount;
+    }
+
+    public long getPhysicalCloseCount() {
+        return physicalCloseCount;
+    }
+
+    public void setPhysicalCloseCount(long physicalCloseCount) {
+        this.physicalCloseCount = physicalCloseCount;
+    }
+
+    /**
+     * Calculate connection pool utilization
+     */
+    public double getUtilizationRate() {
+        return maxPoolSize > 0 ? (double) activeConnections / maxPoolSize : 0.0;
+    }
+
+    /**
+     * Calculate error rate
+     */
+    public double getErrorRate() {
+        return executeCount > 0 ? (double) errorCount / executeCount : 0.0;
+    }
+
+    /**
+     * Calculate rollback rate
+     */
+    public double getRollbackRate() {
+        long totalTransactions = commitCount + rollbackCount;
+        return totalTransactions > 0 ? (double) rollbackCount / totalTransactions : 0.0;
+    }
+
+    /**
+     * Check whether the connection pool is healthy
+     */
+    public boolean isHealthy() {
+        return activeConnections >= 0
+                && totalConnections >= activeConnections
+                && totalConnections <= maxPoolSize
+                && getErrorRate() < 0.05
+                && // Error rate less than 5%
+                getRollbackRate() < 0.1; // Rollback rate less than 10%
+    }
+
+    /**
+     * Get connection pool uptime (ms)
+     */
+    public long getPoolUptime() {
+        return poolCreatedTime > 0 ? timestamp - poolCreatedTime : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "DruidConnectionPoolMetrics{" + "poolName='"
+                + poolName + '\'' + ", activeConnections="
+                + activeConnections + ", idleConnections="
+                + idleConnections + ", totalConnections="
+                + totalConnections + ", maxPoolSize="
+                + maxPoolSize + ", minIdle="
+                + minIdle + ", waitThreadCount="
+                + waitThreadCount + ", connectionTimeout="
+                + connectionTimeout + ", validationTimeout="
+                + validationTimeout + ", autoCommit="
+                + autoCommit + ", idleTimeout="
+                + idleTimeout + ", executeCount="
+                + executeCount + ", errorCount="
+                + errorCount + ", commitCount="
+                + commitCount + ", rollbackCount="
+                + rollbackCount + ", logicConnectCount="
+                + logicConnectCount + ", timeBetweenEvictionRunsMills="
+                + timeBetweenEvictionRunsMills + ", maxEvictableTimeMills="
+                + maxEvictableTimeMills + ", utilizationRate="
+                + getUtilizationRate() + ", errorRate="
+                + getErrorRate() + ", rollbackRate="
+                + getRollbackRate() + ", isHealthy="
+                + isHealthy() + ", poolUptime="
+                + getPoolUptime() + ", timestamp="
+                + timestamp + '}';
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/protocol/HikariConnectionPoolMetrics.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/HikariConnectionPoolMetrics.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.protocol;
+
+import java.io.Serializable;
+
+/**
+ * HikariCP connection pool metrics for detailed monitoring.
+ *
+ * @since 2.1.0
+ */
+public class HikariConnectionPoolMetrics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Active connections
+     */
+    private int activeConnections;
+
+    /**
+     * Idle connections
+     */
+    private int idleConnections;
+
+    /**
+     * Total connections
+     */
+    private int totalConnections;
+
+    /**
+     * Max pool size
+     */
+    private int maxPoolSize;
+
+    /**
+     * Min idle connections
+     */
+    private int minIdle;
+
+    /**
+     * Threads awaiting connection
+     */
+    private int waitThreadCount;
+
+    /**
+     * Connection timeout (ms)
+     */
+    private int connectionTimeout;
+
+    /**
+     * Validation timeout (ms)
+     */
+    private long validationTimeout;
+
+    /**
+     * Auto-commit status
+     */
+    private boolean autoCommit;
+
+    /**
+     * Idle timeout (ms)
+     */
+    private long idleTimeout;
+
+    /**
+     * Connection acquisition time (ms)
+     */
+    private long connectionAcquired;
+
+    /**
+     * Connection timeout rate (0.0–1.0)
+     */
+    private double connectionTimeoutRate;
+
+    /**
+     * Leak detection threshold (ms)
+     */
+    private long leakDetectionThreshold;
+
+    /**
+     * Max lifetime (ms)
+     */
+    private long maxLifeTime;
+
+    /**
+     * Keepalive time (ms)
+     */
+    private long keepaliveTime;
+
+    /**
+     * Pool name
+     */
+    private String poolName;
+
+    /**
+     * JDBC URL
+     */
+    private String jdbcUrl;
+
+    /**
+     * DataSource class name
+     */
+    private String dataSourceClassName;
+
+    /**
+     * Metrics collection timestamp
+     */
+    private long timestamp;
+
+    public HikariConnectionPoolMetrics() {
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public HikariConnectionPoolMetrics(String poolName) {
+        this();
+        this.poolName = poolName;
+    }
+
+    // Getters and setters
+    public int getActiveConnections() {
+        return activeConnections;
+    }
+
+    public void setActiveConnections(int activeConnections) {
+        this.activeConnections = activeConnections;
+    }
+
+    public int getIdleConnections() {
+        return idleConnections;
+    }
+
+    public void setIdleConnections(int idleConnections) {
+        this.idleConnections = idleConnections;
+    }
+
+    public int getTotalConnections() {
+        return totalConnections;
+    }
+
+    public void setTotalConnections(int totalConnections) {
+        this.totalConnections = totalConnections;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getMinIdle() {
+        return minIdle;
+    }
+
+    public void setMinIdle(int minIdle) {
+        this.minIdle = minIdle;
+    }
+
+    public int getWaitThreadCount() {
+        return waitThreadCount;
+    }
+
+    public void setWaitThreadCount(int waitThreadCount) {
+        this.waitThreadCount = waitThreadCount;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public long getValidationTimeout() {
+        return validationTimeout;
+    }
+
+    public void setValidationTimeout(long validationTimeout) {
+        this.validationTimeout = validationTimeout;
+    }
+
+    public boolean isAutoCommit() {
+        return autoCommit;
+    }
+
+    public void setAutoCommit(boolean autoCommit) {
+        this.autoCommit = autoCommit;
+    }
+
+    public long getIdleTimeout() {
+        return idleTimeout;
+    }
+
+    public void setIdleTimeout(long idleTimeout) {
+        this.idleTimeout = idleTimeout;
+    }
+
+    public long getConnectionAcquired() {
+        return connectionAcquired;
+    }
+
+    public void setConnectionAcquired(long connectionAcquired) {
+        this.connectionAcquired = connectionAcquired;
+    }
+
+    public double getConnectionTimeoutRate() {
+        return connectionTimeoutRate;
+    }
+
+    public void setConnectionTimeoutRate(double connectionTimeoutRate) {
+        this.connectionTimeoutRate = connectionTimeoutRate;
+    }
+
+    public long getLeakDetectionThreshold() {
+        return leakDetectionThreshold;
+    }
+
+    public void setLeakDetectionThreshold(long leakDetectionThreshold) {
+        this.leakDetectionThreshold = leakDetectionThreshold;
+    }
+
+    public long getMaxLifeTime() {
+        return maxLifeTime;
+    }
+
+    public void setMaxLifeTime(long maxLifeTime) {
+        this.maxLifeTime = maxLifeTime;
+    }
+
+    public long getKeepaliveTime() {
+        return keepaliveTime;
+    }
+
+    public void setKeepaliveTime(long keepaliveTime) {
+        this.keepaliveTime = keepaliveTime;
+    }
+
+    public String getPoolName() {
+        return poolName;
+    }
+
+    public void setPoolName(String poolName) {
+        this.poolName = poolName;
+    }
+
+    public String getJdbcUrl() {
+        return jdbcUrl;
+    }
+
+    public void setJdbcUrl(String jdbcUrl) {
+        this.jdbcUrl = jdbcUrl;
+    }
+
+    public String getDataSourceClassName() {
+        return dataSourceClassName;
+    }
+
+    public void setDataSourceClassName(String dataSourceClassName) {
+        this.dataSourceClassName = dataSourceClassName;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Calculate connection pool utilization
+     */
+    public double getUtilizationRate() {
+        return maxPoolSize > 0 ? (double) activeConnections / maxPoolSize : 0.0;
+    }
+
+    /**
+     * Check whether the connection pool is healthy
+     */
+    public boolean isHealthy() {
+        return activeConnections >= 0
+                && totalConnections >= activeConnections
+                && totalConnections <= maxPoolSize
+                && connectionTimeoutRate < 0.1; // Timeout rate less than 10%
+    }
+
+    @Override
+    public String toString() {
+        return "HikariConnectionPoolMetrics{" + "poolName='"
+                + poolName + '\'' + ", activeConnections="
+                + activeConnections + ", idleConnections="
+                + idleConnections + ", totalConnections="
+                + totalConnections + ", maxPoolSize="
+                + maxPoolSize + ", minIdle="
+                + minIdle + ", waitThreadCount="
+                + waitThreadCount + ", connectionTimeout="
+                + connectionTimeout + ", validationTimeout="
+                + validationTimeout + ", autoCommit="
+                + autoCommit + ", idleTimeout="
+                + idleTimeout + ", connectionAcquired="
+                + connectionAcquired + ", connectionTimeoutRate="
+                + connectionTimeoutRate + ", leakDetectionThreshold="
+                + leakDetectionThreshold + ", maxLifeTime="
+                + maxLifeTime + ", keepaliveTime="
+                + keepaliveTime + ", utilizationRate="
+                + getUtilizationRate() + ", isHealthy="
+                + isHealthy() + ", timestamp="
+                + timestamp + '}';
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/ConnectionPoolMonitor.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/ConnectionPoolMonitor.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.rpc.netty;
+
+import org.apache.seata.core.protocol.ConnectionPoolInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Connection pool monitor for collecting pool statistics and health information.
+ *
+ * @since 2.1.0
+ */
+public class ConnectionPoolMonitor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionPoolMonitor.class);
+
+    private final String applicationId;
+    private final String transactionServiceGroup;
+
+    public ConnectionPoolMonitor(String applicationId, String transactionServiceGroup) {
+        this.applicationId = applicationId;
+        this.transactionServiceGroup = transactionServiceGroup;
+    }
+
+    /**
+     * Collect current connection pool information
+     */
+    public ConnectionPoolInfo collectPoolInfo() {
+        ConnectionPoolInfo poolInfo = new ConnectionPoolInfo(applicationId, transactionServiceGroup);
+        try {
+            List<Object> dataSourceMetrics = DataSourceConnectionPoolCollector.collectAllPoolMetrics();
+            poolInfo.setDataSourceMetrics(dataSourceMetrics);
+            LOGGER.debug("Collected connection pool information: {}", poolInfo);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to collect connection pool information", e);
+        }
+        return poolInfo;
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/DataSourceConnectionPoolCollector.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/DataSourceConnectionPoolCollector.java
@@ -25,6 +25,7 @@ import javax.sql.DataSource;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -73,7 +74,7 @@ public class DataSourceConnectionPoolCollector {
     public static List<Object> collectAllPoolMetrics() {
         List<Object> allMetrics = new ArrayList<>();
 
-        for (ConcurrentMap.Entry<String, DataSource> entry : REGISTERED_DATASOURCES.entrySet()) {
+        for (Map.Entry<String, DataSource> entry : REGISTERED_DATASOURCES.entrySet()) {
             String name = entry.getKey();
             DataSource dataSource = entry.getValue();
 

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/DataSourceConnectionPoolCollector.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/DataSourceConnectionPoolCollector.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.rpc.netty;
+
+import org.apache.seata.core.protocol.DruidConnectionPoolMetrics;
+import org.apache.seata.core.protocol.HikariConnectionPoolMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * DataSource connection pool metrics collector for HikariCP and Druid.
+ *
+ * @since 2.1.0
+ */
+public class DataSourceConnectionPoolCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceConnectionPoolCollector.class);
+
+    // Cache for registered DataSources
+    private static final ConcurrentMap<String, DataSource> REGISTERED_DATASOURCES = new ConcurrentHashMap<>();
+
+    // Supported DataSource (pool) types
+    private static final String HIKARI_DATASOURCE_CLASS = "com.zaxxer.hikari.HikariDataSource";
+    private static final String DRUID_DATASOURCE_CLASS = "com.alibaba.druid.pool.DruidDataSource";
+
+    /**
+     * Register a DataSource for monitoring
+     */
+    public static void registerDataSource(String name, DataSource dataSource) {
+        if (name != null && dataSource != null) {
+            REGISTERED_DATASOURCES.put(name, dataSource);
+            LOGGER.info(
+                    "Registered DataSource for monitoring: {} - {}",
+                    name,
+                    dataSource.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Unregister a DataSource from monitoring
+     */
+    public static void unregisterDataSource(String name) {
+        DataSource removed = REGISTERED_DATASOURCES.remove(name);
+        if (removed != null) {
+            LOGGER.info("Unregistered DataSource: {}", name);
+        }
+    }
+
+    /**
+     * Collect connection pool metrics for all registered DataSources
+     */
+    public static List<Object> collectAllPoolMetrics() {
+        List<Object> allMetrics = new ArrayList<>();
+
+        for (ConcurrentMap.Entry<String, DataSource> entry : REGISTERED_DATASOURCES.entrySet()) {
+            String name = entry.getKey();
+            DataSource dataSource = entry.getValue();
+
+            try {
+                Object metrics = collectPoolMetrics(name, dataSource);
+                if (metrics != null) {
+                    allMetrics.add(metrics);
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Failed to collect metrics for DataSource: {}", name, e);
+            }
+        }
+
+        return allMetrics;
+    }
+
+    /**
+     * Collect connection pool metrics for a single DataSource
+     */
+    public static Object collectPoolMetrics(String name, DataSource dataSource) {
+        if (dataSource == null) {
+            return null;
+        }
+
+        String className = dataSource.getClass().getName();
+
+        if (className.equals(HIKARI_DATASOURCE_CLASS)) {
+            return collectHikariMetrics(name, dataSource);
+        } else if (className.equals(DRUID_DATASOURCE_CLASS)) {
+            return collectDruidMetrics(name, dataSource);
+        } else {
+            LOGGER.debug("Unsupported DataSource type: {}", className);
+            return null;
+        }
+    }
+
+    /**
+     * Collect HikariCP connection pool metrics
+     */
+    private static HikariConnectionPoolMetrics collectHikariMetrics(String name, DataSource dataSource) {
+        try {
+            HikariConnectionPoolMetrics metrics = new HikariConnectionPoolMetrics(name);
+
+            // Get HikariPoolMXBean
+            Object poolMXBean = invokeMethod(dataSource, "getHikariPoolMXBean");
+            if (poolMXBean == null) {
+                LOGGER.warn("Failed to get HikariPoolMXBean for: {}", name);
+                return null;
+            }
+
+            // Collect basic pool metrics
+            metrics.setActiveConnections(getIntValue(poolMXBean, "getActiveConnections"));
+            metrics.setIdleConnections(getIntValue(poolMXBean, "getIdleConnections"));
+            metrics.setTotalConnections(getIntValue(poolMXBean, "getTotalConnections"));
+            metrics.setWaitThreadCount(getIntValue(poolMXBean, "getThreadsAwaitingConnection"));
+
+            // Collect configuration info
+            metrics.setMaxPoolSize(getIntValue(dataSource, "getMaximumPoolSize"));
+            metrics.setMinIdle(getIntValue(dataSource, "getMinimumIdle"));
+            metrics.setConnectionTimeout(getIntValue(dataSource, "getConnectionTimeout"));
+            metrics.setValidationTimeout(getLongValue(dataSource, "getValidationTimeout"));
+            metrics.setAutoCommit(getBooleanValue(dataSource, "isAutoCommit"));
+            metrics.setIdleTimeout(getLongValue(dataSource, "getIdleTimeout"));
+            metrics.setLeakDetectionThreshold(getLongValue(dataSource, "getLeakDetectionThreshold"));
+            metrics.setMaxLifeTime(getLongValue(dataSource, "getMaxLifetime"));
+            metrics.setKeepaliveTime(getLongValue(dataSource, "getKeepaliveTime"));
+
+            // Get JDBC URL and DataSource class name
+            metrics.setJdbcUrl(getStringValue(dataSource, "getJdbcUrl"));
+            metrics.setDataSourceClassName(getStringValue(dataSource, "getDataSourceClassName"));
+
+            // Calculate connection acquisition time and timeout rate (via stats)
+            calculateDerivedMetrics(metrics, poolMXBean);
+
+            return metrics;
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to collect HikariCP metrics for: {}", name, e);
+            return null;
+        }
+    }
+
+    /**
+     * Collect Druid connection pool metrics
+     */
+    private static DruidConnectionPoolMetrics collectDruidMetrics(String name, DataSource dataSource) {
+        try {
+            DruidConnectionPoolMetrics metrics = new DruidConnectionPoolMetrics(name);
+
+            // Collect basic pool metrics
+            metrics.setActiveConnections(getIntValue(dataSource, "getActiveCount"));
+            metrics.setIdleConnections(getIntValue(dataSource, "getPoolingCount"));
+            metrics.setMaxPoolSize(getIntValue(dataSource, "getMaxActive"));
+            metrics.setMinIdle(getIntValue(dataSource, "getMinIdle"));
+            metrics.setWaitThreadCount(getIntValue(dataSource, "getWaitThreadCount"));
+
+            // Compute total connections
+            int activeCount = getIntValue(dataSource, "getActiveCount");
+            int poolingCount = getIntValue(dataSource, "getPoolingCount");
+            metrics.setTotalConnections(activeCount + poolingCount);
+
+            // Collect configuration info
+            metrics.setConnectionTimeout(getIntValue(dataSource, "getMaxWait"));
+            metrics.setValidationTimeout(getLongValue(dataSource, "getValidationQueryTimeout"));
+            metrics.setAutoCommit(getBooleanValue(dataSource, "isDefaultAutoCommit"));
+            metrics.setIdleTimeout(getLongValue(dataSource, "getMinEvictableIdleTimeMillis"));
+            metrics.setTimeBetweenEvictionRunsMills(getLongValue(dataSource, "getTimeBetweenEvictionRunsMillis"));
+            metrics.setMaxEvictableTimeMills(getLongValue(dataSource, "getMaxEvictableIdleTimeMillis"));
+
+            // Collect statistical info
+            metrics.setExecuteCount(getLongValue(dataSource, "getExecuteCount"));
+            metrics.setErrorCount(getLongValue(dataSource, "getErrorCount"));
+            metrics.setCommitCount(getLongValue(dataSource, "getCommitCount"));
+            metrics.setRollbackCount(getLongValue(dataSource, "getRollbackCount"));
+            metrics.setLogicConnectCount(getLongValue(dataSource, "getConnectCount"));
+            metrics.setPhysicalConnectCount(getLongValue(dataSource, "getCreateCount"));
+            metrics.setPhysicalCloseCount(getLongValue(dataSource, "getDestroyCount"));
+
+            // Get JDBC URL
+            metrics.setJdbcUrl(getStringValue(dataSource, "getUrl"));
+            metrics.setDataSourceClassName(dataSource.getClass().getName());
+
+            // Get pool creation time
+            Object createdTime = invokeMethod(dataSource, "getCreatedTime");
+            if (createdTime instanceof java.util.Date) {
+                metrics.setPoolCreatedTime(((java.util.Date) createdTime).getTime());
+            }
+
+            return metrics;
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to collect Druid metrics for: {}", name, e);
+            return null;
+        }
+    }
+
+    /**
+     * Calculate derived metrics for HikariCP
+     */
+    private static void calculateDerivedMetrics(HikariConnectionPoolMetrics metrics, Object poolMXBean) {
+        try {
+            // More detailed stats can be fetched via JMX or other means
+            // Temporarily use default values; real implementation may use historical monitoring data
+            metrics.setConnectionAcquired(0L);
+            metrics.setConnectionTimeoutRate(0.0);
+        } catch (Exception e) {
+            LOGGER.debug("Failed to calculate derived metrics", e);
+        }
+    }
+
+    /**
+     * Invoke method via reflection
+     */
+    private static Object invokeMethod(Object obj, String methodName) {
+        try {
+            Method method = obj.getClass().getMethod(methodName);
+            return method.invoke(obj);
+        } catch (Exception e) {
+            LOGGER.debug(
+                    "Failed to invoke method: {} on {}",
+                    methodName,
+                    obj.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    /**
+     * Get int value
+     */
+    private static int getIntValue(Object obj, String methodName) {
+        Object value = invokeMethod(obj, methodName);
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return 0;
+    }
+
+    /**
+     * Get long value
+     */
+    private static long getLongValue(Object obj, String methodName) {
+        Object value = invokeMethod(obj, methodName);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return 0L;
+    }
+
+    /**
+     * Get boolean value
+     */
+    private static boolean getBooleanValue(Object obj, String methodName) {
+        Object value = invokeMethod(obj, methodName);
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return false;
+    }
+
+    /**
+     * Get String value
+     */
+    private static String getStringValue(Object obj, String methodName) {
+        Object value = invokeMethod(obj, methodName);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Check whether the DataSource type is supported
+     */
+    public static boolean isSupportedDataSource(DataSource dataSource) {
+        if (dataSource == null) {
+            return false;
+        }
+
+        String className = dataSource.getClass().getName();
+        return HIKARI_DATASOURCE_CLASS.equals(className) || DRUID_DATASOURCE_CLASS.equals(className);
+    }
+
+    /**
+     * Get the number of registered DataSources
+     */
+    public static int getRegisteredDataSourceCount() {
+        return REGISTERED_DATASOURCES.size();
+    }
+
+    /**
+     * Get names of all registered DataSources
+     */
+    public static List<String> getRegisteredDataSourceNames() {
+        return new ArrayList<>(REGISTERED_DATASOURCES.keySet());
+    }
+
+    /**
+     * Clear all registered DataSources
+     */
+    public static void clearAllDataSources() {
+        REGISTERED_DATASOURCES.clear();
+        LOGGER.info("Cleared all registered DataSources");
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/rpc/processor/server/ConnectionPoolInfoCache.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/processor/server/ConnectionPoolInfoCache.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.rpc.processor.server;
+
+import org.apache.seata.core.protocol.ConnectionPoolInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache for storing client connection pool information received via enhanced heartbeats.
+ * This cache provides thread-safe operations for storing, retrieving, and cleaning up
+ * connection pool metrics from multiple clients.
+ *
+ * @since 2.1.0
+ */
+public class ConnectionPoolInfoCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionPoolInfoCache.class);
+
+    private final Map<String, CachedPoolInfo> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Update connection pool information for a specific client.
+     *
+     * @param clientAddress the client address (IP:port)
+     * @param poolInfo      the connection pool information to cache
+     */
+    void updatePoolInfo(String clientAddress, ConnectionPoolInfo poolInfo) {
+        if (clientAddress == null || poolInfo == null) {
+            LOGGER.warn("Cannot update pool info: clientAddress={}, poolInfo={}", clientAddress, poolInfo);
+            return;
+        }
+
+        CachedPoolInfo oldInfo = cache.put(clientAddress, new CachedPoolInfo(poolInfo, System.currentTimeMillis()));
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Updated pool info for client {}, previous info existed: {}", clientAddress, oldInfo != null);
+        }
+    }
+
+    /**
+     * Get cached connection pool information for a specific client.
+     *
+     * @param clientAddress the client address (IP:port)
+     * @return the cached connection pool information, or null if not found
+     */
+    ConnectionPoolInfo getPoolInfo(String clientAddress) {
+        if (clientAddress == null) {
+            return null;
+        }
+
+        CachedPoolInfo cached = cache.get(clientAddress);
+        return cached != null ? cached.poolInfo : null;
+    }
+
+    /**
+     * Get all cached connection pool information.
+     *
+     * @return a map of client address to connection pool information
+     */
+    Map<String, ConnectionPoolInfo> getAllPoolInfo() {
+        Map<String, ConnectionPoolInfo> result = new ConcurrentHashMap<>();
+        cache.forEach((key, value) -> result.put(key, value.poolInfo));
+        return result;
+    }
+
+    private static class CachedPoolInfo {
+        final ConnectionPoolInfo poolInfo;
+        final long timestamp;
+
+        CachedPoolInfo(ConnectionPoolInfo poolInfo, long timestamp) {
+            this.poolInfo = poolInfo;
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxy.java
@@ -127,6 +127,7 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
         TableMetaCacheFactory.registerTableMeta(this);
         // Set the default branch type to 'AT' in the RootContext.
         RootContext.setDefaultBranchType(this.getBranchType());
+        DataSourceProxyEnhancer.onDataSourceProxyInitialized(this);
     }
 
     /**
@@ -456,5 +457,6 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
     public void close() throws Exception {
         // TODO: Need to unregister resource from DefaultResourceManager
         TableMetaCacheFactory.shutdown(resourceId);
+        DataSourceProxyEnhancer.onDataSourceProxyDestroyed(this);
     }
 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxyEnhancer.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxyEnhancer.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource;
+
+import org.apache.seata.core.rpc.netty.DataSourceConnectionPoolCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+/**
+ * DataSource proxy enhancer for connection pool monitoring integration.
+ * This class provides hooks to register DataSource for monitoring after proxy initialization.
+ *
+ * @since 2.1.0
+ */
+public class DataSourceProxyEnhancer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceProxyEnhancer.class);
+
+    private static volatile boolean monitoringEnabled = true;
+
+    /**
+     * Enable or disable DataSource monitoring
+     */
+    public static void setMonitoringEnabled(boolean enabled) {
+        monitoringEnabled = enabled;
+        LOGGER.info("DataSource connection pool monitoring {}", enabled ? "enabled" : "disabled");
+    }
+
+    /**
+     * Check whether monitoring is enabled
+     */
+    public static boolean isMonitoringEnabled() {
+        return monitoringEnabled;
+    }
+
+    /**
+     * Register DataSource monitoring after DataSourceProxy initialization
+     *
+     * @param dataSourceProxy Seata DataSource proxy
+     */
+    public static void onDataSourceProxyInitialized(DataSourceProxy dataSourceProxy) {
+        if (!monitoringEnabled) {
+            return;
+        }
+        try {
+            // Get the underlying (target) DataSource
+            DataSource targetDataSource = dataSourceProxy.getTargetDataSource();
+            if (targetDataSource == null) {
+                LOGGER.warn("Target DataSource is null in DataSourceProxy");
+                return;
+            }
+            // Check whether the DataSource type is supported
+            if (!DataSourceConnectionPoolCollector.isSupportedDataSource(targetDataSource)) {
+                LOGGER.debug(
+                        "Unsupported DataSource type for monitoring: {}",
+                        targetDataSource.getClass().getName());
+                return;
+            }
+            // Generate DataSource name
+            String dataSourceName = generateDataSourceName(dataSourceProxy);
+            // Register DataSource for monitoring
+            DataSourceConnectionPoolCollector.registerDataSource(dataSourceName, targetDataSource);
+            LOGGER.info(
+                    "Registered DataSource [{}] for connection pool monitoring: {}",
+                    dataSourceName,
+                    targetDataSource.getClass().getSimpleName());
+        } catch (Exception e) {
+            LOGGER.warn("Failed to register DataSource for monitoring in DataSourceProxy", e);
+        }
+    }
+
+    /**
+     * Unregister DataSource monitoring when DataSourceProxy is destroyed
+     *
+     * @param dataSourceProxy Seata DataSource proxy
+     */
+    public static void onDataSourceProxyDestroyed(DataSourceProxy dataSourceProxy) {
+        if (!monitoringEnabled) {
+            return;
+        }
+        try {
+            String dataSourceName = generateDataSourceName(dataSourceProxy);
+            DataSourceConnectionPoolCollector.unregisterDataSource(dataSourceName);
+            LOGGER.info("Unregistered DataSource [{}] from connection pool monitoring", dataSourceName);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to unregister DataSource from monitoring in DataSourceProxy", e);
+        }
+    }
+
+    /**
+     * Generate DataSource name
+     */
+    private static String generateDataSourceName(DataSourceProxy dataSourceProxy) {
+        // Use resource ID as DataSource name to ensure uniqueness
+        String resourceId = dataSourceProxy.getResourceId();
+        if (resourceId != null && !resourceId.isEmpty()) {
+            return "seata-" + resourceId.replaceAll("[^a-zA-Z0-9-_]", "_");
+        }
+        // Fallback: use object identity hash code
+        return "seata-datasource-" + System.identityHashCode(dataSourceProxy);
+    }
+
+    /**
+     * Manually register a DataSource
+     */
+    public static void registerDataSource(String name, DataSource dataSource) {
+        if (name == null || dataSource == null) {
+            throw new IllegalArgumentException("DataSource name and instance cannot be null");
+        }
+        if (!monitoringEnabled) {
+            LOGGER.debug("DataSource monitoring is disabled, registration ignored for [{}]", name);
+            return;
+        }
+        try {
+            DataSourceConnectionPoolCollector.registerDataSource(name, dataSource);
+            LOGGER.info("Manually registered DataSource [{}] for monitoring", name);
+        } catch (Exception e) {
+            LOGGER.error("Failed to manually register DataSource [{}]", name, e);
+        }
+    }
+
+    /**
+     * Manually unregister a DataSource
+     */
+    public static void unregisterDataSource(String name) {
+        if (name == null) {
+            return;
+        }
+        try {
+            DataSourceConnectionPoolCollector.unregisterDataSource(name);
+            LOGGER.info("Manually unregistered DataSource [{}] from monitoring", name);
+        } catch (Exception e) {
+            LOGGER.error("Failed to manually unregister DataSource [{}]", name, e);
+        }
+    }
+}


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

        http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.  
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

---

## Ⅰ. Describe what this PR did

Add the **core connection-pool monitoring implementation** (transport-agnostic) for CPM backend.

**Domain / Model**
- `ConnectionPoolInfo`: runtime snapshot DTO for pool metrics.

**Providers**
- `DruidConnectionPoolMetrics`: collect metrics from Druid.
- `HikariConnectionPoolMetrics`: collect metrics from HikariCP.

**Collector**
- `DataSourceConnectionPoolCollector`: aggregate metrics from multiple providers.

**Service**
- `ConnectionPoolMonitor`: periodic collection and read APIs.

**Cache**
- `ConnectionPoolInfoCache`: in-memory storage for fast reads.

**Integration Hook**
- `DataSourceProxyEnhancer`: lifecycle hook for automatic registration/unregistration of monitored DataSources.

> This PR **does not** include any private protocol / networking code (Netty / gRPC).  
> Transport (Netty / gRPC / REST) will be integrated in a follow-up PR to keep layering clean.

---

## Ⅱ. Does this pull request fix one issue?

No. It introduces the core capability for the connection-pool-monitor backend, independent of transport.

---

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Basic unit tests will be added with the follow-up PR.

---

## Ⅳ. Describe how to verify it

This PR introduces transport-agnostic core logic only. Verification will be provided by
follow-up unit tests that cover providers (Druid / Hikari), the collector, the monitor, and the cache.  
Those tests will be sufficient to validate the functionality end-to-end without requiring a running console.

---

## Ⅴ. Special notes for reviews

- All new Java files include ASF headers.  
- No Netty / gRPC classes are included in this PR; those will live in a separate PR.  
- The design keeps **providers → collector → monitor → cache → enhancer** independent from transport for easy pluggability.  
- Package structure may be further refined after backend transport abstraction (e.g., gRPC integration) is finalized.  

