### PR TITLE
test: fix `ClusterWatcherManagerTest`

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -51,6 +51,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7749](https://github.com/apache/incubator-seata/pull/7749)] fix error parsing application/x-www-form-urlencoded requests in Http2HttpHandler
 - [[#7761](https://github.com/apache/incubator-seata/pull/7761)] special handling is applied to the Byte[] type to ensure the correct primary key value
 - [[#7771](https://github.com/apache/incubator-seata/pull/7771)] Shentongdata xa mode should be hold the same connection
+- [[#7785](https://github.com/apache/incubator-seata/pull/7785)] fix the failure test
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -51,6 +51,7 @@
 - [[#7749](https://github.com/apache/incubator-seata/pull/7749)] 修复 Http2HttpHandler 解析 application/x-www-form-urlencoded 请求失败的问题
 - [[#7761](https://github.com/apache/incubator-seata/pull/7761)] 对 Byte[] 类型进行了特殊处理，以确保主键值正确
 - [[#7771](https://github.com/apache/incubator-seata/pull/7771)] 确保神通XA模式相同的事务使用相同的XAConnection
+- [[#7785](https://github.com/apache/incubator-seata/pull/7785)] 修复失败的测试方法
 
 
 ### optimize:

--- a/namingserver/src/test/java/org/apache/seata/namingserver/ClusterWatcherManagerTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/ClusterWatcherManagerTest.java
@@ -223,9 +223,9 @@ public class ClusterWatcherManagerTest {
 
     @Test
     void testScheduledTaskReRegisterNonTimeoutWatcher() throws InterruptedException {
-        long timeout = System.currentTimeMillis() + 3000;
+        int timeoutDuration = 3000;
         Watcher<AsyncContext> watcher =
-                new Watcher<>(TEST_GROUP, asyncContext, (int) timeout, TEST_TERM, TEST_CLIENT_ENDPOINT);
+                new Watcher<>(TEST_GROUP, asyncContext, timeoutDuration, TEST_TERM, TEST_CLIENT_ENDPOINT);
         clusterWatcherManager.registryWatcher(watcher);
 
         clusterWatcherManager.init();


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
fix the `testScheduledTaskReRegisterNonTimeoutWatcher()` in `ClusterWatcherManagerTest`

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
Fix https://github.com/apache/incubator-seata/issues/7784

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

