### PR TITLE
test: add UT for RegistryNamingServerProperties and RegistryMetadataProperties

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -101,6 +101,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7731](https://github.com/apache/incubator-seata/pull/7731)] add UT for rm.fence
 - [[#7737](https://github.com/apache/incubator-seata/pull/7737)] add UT for DefaultResourceManager and ClusterWatcherManager
 - [[#7757](https://github.com/apache/incubator-seata/pull/7757)] add UT for undo module
+- [[#7763](https://github.com/apache/incubator-seata/pull/7763)] add UT for RegistryNamingServerProperties and RegistryMetadataProperties
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -100,6 +100,7 @@
 - [[#7731](https://github.com/apache/incubator-seata/pull/7731)] 为rm.fence模块添加单测
 - [[#7737](https://github.com/apache/incubator-seata/pull/7737)] 为 DefaultResourceManager 和 ClusterWatcherManager 添加测试方法
 - [[#7757](https://github.com/apache/incubator-seata/pull/7757)] 为 undo 模块添加单测
+- [[#7763](https://github.com/apache/incubator-seata/pull/7763)] 为 RegistryNamingServerProperties 和 RegistryMetadataProperties 添加单测
 
 ### refactor:
 

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryMetadataPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryMetadataPropertiesTest.java
@@ -2,7 +2,6 @@ package org.apache.seata.spring.boot.autoconfigure.properties.registry;
 
 import org.junit.jupiter.api.Test;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryMetadataPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryMetadataPropertiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.seata.spring.boot.autoconfigure.properties.registry;
 
 import org.junit.jupiter.api.Test;

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryMetadataPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryMetadataPropertiesTest.java
@@ -1,0 +1,21 @@
+package org.apache.seata.spring.boot.autoconfigure.properties.registry;
+
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RegistryMetadataPropertiesTest {
+
+    @Test
+    void testRegistryMetadataProperties() {
+        RegistryMetadataProperties metadataProperties = new RegistryMetadataProperties();
+
+        metadataProperties.setExternal("external-metadata");
+        assertEquals("external-metadata", metadataProperties.getExternal());
+
+        metadataProperties.setExternal(null);
+        assertNull(metadataProperties.getExternal());
+    }
+}

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryNamingServerPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryNamingServerPropertiesTest.java
@@ -1,0 +1,29 @@
+package org.apache.seata.spring.boot.autoconfigure.properties.registry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RegistryNamingServerPropertiesTest {
+
+    @Test
+    public void testRegistryNamingServerProperties() {
+        RegistryNamingServerProperties namingServerProperties = new RegistryNamingServerProperties();
+        namingServerProperties.setCluster("cluster");
+        namingServerProperties.setServerAddr("addr");
+        namingServerProperties.setNamespace("namespace");
+        namingServerProperties.setHeartbeatPeriod(1);
+        namingServerProperties.setMetadataMaxAgeMs(1L);
+        namingServerProperties.setUsername("username");
+        namingServerProperties.setPassword("password");
+        namingServerProperties.setTokenValidityInMilliseconds(1L);
+
+        Assertions.assertEquals("cluster", namingServerProperties.getCluster());
+        Assertions.assertEquals("addr", namingServerProperties.getServerAddr());
+        Assertions.assertEquals("namespace", namingServerProperties.getNamespace());
+        Assertions.assertEquals(1, namingServerProperties.getHeartbeatPeriod());
+        Assertions.assertEquals(1L, namingServerProperties.getMetadataMaxAgeMs());
+        Assertions.assertEquals("username", namingServerProperties.getUsername());
+        Assertions.assertEquals("password", namingServerProperties.getPassword());
+        Assertions.assertEquals(1L, namingServerProperties.getTokenValidityInMilliseconds());
+    }
+}

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryNamingServerPropertiesTest.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryNamingServerPropertiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.seata.spring.boot.autoconfigure.properties.registry;
 
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
test: add UT for RegistryNamingServerProperties and RegistryMetadataProperties in seata-spring-autoconfigure-core 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

