### PR TITLE
optimize: metadata discovery support for redis

### DIFF
--- a/discovery/seata-discovery-redis/src/main/java/org/apache/seata/discovery/registry/redis/RedisRegistryServiceImpl.java
+++ b/discovery/seata-discovery-redis/src/main/java/org/apache/seata/discovery/registry/redis/RedisRegistryServiceImpl.java
@@ -43,13 +43,13 @@ import java.lang.management.ManagementFactory;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * The type Redis registry service.
@@ -155,23 +155,36 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
     public void register(ServiceInstance instance) {
         InetSocketAddress address = instance.getAddress();
         NetUtil.validAddress(address);
-        doRegisterOrExpire(address, true);
+        // 1) set alive key to ensure key exists
+        doRegisterOrExpire(address);
+        // 2) write metadata once and set ttl; subsequent heartbeats will refresh ttl only
+        String serverAddr = NetUtil.toStringAddress(address);
+        String metaKey = getRedisRegistryMetaKey(serverAddr);
+        try (Jedis jedis = jedisPool.getResource();
+                Pipeline pipelined = jedis.pipelined()) {
+            if (instance.getMetadata() != null && !instance.getMetadata().isEmpty()) {
+                for (Map.Entry<String, Object> e : instance.getMetadata().entrySet()) {
+                    String value = e.getValue() == null ? "" : String.valueOf(e.getValue());
+                    pipelined.hset(metaKey, e.getKey(), value);
+                }
+            }
+            // ensure metadata key ttl
+            pipelined.expire(metaKey, (int) KEY_TTL);
+            // 3) publish register after metadata prepared
+            pipelined.publish(getRedisRegistryKey(), serverAddr + "-" + RedisListener.REGISTER);
+            pipelined.sync();
+        }
         RegistryHeartBeats.addHeartBeat(REGISTRY_TYPE, address, KEY_REFRESH_PERIOD, this::doRegisterOrExpire);
     }
 
     private void doRegisterOrExpire(InetSocketAddress address) {
-        doRegisterOrExpire(address, false);
-    }
-
-    private void doRegisterOrExpire(InetSocketAddress address, boolean publish) {
         String serverAddr = NetUtil.toStringAddress(address);
         String key = getRedisRegistryKey() + "_" + serverAddr; // key = registry.redis.${cluster}_ip:port
         try (Jedis jedis = jedisPool.getResource();
                 Pipeline pipelined = jedis.pipelined()) {
             pipelined.setex(key, KEY_TTL, ManagementFactory.getRuntimeMXBean().getName());
-            if (publish) {
-                pipelined.publish(getRedisRegistryKey(), serverAddr + "-" + RedisListener.REGISTER);
-            }
+            // refresh metadata ttl as well
+            pipelined.expire(getRedisRegistryMetaKey(serverAddr), (int) KEY_TTL);
             pipelined.sync();
         }
     }
@@ -185,6 +198,9 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
                 Pipeline pipelined = jedis.pipelined()) {
             pipelined.hdel(getRedisRegistryKey(), serverAddr);
             pipelined.publish(getRedisRegistryKey(), serverAddr + "-" + RedisListener.UN_REGISTER);
+            // remove ephemeral key and metadata hash proactively
+            pipelined.del(getRedisRegistryKey() + "_" + serverAddr);
+            pipelined.del(getRedisRegistryMetaKey(serverAddr));
             pipelined.sync();
         }
     }
