### PR TITLE
optimize: simplify Maven build configuration for source-release profile

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -62,6 +62,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7443](https://github.com/seata/seata/pull/7443)] Replace @LocalTCC with @SagaTransactional in the saga annotation pattern
 - [[#7645](https://github.com/seata/seata/pull/7645)] simplifying the relevant transport.* configuration types
 - [[#7673](https://github.com/apache/incubator-seata/pull/7673)] bump @babel/runtime from ^7.26.10 to ^7.27.0
+- [[#7701](https://github.com/apache/incubator-seata/pull/7701)] simplify Maven build configuration for source-release profile
 
 
 ### security:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -120,6 +120,5 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [psxjoy](https://github.com/psxjoy)
 - [dsomehan](https://github.com/dsomehan)
 - [LegendPei](https://github.com/LegendPei)
-- [WangzJi](https://github.com/WangzJi)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -120,5 +120,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [psxjoy](https://github.com/psxjoy)
 - [dsomehan](https://github.com/dsomehan)
 - [LegendPei](https://github.com/LegendPei)
+- [WangzJi](https://github.com/WangzJi)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -119,7 +119,6 @@
 - [psxjoy](https://github.com/psxjoy)
 - [dsomehan](https://github.com/dsomehan)
 - [LegendPei](https://github.com/LegendPei)
-- [WangzJi](https://github.com/WangzJi)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -119,6 +119,7 @@
 - [psxjoy](https://github.com/psxjoy)
 - [dsomehan](https://github.com/dsomehan)
 - [LegendPei](https://github.com/LegendPei)
+- [WangzJi](https://github.com/WangzJi)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -61,6 +61,7 @@
 - [[#7443](https://github.com/seata/seata/pull/7443)] 将saga注释模式中的@LocalTCC替换为@SagaTransactional
 - [[#7645](https://github.com/seata/seata/pull/7645)] 简化相关的 transport.* 配置项类型
 - [[#7673](https://github.com/apache/incubator-seata/pull/7673)] 升级 @babel/runtime ^7.26.10 到 ^7.27.0
+- [[#7701](https://github.com/apache/incubator-seata/pull/7701)] 简化 Maven source-release 配置
 
 
 ### security:

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,9 @@
         <module>integration-tx-api</module>
         <module>namingserver</module>
         <!--<module>seata-plugin</module>-->
+        <module>distribution</module>
+        <module>test</module>
+        <module>test-old-version</module>
     </modules>
 
     <!--test-->
@@ -289,46 +292,6 @@
         <!-- profile: source-release -->
         <profile>
             <id>source-release</id>
-            <modules>
-                <module>build</module>
-                <module>all</module>
-                <module>bom</module>
-                <module>common</module>
-                <module>config</module>
-                <module>console</module>
-                <module>core</module>
-                <module>compatible</module>
-                <module>dependencies</module>
-                <module>discovery</module>
-                <module>integration/rpc-core</module>
-                <module>integration/dubbo</module>
-                <module>integration/dubbo-alibaba</module>
-                <module>integration/sofa-rpc</module>
-                <module>integration/motan</module>
-                <module>integration/grpc</module>
-                <module>integration/http</module>
-                <module>integration/http-jakarta</module>
-                <module>integration/hsf</module>
-                <module>integration/brpc</module>
-                <module>rm</module>
-                <module>rm-datasource</module>
-                <module>rocketmq</module>
-                <module>spring</module>
-                <module>tcc</module>
-                <module>mock-server</module>
-                <module>tm</module>
-                <module>metrics</module>
-                <module>serializer</module>
-                <module>seata-spring-boot-starter</module>
-                <module>seata-spring-autoconfigure</module>
-                <module>compressor</module>
-                <module>saga</module>
-                <module>sqlparser</module>
-                <module>server</module>
-                <module>ext/apm-seata-skywalking-plugin</module>
-                <module>integration-tx-api</module>
-                <module>namingserver</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -352,22 +315,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>include-test-modules</id>
-            <activation>
-                <file>
-                    <exists>test/pom.xml</exists>
-                </file>
-                <property>
-                    <name>!excludeTestModules</name>
-                </property>
-            </activation>
-            <modules>
-                <module>distribution</module>
-                <module>test</module>
-                <module>test-old-version</module>
-            </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Remove redundant module definitions and optimize profile configuration:

- Remove duplicate modules list from source-release profile
- Remove include-test-modules profile
- Move test modules to main modules list

The source package content is controlled by assembly descriptor's fileSets, not by reactor module definitions, making the removed configuration redundant.

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

