### PR TITLE
optimize: upgrade axios to 1.12.2

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -68,6 +68,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 - [[#7632](https://github.com/apache/incubator-seata/pull/7632)] upgrade sha.js to version 2.4.12
 - [[#7633](https://github.com/apache/incubator-seata/pull/7633)] Upgrade cipher-base to version 1.0.6
+- [[#7659](https://github.com/apache/incubator-seata/pull/7659)] Upgrade axios to version 1.12.2
 
 
 ### test:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -68,7 +68,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 - [[#7632](https://github.com/apache/incubator-seata/pull/7632)] upgrade sha.js to version 2.4.12
 - [[#7633](https://github.com/apache/incubator-seata/pull/7633)] Upgrade cipher-base to version 1.0.6
-- [[#7659](https://github.com/apache/incubator-seata/pull/7659)] Upgrade axios to version 1.12.2
+- [[#7699](https://github.com/apache/incubator-seata/pull/7699)] Upgrade axios to version 1.12.2
 
 
 ### test:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -67,7 +67,7 @@
 
 - [[#7632](https://github.com/apache/incubator-seata/pull/7632)] 升级sha.js为2.4.12
 - [[#7633](https://github.com/apache/incubator-seata/pull/7633)] 升级cipher-base为1.0.6
-
+- [[#7659](https://github.com/apache/incubator-seata/pull/7659)] 升级axios到1.12.2
 
 ### test:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -67,7 +67,7 @@
 
 - [[#7632](https://github.com/apache/incubator-seata/pull/7632)] 升级sha.js为2.4.12
 - [[#7633](https://github.com/apache/incubator-seata/pull/7633)] 升级cipher-base为1.0.6
-- [[#7659](https://github.com/apache/incubator-seata/pull/7659)] 升级axios到1.12.2
+- [[#7699](https://github.com/apache/incubator-seata/pull/7699)] 升级axios到1.12.2
 
 ### test:
 

--- a/console/src/main/resources/static/console-fe/package-lock.json
+++ b/console/src/main/resources/static/console-fe/package-lock.json
@@ -14,7 +14,7 @@
         "@alicloud/console-components-app-layout": "^1.1.4",
         "@alicloud/console-components-console-menu": "^1.2.12",
         "@babel/traverse": "^7.23.7",
-        "axios": "^1.8.2",
+        "axios": "^1.12.2",
         "browserify-sign": "^4.2.2",
         "decode-uri-component": "^0.4.1",
         "elliptic": "^6.5.7",
@@ -4085,12 +4085,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/console/src/main/resources/static/console-fe/package.json
+++ b/console/src/main/resources/static/console-fe/package.json
@@ -79,7 +79,7 @@
     "@alicloud/console-components-app-layout": "^1.1.4",
     "@alicloud/console-components-console-menu": "^1.2.12",
     "@babel/traverse": "^7.23.7",
-    "axios": "^1.8.2",
+    "axios": "^1.12.2",
     "browserify-sign": "^4.2.2",
     "decode-uri-component": "^0.4.1",
     "elliptic": "^6.5.7",


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
This PR upgrades **axios** in the console frontend to version ^1.12.2 (and updates the lockfile to 1.12.2) to address the security vulnerability **CVE-2025-58754**.

### Ⅱ. Does this pull request fix one issue?
fixes #7659  

### Ⅲ. Why don't you add test cases (unit test/integration test)?
No behavioral change was introduced—only a dependency version bump—so no new tests are required.

### Ⅳ. Describe how to verify it
1. Run `npm ls axios` → should output `axios@1.12.2`  
2. Confirm `package.json` contains `"axios": "^1.12.2"`  
3. Confirm `package-lock.json` shows `axios 1.12.2`  
4. (optional) Run `npm run build` to ensure the console frontend builds successfully.

### Ⅴ. Special notes for reviews
- Scope strictly limited to axios dependency update.  
- No source-code or behavioral changes.  
- Maintains backward compatibility and aligns with Apache Seata’s security policy.
