### PR TITLE
bugfix: fix Byte[] type to ensure the correct primary key value.

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -49,6 +49,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7643](https://github.com/apache/incubator-seata/pull/7643)] fix DM transaction rollback not using database auto-increment primary keys
 - [[#7747](https://github.com/apache/incubator-seata/pull/7747)] undo log table name dynamic derivation
 - [[#7749](https://github.com/apache/incubator-seata/pull/7749)] fix error parsing application/x-www-form-urlencoded requests in Http2HttpHandler
+- [[#7761](https://github.com/apache/incubator-seata/pull/7761)] special handling is applied to the Byte[] type to ensure the correct primary key value
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,6 +49,7 @@
 - [[#7643](https://github.com/apache/incubator-seata/pull/7643)] 修复 DM 事务回滚不使用数据库自动增量主键
 - [[#7747](https://github.com/apache/incubator-seata/pull/7747)] 支持undo_log序列名动态推导
 - [[#7749](https://github.com/apache/incubator-seata/pull/7749)] 修复 Http2HttpHandler 解析 application/x-www-form-urlencoded 请求失败的问题
+- [[#7761](https://github.com/apache/incubator-seata/pull/7761)] 对 Byte[] 类型进行了特殊处理，以确保主键值正确
 
 
 ### optimize:

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutor.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutor.java
@@ -18,6 +18,7 @@ package org.apache.seata.rm.datasource.exec;
 
 import org.apache.seata.common.DefaultValues;
 import org.apache.seata.common.exception.ShouldNeverHappenException;
+import org.apache.seata.common.util.ArrayUtils;
 import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.common.util.IOUtil;
 import org.apache.seata.common.util.StringUtils;
@@ -457,7 +458,12 @@ public abstract class BaseTransactionalExecutor<T, S extends Statement> implemen
                 }
                 Object pkVal = rowMap.get(pkName).getValue();
                 validPk(String.valueOf(pkVal));
-                sb.append(pkVal);
+                // Handle byte[] primary keys properly to avoid using memory address as lock key
+                if (pkVal instanceof byte[]) {
+                    sb.append(ArrayUtils.toString(pkVal));
+                } else {
+                    sb.append(pkVal);
+                }
                 pkSplitIndex++;
             }
             rowSequence++;

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutorTest.java
@@ -171,4 +171,104 @@ public class BaseTransactionalExecutorTest {
         when(executor.getTableMeta()).thenReturn(tableMeta);
         assertThat(executor.buildLockKey(tableRecords)).isEqualTo(buildLockKeyExpect);
     }
+
+    @Test
+    public void testBuildLockKeyWithBinaryPrimaryKey() {
+        // Test binary (byte[]) primary key handling
+        String tableName = "test_binary_table";
+        byte[] binaryPkValue1 = new byte[]{1, 2, 3, 15, -1};  // -1 represents 0xFF in signed byte
+        byte[] binaryPkValue2 = new byte[]{10, 20, 30};
+        String pkColumnName = "binary_id";
+        
+        // Expected: test_binary_table:[1, 2, 3, 15, -1],[10, 20, 30]
+        // Using ArrayUtils.toString() format instead of memory address like [B@1b57bff9]
+        // Note: byte is signed in Java, so 0xFF (255) is represented as -1
+        String expectedLockKey = tableName + ":[1, 2, 3, 15, -1],[10, 20, 30]";
+        
+        // Mock fields with byte[] values
+        Field binaryField1 = mock(Field.class);
+        when(binaryField1.getValue()).thenReturn(binaryPkValue1);
+        Field binaryField2 = mock(Field.class);
+        when(binaryField2.getValue()).thenReturn(binaryPkValue2);
+        
+        List<Map<String, Field>> pkRows = new ArrayList<>();
+        pkRows.add(Collections.singletonMap(pkColumnName, binaryField1));
+        pkRows.add(Collections.singletonMap(pkColumnName, binaryField2));
+
+        // Mock tableMeta
+        TableMeta tableMeta = mock(TableMeta.class);
+        when(tableMeta.getTableName()).thenReturn(tableName);
+        when(tableMeta.getPrimaryKeyOnlyName()).thenReturn(Arrays.asList(new String[]{pkColumnName}));
+        
+        // Mock tableRecords
+        TableRecords tableRecords = mock(TableRecords.class);
+        when(tableRecords.getTableMeta()).thenReturn(tableMeta);
+        when(tableRecords.size()).thenReturn(pkRows.size());
+        when(tableRecords.pkRows()).thenReturn(pkRows);
+        
+        // Mock executor
+        BaseTransactionalExecutor executor = mock(BaseTransactionalExecutor.class);
+        when(executor.buildLockKey(tableRecords)).thenCallRealMethod();
+        when(executor.getTableMeta()).thenReturn(tableMeta);
+        
+        String actualLockKey = executor.buildLockKey(tableRecords);
+        
+        // Verify that byte[] is properly converted to readable format
+        assertThat(actualLockKey).isEqualTo(expectedLockKey);
+        // Ensure it's not using memory address format
+        assertThat(actualLockKey).doesNotContain("[B@]");
+        assertThat(actualLockKey).contains("[1, 2, 3, 15, -1]");
+        assertThat(actualLockKey).contains("[10, 20, 30]");
+    }
+
+    @Test 
+    public void testBuildLockKeyWithMixedPrimaryKeys() {
+        // Test mixed primary keys: one regular string and one binary
+        String tableName = "test_mixed_table";
+        String stringPkValue = "user123";
+        byte[] binaryPkValue = new byte[]{16, 32, 48, 64};
+        String stringPkColumnName = "user_id";
+        String binaryPkColumnName = "session_id";
+        
+        // Expected: test_mixed_table:user123_[16, 32, 48, 64]
+        String expectedLockKey = tableName + ":user123_[16, 32, 48, 64]";
+        
+        // Mock fields
+        Field stringField = mock(Field.class);
+        when(stringField.getValue()).thenReturn(stringPkValue);
+        Field binaryField = mock(Field.class);
+        when(binaryField.getValue()).thenReturn(binaryPkValue);
+        
+        List<Map<String, Field>> pkRows = new ArrayList<>();
+        Map<String, Field> row = new HashMap<String, Field>() {{
+            put(stringPkColumnName, stringField);
+            put(binaryPkColumnName, binaryField);
+        }};
+        pkRows.add(row);
+
+        // Mock tableMeta
+        TableMeta tableMeta = mock(TableMeta.class);
+        when(tableMeta.getTableName()).thenReturn(tableName);
+        when(tableMeta.getPrimaryKeyOnlyName())
+                .thenReturn(Arrays.asList(new String[]{stringPkColumnName, binaryPkColumnName}));
+        
+        // Mock tableRecords
+        TableRecords tableRecords = mock(TableRecords.class);
+        when(tableRecords.getTableMeta()).thenReturn(tableMeta);
+        when(tableRecords.size()).thenReturn(pkRows.size());
+        when(tableRecords.pkRows()).thenReturn(pkRows);
+        
+        // Mock executor
+        BaseTransactionalExecutor executor = mock(BaseTransactionalExecutor.class);
+        when(executor.buildLockKey(tableRecords)).thenCallRealMethod();
+        when(executor.getTableMeta()).thenReturn(tableMeta);
+        
+        String actualLockKey = executor.buildLockKey(tableRecords);
+        
+        // Verify mixed types are handled correctly
+        assertThat(actualLockKey).isEqualTo(expectedLockKey);
+        assertThat(actualLockKey).doesNotContain("[B@]");
+        assertThat(actualLockKey).contains("user123");
+        assertThat(actualLockKey).contains("[16, 32, 48, 64]");
+    }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutorTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutorTest.java
@@ -176,21 +176,21 @@ public class BaseTransactionalExecutorTest {
     public void testBuildLockKeyWithBinaryPrimaryKey() {
         // Test binary (byte[]) primary key handling
         String tableName = "test_binary_table";
-        byte[] binaryPkValue1 = new byte[]{1, 2, 3, 15, -1};  // -1 represents 0xFF in signed byte
-        byte[] binaryPkValue2 = new byte[]{10, 20, 30};
+        byte[] binaryPkValue1 = new byte[] {1, 2, 3, 15, -1}; // -1 represents 0xFF in signed byte
+        byte[] binaryPkValue2 = new byte[] {10, 20, 30};
         String pkColumnName = "binary_id";
-        
+
         // Expected: test_binary_table:[1, 2, 3, 15, -1],[10, 20, 30]
         // Using ArrayUtils.toString() format instead of memory address like [B@1b57bff9]
         // Note: byte is signed in Java, so 0xFF (255) is represented as -1
         String expectedLockKey = tableName + ":[1, 2, 3, 15, -1],[10, 20, 30]";
-        
+
         // Mock fields with byte[] values
         Field binaryField1 = mock(Field.class);
         when(binaryField1.getValue()).thenReturn(binaryPkValue1);
         Field binaryField2 = mock(Field.class);
         when(binaryField2.getValue()).thenReturn(binaryPkValue2);
-        
+
         List<Map<String, Field>> pkRows = new ArrayList<>();
         pkRows.add(Collections.singletonMap(pkColumnName, binaryField1));
         pkRows.add(Collections.singletonMap(pkColumnName, binaryField2));
@@ -198,21 +198,21 @@ public class BaseTransactionalExecutorTest {
         // Mock tableMeta
         TableMeta tableMeta = mock(TableMeta.class);
         when(tableMeta.getTableName()).thenReturn(tableName);
-        when(tableMeta.getPrimaryKeyOnlyName()).thenReturn(Arrays.asList(new String[]{pkColumnName}));
-        
+        when(tableMeta.getPrimaryKeyOnlyName()).thenReturn(Arrays.asList(new String[] {pkColumnName}));
+
         // Mock tableRecords
         TableRecords tableRecords = mock(TableRecords.class);
         when(tableRecords.getTableMeta()).thenReturn(tableMeta);
         when(tableRecords.size()).thenReturn(pkRows.size());
         when(tableRecords.pkRows()).thenReturn(pkRows);
-        
+
         // Mock executor
         BaseTransactionalExecutor executor = mock(BaseTransactionalExecutor.class);
         when(executor.buildLockKey(tableRecords)).thenCallRealMethod();
         when(executor.getTableMeta()).thenReturn(tableMeta);
-        
+
         String actualLockKey = executor.buildLockKey(tableRecords);
-        
+
         // Verify that byte[] is properly converted to readable format
         assertThat(actualLockKey).isEqualTo(expectedLockKey);
         // Ensure it's not using memory address format
@@ -221,50 +221,52 @@ public class BaseTransactionalExecutorTest {
         assertThat(actualLockKey).contains("[10, 20, 30]");
     }
 
-    @Test 
+    @Test
     public void testBuildLockKeyWithMixedPrimaryKeys() {
         // Test mixed primary keys: one regular string and one binary
         String tableName = "test_mixed_table";
         String stringPkValue = "user123";
-        byte[] binaryPkValue = new byte[]{16, 32, 48, 64};
+        byte[] binaryPkValue = new byte[] {16, 32, 48, 64};
         String stringPkColumnName = "user_id";
         String binaryPkColumnName = "session_id";
-        
+
         // Expected: test_mixed_table:user123_[16, 32, 48, 64]
         String expectedLockKey = tableName + ":user123_[16, 32, 48, 64]";
-        
+
         // Mock fields
         Field stringField = mock(Field.class);
         when(stringField.getValue()).thenReturn(stringPkValue);
         Field binaryField = mock(Field.class);
         when(binaryField.getValue()).thenReturn(binaryPkValue);
-        
+
         List<Map<String, Field>> pkRows = new ArrayList<>();
-        Map<String, Field> row = new HashMap<String, Field>() {{
-            put(stringPkColumnName, stringField);
-            put(binaryPkColumnName, binaryField);
-        }};
+        Map<String, Field> row = new HashMap<String, Field>() {
+            {
+                put(stringPkColumnName, stringField);
+                put(binaryPkColumnName, binaryField);
+            }
+        };
         pkRows.add(row);
 
         // Mock tableMeta
         TableMeta tableMeta = mock(TableMeta.class);
         when(tableMeta.getTableName()).thenReturn(tableName);
         when(tableMeta.getPrimaryKeyOnlyName())
-                .thenReturn(Arrays.asList(new String[]{stringPkColumnName, binaryPkColumnName}));
-        
+                .thenReturn(Arrays.asList(new String[] {stringPkColumnName, binaryPkColumnName}));
+
         // Mock tableRecords
         TableRecords tableRecords = mock(TableRecords.class);
         when(tableRecords.getTableMeta()).thenReturn(tableMeta);
         when(tableRecords.size()).thenReturn(pkRows.size());
         when(tableRecords.pkRows()).thenReturn(pkRows);
-        
+
         // Mock executor
         BaseTransactionalExecutor executor = mock(BaseTransactionalExecutor.class);
         when(executor.buildLockKey(tableRecords)).thenCallRealMethod();
         when(executor.getTableMeta()).thenReturn(tableMeta);
-        
+
         String actualLockKey = executor.buildLockKey(tableRecords);
-        
+
         // Verify mixed types are handled correctly
         assertThat(actualLockKey).isEqualTo(expectedLockKey);
         assertThat(actualLockKey).doesNotContain("[B@]");


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
When the primary key is of type `BINARY(16)`, `pkVal` is actually a `byte[]` array.

- For a `byte[]` array, `StringBuilder.append(Object obj)` calls `obj.toString()`.

- The default `toString()` method of `byte[]` returns a string representing the memory address of the Java object.

- This address string is stored in the `pk` field of the global lock table `lock_table`.

The problem lies in the undo_log serialization logic: it correctly serializes the contents of the `byte[]` array, not the memory address.

My solution: Based on the  `buildLockKey`, I performed special processing on the `byte[]` type. Calling `ArrayUtils.toString(pkVal)` returns the actual content instead of the memory address.

In addition, I added corresponding unit tests to verify the correctness of the modification.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7738 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
mvn clean test

### Ⅴ. Special notes for reviews

