### PR TITLE
test: Fix non-deterministic in StringUtilsTest#testToStringAndCycleDependency

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -119,7 +119,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7727](https://github.com/apache/incubator-seata/pull/7727)] add some UT for compatible module
 - [[#7803](https://github.com/apache/incubator-seata/pull/7803)] Fix flakiness in `DataCompareUtilsTest` caused by non-deterministic Map key iteration order.
 - [[#7804](https://github.com/apache/incubator-seata/pull/7804)] fix testXARollbackWithResourceLock() to ensure ci runs normally
-
+- [[#7800](https://github.com/apache/incubator-seata/pull/7800)] fix non-deterministic in StringUtilsTest#testToStringAndCycleDependency
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -118,7 +118,7 @@
 - [[#7727](https://github.com/apache/incubator-seata/pull/7727)] 为 compatible 模块添加单测
 - [[#7803](https://github.com/apache/incubator-seata/pull/7803)] 修复 `DataCompareUtilsTest` 中因键迭代顺序不稳定导致的测试用例间歇性失败问题。
 - [[#7804](https://github.com/apache/incubator-seata/pull/7804)] 修复 testXARollbackWithResourceLock() 以确保 CI 正常运行
-
+- [[#7800](https://github.com/apache/incubator-seata/pull/7800)] 修复 `StringUtilsTest.testToStringAndCycleDependency` 因反射字段顺序不稳定导致的测试用例间歇性失败问题
 
 ### refactor:
 

--- a/common/src/test/java/org/apache/seata/common/util/StringUtilsTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/StringUtilsTest.java
@@ -282,29 +282,50 @@ public class StringUtilsTest {
         Assertions.assertFalse(CycleDependencyHandler.isStarting());
 
         // case: Object
-        Assertions.assertEquals("CycleDependency(s=\"a\", obj=null)", StringUtils.toString(CycleDependency.A));
+        String resultCycleDependencyA = StringUtils.toString(CycleDependency.A);
+        Assertions.assertTrue(resultCycleDependencyA.startsWith("CycleDependency("));
+        Assertions.assertTrue(resultCycleDependencyA.endsWith(")"));
+        Assertions.assertTrue(resultCycleDependencyA.contains("s=\"a\""));
+        Assertions.assertTrue(resultCycleDependencyA.contains("obj=null"));
         // case: Object, and cycle dependency
         CycleDependency obj = new CycleDependency("c");
         obj.setObj(obj);
-        Assertions.assertEquals("CycleDependency(s=\"c\", obj=(this CycleDependency))", StringUtils.toString(obj));
+        String resultCycleDependencyObj = StringUtils.toString(obj);
+        Assertions.assertTrue(resultCycleDependencyObj.startsWith("CycleDependency("));
+        Assertions.assertTrue(resultCycleDependencyObj.endsWith(")"));
+        Assertions.assertTrue(resultCycleDependencyObj.contains("s=\"c\""));
+        Assertions.assertTrue(resultCycleDependencyObj.contains("obj=(this CycleDependency)"));
         // case: Object
         CycleDependency obj2 = new CycleDependency("d");
         obj.setObj(obj2);
-        Assertions.assertEquals(
-                "CycleDependency(s=\"c\", obj=CycleDependency(s=\"d\", obj=null))", StringUtils.toString(obj));
+        String actualCD = StringUtils.toString(obj);
+        String expectedCanonicalCD = "CycleDependency(s=\"c\", obj=CycleDependency(s=\"d\", obj=null))";
+        String expectedAlternateCD = "CycleDependency(obj=CycleDependency(obj=null, s=\"d\"), s=\"c\")";
+        Assertions.assertTrue(
+                expectedCanonicalCD.equals(actualCD) || expectedAlternateCD.equals(actualCD),
+                "Unexpected String representation for nested CycleDependency. Actual: " + actualCD);
         // case: Object, and cycle dependency
         TestClass a = new TestClass();
         a.setObj(a);
-        Assertions.assertEquals("TestClass(obj=(this TestClass), s=null)", StringUtils.toString(a));
+        String resultA = StringUtils.toString(a); // check for the presence of field-value pairs regardless of order
+        Assertions.assertTrue(resultA.startsWith("TestClass("));
+        Assertions.assertTrue(resultA.endsWith(")"));
+        Assertions.assertTrue(resultA.contains("obj=(this TestClass)"));
+        Assertions.assertTrue(resultA.contains("s=null"));
         // case: Object, and cycle dependency（deep case）
         TestClass b = new TestClass();
         TestClass c = new TestClass();
         b.setObj(c);
         c.setObj(a);
         a.setObj(b);
-        Assertions.assertEquals(
-                "TestClass(obj=TestClass(obj=TestClass(obj=(ref TestClass), s=null), s=null), s=null)",
-                StringUtils.toString(a));
+        String actual = StringUtils.toString(a);
+        String expectedCanonical =
+                "TestClass(obj=TestClass(obj=TestClass(obj=(ref TestClass), s=null), s=null), s=null)";
+        String expectedAlternate =
+                "TestClass(s=null, obj=TestClass(s=null, obj=TestClass(s=null, obj=(ref TestClass))))";
+        Assertions.assertTrue(
+                expectedCanonical.equals(actual) || expectedAlternate.equals(actual),
+                "Unexpected String representation for deep cycle dependency. Actual: " + actual);
 
         // case: anonymous class from an interface
         Object anonymousObj = new TestInterface() {


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR fixes flakiness in the `testToStringAndCycleDependency` unit test within `StringUtilsTest`.

The flakiness was caused by **non-deterministic field ordering** returned by **Java Reflection** when the `StringUtils.toString()` method processes `CycleDependency` and `TestClass` objects. This led to `AssertionFailedError` because the hardcoded expected string did not match the actual string when fields were returned in an alternate order (e.g., `obj` then `s` instead of `s` then `obj`, or vice-versa).

**No production code changes were made; this is a test-only change to improve CI stability.**

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
This PR specifically addresses the flakiness of an existing unit test (`testToStringAndCycleDependency`) by making its assertions order-independent. 

### Ⅳ. Describe how to verify it
To confirm the flakiness is resolved, run the affected test repeatedly using a non-deterministic test runner such as [nondex](https://github.com/TestingResearchIllinois/NonDex). Successful runs across multiple attempts verify the fix:
```bash
mvn -pl common \
    -am edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.seata.common.util.StringUtilsTest#testToStringAndCycleDependency \
    -DnondexRuns=10 \
    -DfailIfNoTests=false
```

### Ⅴ. Special notes for reviews
- No production code touched, and only modified one unit test case.