### PR TITLE
optimize: metadata discovery support for zookeeper

### DIFF
--- a/discovery/seata-discovery-zk/src/main/java/org/apache/seata/discovery/registry/zk/ZookeeperRegisterServiceImpl.java
+++ b/discovery/seata-discovery-zk/src/main/java/org/apache/seata/discovery/registry/zk/ZookeeperRegisterServiceImpl.java
@@ -91,6 +91,7 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<CuratorCach
     private static final int REGISTERED_PATH_SET_SIZE = 1;
     private static final Set<String> REGISTERED_PATH_SET =
             Collections.synchronizedSet(new HashSet<>(REGISTERED_PATH_SET_SIZE));
+    private static final ConcurrentMap<String, String> REGISTERED_PATH_DATA_MAP = new ConcurrentHashMap<>();
 
     private String transactionServiceGroup;
 
@@ -113,6 +114,8 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<CuratorCach
         NetUtil.validAddress(address);
 
         String path = getRegisterPathByPath(address);
+        String data = serializeMetadata(instance.getMetadata());
+        REGISTERED_PATH_DATA_MAP.put(path, data);
         doRegister(path);
     }
 
@@ -121,7 +124,8 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<CuratorCach
             return false;
         }
         createParentIfNotPresent(path);
-        createEphemeral(path, Boolean.TRUE.toString());
+        String data = REGISTERED_PATH_DATA_MAP.getOrDefault(path, Boolean.TRUE.toString());
+        createEphemeral(path, data);
         REGISTERED_PATH_SET.add(path);
         return true;
     }
@@ -359,18 +363,70 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<CuratorCach
             CLUSTER_INSTANCE_MAP.put(clusterName, newInstanceList);
             return;
         }
-        for (String path : instances) {
+        String basePath = ROOT_PATH + clusterName + ZK_PATH_SPLIT_CHAR;
+        for (String nodeName : instances) {
             try {
-                String[] ipAndPort = NetUtil.splitIPPortStr(path);
-                newInstanceList.add(
-                        new ServiceInstance(new InetSocketAddress(ipAndPort[0], Integer.parseInt(ipAndPort[1]))));
+                String[] ipAndPort = NetUtil.splitIPPortStr(nodeName);
+                InetSocketAddress address = new InetSocketAddress(ipAndPort[0], Integer.parseInt(ipAndPort[1]));
+                byte[] dataBytes = null;
+                try {
+                    dataBytes = getClientInstance().getData().forPath(basePath + nodeName);
+                } catch (Exception ignored) {
+                }
+                Map<String, String> metadata = parseMetadata(dataBytes);
+                ServiceInstance serviceInstance = metadata == null
+                        ? new ServiceInstance(address)
+                        : ServiceInstance.fromStringMap(address, metadata);
+                newInstanceList.add(serviceInstance);
             } catch (Exception e) {
-                LOGGER.warn("The cluster instance info is error, instance info:{}", path);
+                LOGGER.warn("The cluster instance info is error, instance info:{}", nodeName);
             }
         }
         CLUSTER_INSTANCE_MAP.put(clusterName, newInstanceList);
 
         removeOfflineAddressesIfNecessary(transactionServiceGroup, clusterName, newInstanceList);
+    }
+
+    private String serializeMetadata(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+            String key = entry.getKey() == null ? "" : entry.getKey();
+            String value = entry.getValue() == null ? "" : String.valueOf(entry.getValue());
+            // simple line-based format: key=value\n
+            sb.append(key.replace("\n", " "))
+                    .append("=")
+                    .append(value.replace("\n", " "))
+                    .append("\n");
+        }
+        return sb.toString();
+    }
+
+    private Map<String, String> parseMetadata(byte[] dataBytes) {
+        if (dataBytes == null || dataBytes.length == 0) {
+            return null;
+        }
+        String data = new String(dataBytes, CHARSET);
+        if (StringUtils.isBlank(data)) {
+            return null;
+        }
+        Map<String, String> map = new HashMap<>();
+        String[] lines = data.split("\n");
+        for (String line : lines) {
+            if (StringUtils.isBlank(line)) {
+                continue;
+            }
+            int idx = line.indexOf('=');
+            if (idx <= 0) {
+                continue;
+            }
+            String k = line.substring(0, idx);
+            String v = line.substring(idx + 1);
+            map.put(k, v);
+        }
+        return map.isEmpty() ? null : map;
     }
 
     private String getClusterName() {

--- a/discovery/seata-discovery-zk/src/test/java/org/apache/seata/discovery/registry/zk/ZookeeperRegisterServiceImplTest.java
+++ b/discovery/seata-discovery-zk/src/test/java/org/apache/seata/discovery/registry/zk/ZookeeperRegisterServiceImplTest.java
@@ -79,7 +79,10 @@ public class ZookeeperRegisterServiceImplTest {
 
     @Test
     public void testAll() throws Exception {
-        service.register(new ServiceInstance(new InetSocketAddress(NetUtil.getLocalAddress(), 33333)));
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("zone", "A");
+        meta.put("version", "v1");
+        service.register(new ServiceInstance(new InetSocketAddress(NetUtil.getLocalAddress(), 33333), meta));
 
         Assertions.assertThrows(ConfigNotFoundException.class, new Executable() {
             @Override
@@ -89,6 +92,9 @@ public class ZookeeperRegisterServiceImplTest {
         });
         List<ServiceInstance> lookup2 = service.doLookup("default");
         Assertions.assertEquals(1, lookup2.size());
+        Assertions.assertNotNull(lookup2.get(0).getMetadata());
+        Assertions.assertEquals("A", lookup2.get(0).getMetadata().get("zone"));
+        Assertions.assertEquals("v1", lookup2.get(0).getMetadata().get("version"));
 
         final List<String> data = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Enhance the Zookeeper registry center with metadata registration and discovery capabilities based on branch 'gsoc-2025-meta-registry'.

1. **Register and write metadata:** In `register(ServiceInstance)`, the metadata is serialized into a string and written to the ZK temporary node `data`. The node path remains `.../registry/zk/{cluster}/{ip:port}`.

2. **Lookup/listen and backfill metadata:** In `lookup` and child node change callbacks, `getData()` reads the node `data`, parses it into a `Map<String,String>`, constructs it using `ServiceInstance.fromStringMap(address, metadata)`, and sends the metadata back to the calling side.

3. **Prevent metadata loss during reconnection `recover()`:** A new `REGISTERED_PATH_DATA_MAP` cache is added for `path→data`. When `recover()` rebuilds the temporary node, it uses the cached `data` to write back, ensuring metadata consistency.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
1. **Compatibility:** If getData() fails or the node has no data, it will fall back to the address instance `InetSocketAddress` only.
2. **Serialization:** Uses lightweight line-based key=value\n text, with zero dependencies;
