### PR TITLE
test: fix the NPE on ConsulConfigurationTest method

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -52,6 +52,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7761](https://github.com/apache/incubator-seata/pull/7761)] special handling is applied to the Byte[] type to ensure the correct primary key value
 - [[#7771](https://github.com/apache/incubator-seata/pull/7771)] Shentongdata xa mode should be hold the same connection
 - [[#7785](https://github.com/apache/incubator-seata/pull/7785)] fix the failure test
+- [[#7796](https://github.com/apache/incubator-seata/pull/7796)] fix the NPE on ConsulConfigurationTest method
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -52,6 +52,7 @@
 - [[#7761](https://github.com/apache/incubator-seata/pull/7761)] 对 Byte[] 类型进行了特殊处理，以确保主键值正确
 - [[#7771](https://github.com/apache/incubator-seata/pull/7771)] 确保神通XA模式相同的事务使用相同的XAConnection
 - [[#7785](https://github.com/apache/incubator-seata/pull/7785)] 修复失败的测试方法
+- [[#7796](https://github.com/apache/incubator-seata/pull/7796)] 修复 Consul 监听器空值 NPE 问题
 
 
 ### optimize:

--- a/config/seata-config-consul/src/test/java/org/apache/seata/config/consul/ConsulConfigurationTest.java
+++ b/config/seata-config-consul/src/test/java/org/apache/seata/config/consul/ConsulConfigurationTest.java
@@ -135,26 +135,36 @@ class ConsulConfigurationTest {
 
     @Test
     void testOnChangeEvent_skipWhenValueIsBlank() throws InterruptedException {
-
         String dataId = "seata.properties";
-        ConsulConfiguration.ConsulListener listener = new ConsulConfiguration.ConsulListener(dataId, null);
 
+        // Mock the initial call in ConsulListener constructor (2-arg version)
+        GetValue initValue = mock(GetValue.class);
+        when(initValue.getDecodedValue()).thenReturn("dummy");
+        Response<GetValue> initResponse = new Response<>(initValue, 1L, false, 1L);
+        when(mockConsulClient.getKVValue(eq(dataId), (String) isNull())).thenReturn(initResponse);
+
+        // Mock the watch call in onChangeEvent loop (3-arg version)
         GetValue blankValue = mock(GetValue.class);
         when(blankValue.getDecodedValue()).thenReturn("");
-
         Response<GetValue> blankResponse = new Response<>(blankValue, 2L, false, 2L);
-        when(mockConsulClient.getKVValue(eq(dataId), isNull(), any(QueryParams.class)))
+        when(mockConsulClient.getKVValue(eq(dataId), (String) isNull(), any(QueryParams.class)))
                 .thenReturn(blankResponse);
 
+        ConsulConfiguration.ConsulListener listener = new ConsulConfiguration.ConsulListener(dataId, null);
+
         // Run onChangeEvent in a separate thread since it loops indefinitely
-        Thread thread = new Thread(() -> listener.onChangeEvent(new ConfigurationChangeEvent()));
+        Thread thread = new Thread(() -> {
+            try {
+                listener.onChangeEvent(new ConfigurationChangeEvent());
+            } catch (Exception e) {
+                // ignore
+            }
+        });
         thread.start();
         Thread.sleep(100);
-        // Interrupt to break the loop
         thread.interrupt();
         thread.join(500);
 
-        // Assert: Test passes as long as no exceptions are thrown
         assertTrue(true);
     }
 


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
fix the NPE on `ConsulConfigurationTest ` `testOnChangeEvent_skipWhenValueIsBlank` method

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/apache/incubator-seata/issues/7795

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

