### PR TITLE
test: fix testXARollbackWithResourceLock() to ensure ci runs normally

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -115,6 +115,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7733](https://github.com/apache/incubator-seata/pull/7733)] add some UT for core module
 - [[#7728](https://github.com/apache/incubator-seata/pull/7728)] add some UT for compatible module
 - [[#7727](https://github.com/apache/incubator-seata/pull/7727)] add some UT for compatible module
+- [[#7804](https://github.com/apache/incubator-seata/pull/7804)] fix testXARollbackWithResourceLock() to ensure ci runs normally
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -114,6 +114,7 @@
 - [[#7733](https://github.com/apache/incubator-seata/pull/7733)] 为 core 模块添加单测
 - [[#7728](https://github.com/apache/incubator-seata/pull/7728)] 为 compatible 模块添加单测
 - [[#7727](https://github.com/apache/incubator-seata/pull/7727)] 为 compatible 模块添加单测
+- [[#7804](https://github.com/apache/incubator-seata/pull/7804)] 修复 testXARollbackWithResourceLock() 以确保 CI 正常运行
 
 
 ### refactor:

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXATest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXATest.java
@@ -635,8 +635,7 @@ public class ConnectionProxyXATest {
                 new ConnectionProxyXA(mockConnection, mockXAConnection, mockDataSourceResource, xid);
         connectionProxyXA.init();
         // Set up mock for branch registration to enable XA transaction
-        when(mockResourceManager.branchRegister(
-                eq(BranchType.XA), anyString(), eq(null), eq(xid), eq(null), eq(null)))
+        when(mockResourceManager.branchRegister(eq(BranchType.XA), anyString(), eq(null), eq(xid), eq(null), eq(null)))
                 .thenReturn(branchId);
 
         // Start XA transaction by setting autoCommit to false

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXATest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/ConnectionProxyXATest.java
@@ -634,7 +634,13 @@ public class ConnectionProxyXATest {
         ConnectionProxyXA connectionProxyXA =
                 new ConnectionProxyXA(mockConnection, mockXAConnection, mockDataSourceResource, xid);
         connectionProxyXA.init();
+        // Set up mock for branch registration to enable XA transaction
+        when(mockResourceManager.branchRegister(
+                eq(BranchType.XA), anyString(), eq(null), eq(xid), eq(null), eq(null)))
+                .thenReturn(branchId);
 
+        // Start XA transaction by setting autoCommit to false
+        connectionProxyXA.setAutoCommit(false);
         // Should not throw exception
         Assertions.assertDoesNotThrow(
                 () -> connectionProxyXA.xaRollback(xid, branchId, null), "xaRollback should not throw exception");


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Addressing the CI issue caused by testXARollbackWithResourceLock()

The root cause was a change made in #7708 , but the test pull request wasn't synchronized to the last branch, leading to the problem.

https://github.com/apache/incubator-seata/actions/runs/19563643682/job/56021142515?pr=7781

This has now been fixed.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
mvn clean test

### Ⅴ. Special notes for reviews

