### PR TITLE
test: Fix non-deterministic in ConnectionContextProxyTest

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -119,6 +119,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7727](https://github.com/apache/incubator-seata/pull/7727)] add some UT for compatible module
 - [[#7803](https://github.com/apache/incubator-seata/pull/7803)] Fix flakiness in `DataCompareUtilsTest` caused by non-deterministic Map key iteration order.
 - [[#7804](https://github.com/apache/incubator-seata/pull/7804)] fix testXARollbackWithResourceLock() to ensure ci runs normally
+- [[#7802](https://github.com/apache/incubator-seata/pull/7802)] Fix non-deterministic in `ConnectionContextProxyTest`.
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -118,6 +118,7 @@
 - [[#7727](https://github.com/apache/incubator-seata/pull/7727)] 为 compatible 模块添加单测
 - [[#7803](https://github.com/apache/incubator-seata/pull/7803)] 修复 `DataCompareUtilsTest` 中因键迭代顺序不稳定导致的测试用例间歇性失败问题。
 - [[#7804](https://github.com/apache/incubator-seata/pull/7804)] 修复 testXARollbackWithResourceLock() 以确保 CI 正常运行
+- [[#7802](https://github.com/apache/incubator-seata/pull/7802)] 修复 `ConnectionContextProxyTest` 中锁键顺序不稳定导致的测试用例间歇性失败问题。
 
 
 ### refactor:

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/ConnectionContextProxyTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/ConnectionContextProxyTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Savepoint;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -34,13 +35,32 @@ import java.util.List;
 public class ConnectionContextProxyTest {
     ConnectionContext connectionContext = new ConnectionContext();
 
+    private static void assertLockKeysEqual(String expected, String actual) {
+        if (actual == null && expected == null) {
+            return;
+        }
+
+        Assertions.assertNotNull(actual, "Actual lock keys should not be null.");
+        Assertions.assertNotNull(expected, "Expected lock keys should not be null.");
+
+        // Split, sort, and compare the key arrays
+        String[] actualKeys = actual.split(";");
+        String[] expectedKeys = expected.split(";");
+
+        Arrays.sort(actualKeys);
+        Arrays.sort(expectedKeys);
+
+        Assertions.assertArrayEquals(expectedKeys, actualKeys, "The sorted arrays of lock keys should be equal.");
+    }
+
     @Test
     public void testBuildLockKeys() throws Exception {
         connectionContext.appendLockKey("abc");
         connectionContext.appendLockKey("bcd");
 
         Assertions.assertTrue(connectionContext.hasLockKey());
-        Assertions.assertEquals(connectionContext.buildLockKeys(), "bcd;abc");
+
+        assertLockKeysEqual("abc;bcd", connectionContext.buildLockKeys());
     }
 
     @Test
@@ -104,15 +124,18 @@ public class ConnectionContextProxyTest {
         connectionContext.appendUndoItem(new SQLUndoLog());
 
         Assertions.assertEquals(connectionContext.getUndoItems().size(), 2);
-        Assertions.assertEquals(connectionContext.buildLockKeys(), "sp3-lock-key;sp1-lock-key");
+
+        assertLockKeysEqual(connectionContext.buildLockKeys(), "sp1-lock-key;sp3-lock-key");
 
         connectionContext.removeSavepoint(sp3);
-        Assertions.assertEquals(connectionContext.getUndoItems().size(), 1);
-        Assertions.assertEquals(connectionContext.buildLockKeys(), "sp1-lock-key");
+        Assertions.assertEquals(1, connectionContext.getUndoItems().size());
+
+        assertLockKeysEqual(connectionContext.buildLockKeys(), "sp1-lock-key");
 
         connectionContext.removeSavepoint(null);
-        Assertions.assertEquals(connectionContext.getUndoItems().size(), 0);
-        Assertions.assertNull(connectionContext.buildLockKeys());
+        Assertions.assertEquals(0, connectionContext.getUndoItems().size());
+
+        assertLockKeysEqual(connectionContext.buildLockKeys(), null);
     }
 
     @Test
@@ -130,16 +153,21 @@ public class ConnectionContextProxyTest {
         connectionContext.appendLockKey("sp3-lock-key");
         connectionContext.appendUndoItem(new SQLUndoLog());
 
-        Assertions.assertEquals(connectionContext.getUndoItems().size(), 2);
-        Assertions.assertEquals(connectionContext.buildLockKeys(), "sp3-lock-key;sp1-lock-key");
+        Assertions.assertEquals(2, connectionContext.getUndoItems().size());
+
+        String expectedLockKeys = "sp1-lock-key;sp3-lock-key";
+
+        assertLockKeysEqual(connectionContext.buildLockKeys(), expectedLockKeys);
 
         connectionContext.releaseSavepoint(sp3);
-        Assertions.assertEquals(connectionContext.getUndoItems().size(), 2);
-        Assertions.assertEquals(connectionContext.buildLockKeys(), "sp3-lock-key;sp1-lock-key");
+        Assertions.assertEquals(2, connectionContext.getUndoItems().size());
+
+        assertLockKeysEqual(connectionContext.buildLockKeys(), expectedLockKeys);
 
         connectionContext.releaseSavepoint(null);
-        Assertions.assertEquals(connectionContext.getUndoItems().size(), 2);
-        Assertions.assertEquals(connectionContext.buildLockKeys(), "sp3-lock-key;sp1-lock-key");
+        Assertions.assertEquals(2, connectionContext.getUndoItems().size());
+
+        assertLockKeysEqual(connectionContext.buildLockKeys(), expectedLockKeys);
     }
 
     @AfterEach


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR comprehensively fixes flakiness issues in three unit tests of `ConnectionContextProxyTest.java` within the `rm-datasource` module.

The tests (`testBuildLockKeys`, `testRemoveSavepoint`, and `testReleaseSavepoint`) were failing intermittently because they relied on strict string comparison of the lock key list returned by `ConnectionContext.buildLockKeys()`. The method's underlying collection does not guarantee iteration order, resulting in non-deterministic key concatenation (e.g., "key1;key2" vs. "key2;key1").

The fix implements a robust, order-independent assertion across all affected methods by:
1.  Splitting the actual and expected lock key strings by the semicolon delimiter.
2.  Sorting the resulting list of keys (canonicalization).
3.  Asserting the equality of the sorted lists, thus validating the content regardless of key concatenation order.

**No production code changes were made; this is a test-only change to improve CI stability.**

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
This PR specifically addresses the flakiness of existing unit tests in a single file.

### Ⅳ. Describe how to verify it
To confirm the flakiness is resolved, run the affected test repeatedly using a non-deterministic test runner such as [nondex](https://github.com/TestingResearchIllinois/NonDex). Successful runs across multiple attempts verify the fix:
```bash
mvn -pl rm-datasource \
    -am edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.seata.rm.datasource.ConnectionContextProxyTest#testBuildLockKeys \
    -DnondexRuns=10 \
    -DfailIfNoTests=false
```

### Ⅴ. Special notes for reviews
- Test-only change in `rm-datasource` module (ConnectionContextProxyTest.java).
- No production code modified.