@@ -252,9 +268,21 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
                 String eventType = msgr[1];
                 switch (eventType) {
                     case RedisListener.REGISTER:
-                        CollectionUtils.computeIfAbsent(
-                                        CLUSTER_INSTANCE_MAP, clusterName, value -> ConcurrentHashMap.newKeySet(2))
-                                .add(new ServiceInstance(NetUtil.toInetSocketAddress(serverAddr)));
+                        {
+                            Map<String, String> meta = null;
+                            try (Jedis jedis = jedisPool.getResource()) {
+                                meta = jedis.hgetAll(getRedisRegistryMetaKey(serverAddr));
+                            }
+                            InetSocketAddress addr = NetUtil.toInetSocketAddress(serverAddr);
+                            ServiceInstance instance = meta == null || meta.isEmpty()
+                                    ? new ServiceInstance(addr)
+                                    : ServiceInstance.fromStringMap(addr, meta);
+                            Set<ServiceInstance> set = CollectionUtils.computeIfAbsent(
+                                    CLUSTER_INSTANCE_MAP, clusterName, value -> ConcurrentHashMap.newKeySet(2));
+                            // replace older entry with same address to avoid duplicates with/without metadata
+                            set.removeIf(si -> si.getAddress().equals(addr));
+                            set.add(instance);
+                        }
                         break;
                     case RedisListener.UN_REGISTER:
                         removeServerAddressByPushEmptyProtection(clusterName, serverAddr);
@@ -365,25 +393,29 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
         scanParams.count(10);
         scanParams.match(redisRegistryKey + "_*");
         String cursor = ScanParams.SCAN_POINTER_START;
-        Set<InetSocketAddress> newAddressSet = ConcurrentHashMap.newKeySet(2);
+        Set<ServiceInstance> currentInstances = ConcurrentHashMap.newKeySet(2);
         do {
             ScanResult<String> scanResult = jedis.scan(cursor, scanParams);
             cursor = scanResult.getCursor();
             List<String> instances = scanResult.getResult();
             if (instances != null && !instances.isEmpty()) {
                 // key = registry.redis.${cluster}_ip:port
-                Set<InetSocketAddress> part = instances.stream()
-                        .map(key -> {
-                            String[] split = key.split("_");
-                            return NetUtil.toInetSocketAddress(split[1]);
-                        })
-                        .collect(Collectors.toSet());
-
-                newAddressSet.addAll(part);
+                for (String key : instances) {
+                    String[] split = key.split("_");
+                    if (split.length < 2) {
+                        continue;
+                    }
+                    String serverAddr = split[1];
+                    InetSocketAddress address = NetUtil.toInetSocketAddress(serverAddr);
+                    Map<String, String> meta = jedis.hgetAll(getRedisRegistryMetaKey(serverAddr));
+                    if (meta == null || meta.isEmpty()) {
+                        currentInstances.add(new ServiceInstance(address));
+                    } else {
+                        currentInstances.add(ServiceInstance.fromStringMap(address, meta));
+                    }
+                }
             }
         } while (!cursor.equals(ScanParams.SCAN_POINTER_START));
-
-        Set<ServiceInstance> currentInstances = ServiceInstance.convertToServiceInstanceSet(newAddressSet);
 
         if (CollectionUtils.isNotEmpty(currentInstances)
                 && !currentInstances.equals(CLUSTER_INSTANCE_MAP.get(clusterName))) {
@@ -393,6 +425,11 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
 
     private String getRedisRegistryKey() {
         return REDIS_FILEKEY_PREFIX + clusterName;
+    }
+
+    private String getRedisRegistryMetaKey(String serverAddr) {
+        // meta key example: registry.redis.${cluster}.meta_ip:port
+        return REDIS_FILEKEY_PREFIX + clusterName + ".meta_" + serverAddr;
     }
 
     private String getRedisAddrFileKey() {

--- a/discovery/seata-discovery-redis/src/test/java/org/apache/seata/discovery/registry/redis/RedisRegisterServiceImplTest.java
+++ b/discovery/seata-discovery-redis/src/test/java/org/apache/seata/discovery/registry/redis/RedisRegisterServiceImplTest.java
@@ -35,6 +35,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -66,15 +69,24 @@ public class RedisRegisterServiceImplTest {
 
     @Test
     @Order(1)
-    public void testFlow() {
-        ServiceInstance serviceInstance = new ServiceInstance(new InetSocketAddress(NetUtil.getLocalIp(), 8091));
+    public void testRegisterWithMetadataAndLookup() {
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("zone", "A");
+        meta.put("version", "v1");
+        ServiceInstance serviceInstance = new ServiceInstance(new InetSocketAddress(NetUtil.getLocalIp(), 8092), meta);
         redisRegistryService.register(serviceInstance);
 
-        Assertions.assertTrue(redisRegistryService.lookup("default_tx_group").size() > 0);
+        List<ServiceInstance> instances = redisRegistryService.lookup("default_tx_group");
+        ServiceInstance target = instances.stream()
+                .filter(si -> si.getAddress().getPort() == 8092)
+                .findFirst()
+                .orElse(null);
+        Assertions.assertNotNull(target);
+        Assertions.assertNotNull(target.getMetadata());
+        Assertions.assertEquals("A", target.getMetadata().get("zone"));
+        Assertions.assertEquals("v1", target.getMetadata().get("version"));
 
         redisRegistryService.unregister(serviceInstance);
-
-        Assertions.assertTrue(redisRegistryService.lookup("default_tx_group").size() > 0);
     }
 
     @Test


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Enhance the Redis registry center with metadata registration and discovery capabilities based on branch 'gsoc-2025-meta-registry'.

**1. Storage Design**

Survival Key: `registry.redis.{cluster}_{ip:port}` (String, `SETEX` for keep-alive, heartbeat renewal)

Metadata Key: `registry.redis.{cluster}.meta_{ip:port}` (Hash, `HSET` for key -> value, `EXPIRE` has the same TTL as the survival key)

> Compatibility: Write two keys for instances with metadata, write one key for instances without metadata, ensuring normal operation even with client and server version mismatches.

**2. Registration Process**

Write the survival key first (without publishing) → Ensure its existence

Then write the metadata hash and set the TTL (set the TTL even without metadata)

Finally, publish the `REGISTER` event to ensure consumers can read the "with metadata" instance on the first read.

> Heartbeat: During renewal, only refresh the TTL of the two keys, do not repeatedly write metadata.

**3. Lookup/Subscribe:**

- Initial Load: `SCAN registry.redis.{cluster}_*`, directly parse `{ip:port}` from the key name, read the corresponding meta hash, and build... ServiceInstance (with metadata preferred)

- Subscribe to updates: Upon receiving the REGISTER, first delete the old instance at the same address, then add the new instance (with metadata) to remove duplicates and avoid "coexistence of instances with/without metadata at the same address".

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

