### PR TITLE
feature(server): add ConnectionPoolController

### DIFF
--- a/server/src/main/java/org/apache/seata/server/Server.java
+++ b/server/src/main/java/org/apache/seata/server/Server.java
@@ -25,6 +25,7 @@ import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.core.rpc.netty.NettyRemotingServer;
 import org.apache.seata.core.rpc.netty.NettyServerConfig;
+import org.apache.seata.server.controller.ConnectionPoolController;
 import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.instance.SeataInstanceStrategy;
 import org.apache.seata.server.lock.LockerManagerFactory;
@@ -53,6 +54,9 @@ public class Server {
 
     @Resource
     SeataInstanceStrategy seataInstanceStrategy;
+
+    @Resource
+    private ConnectionPoolController connectionPoolController;
 
     /**
      * The entry point of application.
@@ -110,5 +114,6 @@ public class Server {
         // let ServerRunner do destroy instead ShutdownHook, see https://github.com/seata/seata/issues/4028
         ServerRunner.addDisposable(coordinator);
         nettyRemotingServer.init();
+        connectionPoolController.setNettyRemotingServer(nettyRemotingServer);
     }
 }

--- a/server/src/main/java/org/apache/seata/server/controller/ConnectionPoolController.java
+++ b/server/src/main/java/org/apache/seata/server/controller/ConnectionPoolController.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.controller;
+
+import org.apache.seata.common.result.SingleResult;
+import org.apache.seata.core.protocol.ConnectionPoolInfo;
+import org.apache.seata.core.rpc.netty.DataSourceConnectionPoolCollector;
+import org.apache.seata.core.rpc.netty.NettyRemotingServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Controller for accessing client connection pool information.
+ * Provides REST endpoints to query cached connection pool metrics
+ * received from clients via enhanced heartbeats.
+ *
+ * @since 2.1.0
+ */
+@RestController
+@RequestMapping("/api/v1/connection-pool")
+public class ConnectionPoolController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionPoolController.class);
+
+    private NettyRemotingServer nettyRemotingServer;
+
+    /**
+     * Get connection pool information for all clients.
+     *
+     * @return Result containing all client connection pool information
+     */
+    @GetMapping("/info")
+    public ResponseEntity<SingleResult<Map<String, Object>>> getAllConnectionPoolInfo() {
+        SingleResult<Map<String, Object>> result = new SingleResult<>("0", "成功");
+
+        try {
+            Map<String, ConnectionPoolInfo> allPoolInfo = nettyRemotingServer.getAllClientPoolInfo();
+
+            Map<String, Object> responseData = new HashMap<>();
+            responseData.put("totalClients", allPoolInfo.size());
+            responseData.put("clients", allPoolInfo);
+            responseData.put("timestamp", System.currentTimeMillis());
+
+            result.setData(responseData);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Retrieved connection pool info for {} clients", allPoolInfo.size());
+            }
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to retrieve connection pool information", e);
+            result.setCode("500");
+            result.setMessage("Failed to retrieve connection pool information: " + e.getMessage());
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Get connection pool information for a specific client.
+     *
+     * @param clientAddress the client address (IP:port)
+     * @return SingleResult containing the client's connection pool information
+     */
+    @GetMapping("/info/{clientAddress}")
+    public ResponseEntity<SingleResult<Map<String, Object>>> getConnectionPoolInfo(@PathVariable String clientAddress) {
+        SingleResult<Map<String, Object>> result = new SingleResult<>("0", "成功");
+
+        try {
+            // Decode the client address (replace underscores with colons for IP:port format)
+            String decodedAddress = clientAddress.replace("_", ":");
+
+            ConnectionPoolInfo poolInfo = nettyRemotingServer.getClientPoolInfo(decodedAddress);
+            Map<String, Object> responseData = new HashMap<>();
+            responseData.put("clientAddress", decodedAddress);
+            responseData.put("poolInfo", poolInfo);
+            responseData.put("timestamp", System.currentTimeMillis());
+
+            result.setData(responseData);
+
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Retrieved connection pool info for client: {}", decodedAddress);
+            }
+
+        } catch (Exception e) {
+            LOGGER.error("Failed to retrieve connection pool information for client: {}", clientAddress, e);
+            result.setCode("500");
+            result.setMessage("Failed to retrieve connection pool information: " + e.getMessage());
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+    public void setNettyRemotingServer(NettyRemotingServer nettyRemotingServer) {
+        this.nettyRemotingServer = nettyRemotingServer;
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<Object>> getAllConnectionPools() {
+        List<Object> result = DataSourceConnectionPoolCollector.collectAllPoolMetrics();
+        return ResponseEntity.ok(result);
+    }
+}

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -157,4 +157,9 @@
     </root>
     <logger name="org.springframework.security.config.annotation.web.builders.WebSecurity" level="ERROR"/>
     <logger name="org.springframework.security.web.DefaultSecurityFilterChain" level="ERROR"/>
+
+    <logger name="org.apache.seata" level="DEBUG"/>
+    <logger name="org.apache.seata.config" level="INFO"/>
+    <logger name="io.seata" level="DEBUG"/>
+
 </configuration>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Implemented private-protocol-based connection pool metrics reporting and server-side REST APIs.

- **Client (RM) side**:
  - Enhanced `RmNettyRemotingClient` to include `ConnectionPoolInfo` in heartbeat messages (`HeartbeatMessage.PING`).
  - Reports pool metrics periodically (default: 30s) through a private channel without exposing public HTTP endpoints.

- **Server (TC) side**:
  - `ServerHeartbeatProcessor` parses and caches `ConnectionPoolInfo` from incoming heartbeat messages.
  - Added access methods in `NettyRemotingServer` to fetch all or per-client pool info.

- **REST endpoints**:
  - Added `ConnectionPoolController` under `/api/v1/connection-pool`:
    - `GET /info` — Retrieve connection pool info of all clients.
    - `GET /info/{clientAddress}` — Retrieve connection pool info of a specific client.
    - `GET /all` — Retrieve locally collected data source pool metrics via `DataSourceConnectionPoolCollector`.

- **Server integration**:
  - Registered `NettyRemotingServer` in Spring context and injected it into `ConnectionPoolController` for REST access.

Backward-compatible: older clients still send standard heartbeat messages, and the server responds normally.

### Ⅱ. Does this pull request fix one issue?

Yes, it fixs #7575 .

### Ⅲ. Why don't you add test cases (unit test/integration test)?

- The changes involve both network-level heartbeat communication and in-memory caching logic, which are more suitable for integration testing.
- Test cases will be added.

### Ⅳ. Describe how to verify it

1. Start the Seata server.
2. Run an RM client using this version of `RmNettyRemotingClient`.
3. After ~30 seconds:
   - Access `GET /api/v1/connection-pool/info` to view all active client pool info.
   - Access `GET /api/v1/connection-pool/info/{clientAddress}` to query a specific client (use `_` instead of `:` in path).
   - Access `GET /api/v1/connection-pool/all` to verify locally collected pool metrics.
4. Verify that:
   - New clients report valid metrics.
   - Old clients work as before (no metrics available but heartbeat succeeds).

### Ⅴ. Special notes for reviews

