### PR TITLE
feature: Support HTTP/2 response handling for the Watch API in Server Raft mode

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -29,6 +29,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7664](https://github.com/apache/incubator-seata/pull/7664)] support shentongdatabase XA mode
 - [[#7675](https://github.com/apache/incubator-seata/pull/7675)] support Oracle Batch Insert
 - [[#7663](https://github.com/apache/incubator-seata/pull/7663)] add Java 25 support in CI configuration files
+- [[#7826](https://github.com/apache/incubator-seata/pull/7826)] Support HTTP/2 response handling for the Watch API in Server Raft mode
 
 
 ### bugfix:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -29,6 +29,7 @@
 - [[#7664](https://github.com/apache/incubator-seata/pull/7565)] 支持神通数据库的XA模式
 - [[#7675](https://github.com/apache/incubator-seata/pull/7675)] 支持Oracle批量插入
 - [[#7663](https://github.com/apache/incubator-seata/pull/7663)] 支持java25版本的CI流水綫
+- [[#7826](https://github.com/apache/incubator-seata/pull/7826)] 在 Server Raft 模式下，为 Watch API 提供对 HTTP/2 响应处理的支持
 
 
 ### bugfix:

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -301,7 +301,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -136,17 +136,17 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             ctx.write(new DefaultHttp2HeadersFrame(headers));
 
             // Send empty data frame with endStream=true to close the stream
-            ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true)).addListener(f -> {
-                if (!f.isSuccess() && logger.isWarnEnabled()) {
-                    logger.warn(
-                            "Failed to send HTTP/2 response for watcher on group {}: {}",
-                            watcher.getGroup(),
-                            f.cause() != null ? f.cause().getMessage() : "unknown error",
-                            f.cause());
-                }
-            });
+            ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true))
+                    .addListener(f -> {
+                        if (!f.isSuccess() && logger.isWarnEnabled()) {
+                            logger.warn(
+                                    "Failed to send HTTP/2 response for watcher on group {}: {}",
+                                    watcher.getGroup(),
+                                    f.cause() != null ? f.cause().getMessage() : "unknown error",
+                                    f.cause());
+                        }
+                    });
         }
-
     }
 
     public void registryWatcher(Watcher<HttpContext> watcher) {

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -24,6 +24,10 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2Headers;
 import org.apache.seata.common.rpc.http.HttpContext;
 import org.apache.seata.common.thread.NamedThreadFactory;
 import org.apache.seata.server.cluster.listener.ClusterChangeEvent;
@@ -107,22 +111,34 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             return;
         }
         ChannelHandlerContext ctx = context.getContext();
-        if (!context.isHttp2()) {
-            if (ctx.channel().isActive()) {
-                HttpResponse response =
-                        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, Unpooled.EMPTY_BUFFER);
-                response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        if (!ctx.channel().isActive()) {
+            logger.warn(
+                    "Netty channel is not active for watcher on group {}, cannot send response.",
+                    watcher.getGroup());
+            return;
+        }
 
-                if (!context.isKeepAlive()) {
-                    ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
-                } else {
-                    ctx.writeAndFlush(response);
-                }
+        if (!context.isHttp2()) {
+            // HTTP/1.1 response
+            HttpResponse response =
+                    new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, nettyStatus, Unpooled.EMPTY_BUFFER);
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+
+            if (!context.isKeepAlive()) {
+                ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
             } else {
-                logger.warn(
-                        "Netty channel is not active for watcher on group {}, cannot send response.",
-                        watcher.getGroup());
+                ctx.writeAndFlush(response);
             }
+        } else {
+            // HTTP/2 response (h2c support)
+            // Send headers frame
+            Http2Headers headers = new DefaultHttp2Headers().status(nettyStatus.codeAsText());
+            headers.set(HttpHeaderNames.CONTENT_LENGTH, "0");
+            ctx.write(new DefaultHttp2HeadersFrame(headers));
+
+            // Send empty data frame with endStream=true to close the stream
+            ctx.write(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true));
+            ctx.flush();
         }
     }
 

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -136,17 +136,17 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             ctx.write(new DefaultHttp2HeadersFrame(headers));
 
             // Send empty data frame with endStream=true to close the stream
-            ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true))
-                    .addListener(future -> {
-                        if (!future.isSuccess() && logger.isWarnEnabled()) {
-                            logger.warn(
-                                    "Failed to send HTTP/2 response for watcher on group {}: {}",
-                                    watcher.getGroup(),
-                                    future.cause() != null ? future.cause().getMessage() : "unknown error",
-                                    future.cause());
-                        }
-                    });
+            ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true)).addListener(f -> {
+                if (!f.isSuccess() && logger.isWarnEnabled()) {
+                    logger.warn(
+                            "Failed to send HTTP/2 response for watcher on group {}: {}",
+                            watcher.getGroup(),
+                            f.cause() != null ? f.cause().getMessage() : "unknown error",
+                            f.cause());
+                }
+            });
         }
+
     }
 
     public void registryWatcher(Watcher<HttpContext> watcher) {

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -136,8 +136,16 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             ctx.write(new DefaultHttp2HeadersFrame(headers));
 
             // Send empty data frame with endStream=true to close the stream
-            ctx.write(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true));
-            ctx.flush();
+            ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true))
+                    .addListener(future -> {
+                        if (!future.isSuccess() && logger.isWarnEnabled()) {
+                            logger.warn(
+                                    "Failed to send HTTP/2 response for watcher on group {}: {}",
+                                    watcher.getGroup(),
+                                    future.cause() != null ? future.cause().getMessage() : "unknown error",
+                                    future.cause());
+                        }
+                    });
         }
     }
 

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -113,8 +113,7 @@ public class ClusterWatcherManager implements ClusterChangeListener {
         ChannelHandlerContext ctx = context.getContext();
         if (!ctx.channel().isActive()) {
             logger.warn(
-                    "Netty channel is not active for watcher on group {}, cannot send response.",
-                    watcher.getGroup());
+                    "Netty channel is not active for watcher on group {}, cannot send response.", watcher.getGroup());
             return;
         }
 

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -139,7 +139,10 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true))
                     .addListener(f -> {
                         if (!f.isSuccess()) {
-                            logger.warn("Failed to send HTTP2 response for watcher on group {}", watcher.getGroup());
+                            logger.warn(
+                                    "Failed to send HTTP2 response for watcher on group {}: {}",
+                                    watcher.getGroup(),
+                                    f.cause().toString());
                         }
                     });
         }

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -138,12 +138,8 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             // Send empty data frame with endStream=true to close the stream
             ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true))
                     .addListener(f -> {
-                        if (!f.isSuccess() && logger.isWarnEnabled()) {
-                            logger.warn(
-                                    "Failed to send HTTP/2 response for watcher on group {}: {}",
-                                    watcher.getGroup(),
-                                    f.cause() != null ? f.cause().getMessage() : "unknown error",
-                                    f.cause());
+                        if (!f.isSuccess()) {
+                            logger.warn("Failed to send HTTP2 response for watcher on group {}", watcher.getGroup());
                         }
                     });
         }

--- a/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
+++ b/server/src/main/java/org/apache/seata/server/cluster/manager/ClusterWatcherManager.java
@@ -102,18 +102,18 @@ public class ClusterWatcherManager implements ClusterChangeListener {
     }
 
     private void sendWatcherResponse(Watcher<HttpContext> watcher, HttpResponseStatus nettyStatus) {
+        String group = watcher.getGroup();
         HttpContext context = watcher.getAsyncContext();
         if (!(context instanceof HttpContext)) {
             logger.warn(
                     "Unsupported context type for watcher on group {}: {}",
-                    watcher.getGroup(),
+                    group,
                     context != null ? context.getClass().getName() : "null");
             return;
         }
         ChannelHandlerContext ctx = context.getContext();
         if (!ctx.channel().isActive()) {
-            logger.warn(
-                    "Netty channel is not active for watcher on group {}, cannot send response.", watcher.getGroup());
+            logger.warn("Netty channel is not active for watcher on group {}, cannot send response.", group);
             return;
         }
 
@@ -139,10 +139,7 @@ public class ClusterWatcherManager implements ClusterChangeListener {
             ctx.writeAndFlush(new DefaultHttp2DataFrame(Unpooled.EMPTY_BUFFER, true))
                     .addListener(f -> {
                         if (!f.isSuccess()) {
-                            logger.warn(
-                                    "Failed to send HTTP2 response for watcher on group {}: {}",
-                                    watcher.getGroup(),
-                                    f.cause().toString());
+                            logger.warn("HTTP2 response send failed, group={}", group, f.cause());
                         }
                     });
         }

--- a/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
@@ -17,6 +17,7 @@
 package org.apache.seata.server.cluster.manager;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.seata.common.rpc.http.HttpContext;
 import org.apache.seata.server.BaseSpringBootTest;
@@ -129,6 +130,12 @@ class ClusterWatcherManagerTest extends BaseSpringBootTest {
     void testSendWatcherResponseWithActiveChannel_Http2() {
         // Test normal flow with active channel (HTTP/2)
         when(mockChannel.isActive()).thenReturn(true);
+        
+        // Mock writeAndFlush to return a non-null ChannelFuture
+        ChannelFuture mockChannelFuture = mock(ChannelFuture.class);
+        when(mockChannelHandlerContext.writeAndFlush(any())).thenReturn(mockChannelFuture);
+        when(mockChannelFuture.addListener(any())).thenReturn(mockChannelFuture);
+        
         // Create HTTP/2 context
         HttpContext<Object> http2Context =
                 new HttpContext<>(new Object(), mockChannelHandlerContext, true, HttpContext.HTTP_2_0);
@@ -142,7 +149,7 @@ class ClusterWatcherManagerTest extends BaseSpringBootTest {
         verify(mockChannel, atLeastOnce()).isActive();
 
         verify(mockChannelHandlerContext, atLeastOnce()).write(any());
-        verify(mockChannelHandlerContext, atLeastOnce()).flush();
+        verify(mockChannelHandlerContext, atLeastOnce()).writeAndFlush(any());
 
         assertTrue(watcher.isDone());
     }

--- a/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
@@ -19,6 +19,8 @@ package org.apache.seata.server.cluster.manager;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import org.apache.seata.common.rpc.http.HttpContext;
 import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.cluster.listener.ClusterChangeEvent;
@@ -26,6 +28,7 @@ import org.apache.seata.server.cluster.watch.Watcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
@@ -35,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -219,6 +223,40 @@ class ClusterWatcherManagerTest extends BaseSpringBootTest {
 
         verify(mockChannelHandlerContext, never()).write(any());
         verify(mockChannelHandlerContext, never()).writeAndFlush(any());
+
+        assertTrue(watcher.isDone());
+    }
+
+    @Test
+    void testHttp2WriteAndFlushFailedShouldTriggerListener() throws Exception {
+        when(mockChannel.isActive()).thenReturn(true);
+
+        ChannelFuture mockFuture = mock(ChannelFuture.class);
+        when(mockChannelHandlerContext.writeAndFlush(any())).thenReturn(mockFuture);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<GenericFutureListener<? extends Future<? super Void>>> listenerCaptor =
+                ArgumentCaptor.forClass(GenericFutureListener.class);
+
+        when(mockFuture.addListener(listenerCaptor.capture())).thenReturn(mockFuture);
+
+        RuntimeException cause = new RuntimeException("mock http2 write failed");
+        when(mockFuture.isSuccess()).thenReturn(false);
+        when(mockFuture.cause()).thenReturn(cause);
+
+        HttpContext<Object> http2Context =
+                new HttpContext<>(new Object(), mockChannelHandlerContext, true, HttpContext.HTTP_2_0);
+
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, http2Context, TEST_TIMEOUT, TEST_TERM);
+
+        assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(clusterWatcherManager, "notifyWatcher", watcher));
+
+        GenericFutureListener<? extends Future<? super Void>> listener = listenerCaptor.getValue();
+        assertNotNull(listener);
+
+        verify(mockChannel, atLeastOnce()).isActive();
+        verify(mockChannelHandlerContext, atLeastOnce()).write(any());
+        verify(mockChannelHandlerContext, atLeastOnce()).writeAndFlush(any());
 
         assertTrue(watcher.isDone());
     }

--- a/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
@@ -130,12 +130,12 @@ class ClusterWatcherManagerTest extends BaseSpringBootTest {
     void testSendWatcherResponseWithActiveChannel_Http2() {
         // Test normal flow with active channel (HTTP/2)
         when(mockChannel.isActive()).thenReturn(true);
-        
+
         // Mock writeAndFlush to return a non-null ChannelFuture
         ChannelFuture mockChannelFuture = mock(ChannelFuture.class);
         when(mockChannelHandlerContext.writeAndFlush(any())).thenReturn(mockChannelFuture);
         when(mockChannelFuture.addListener(any())).thenReturn(mockChannelFuture);
-        
+
         // Create HTTP/2 context
         HttpContext<Object> http2Context =
                 new HttpContext<>(new Object(), mockChannelHandlerContext, true, HttpContext.HTTP_2_0);

--- a/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/manager/ClusterWatcherManagerTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.cluster.manager;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.seata.common.rpc.http.HttpContext;
+import org.apache.seata.server.BaseSpringBootTest;
+import org.apache.seata.server.cluster.listener.ClusterChangeEvent;
+import org.apache.seata.server.cluster.watch.Watcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ClusterWatcherManagerTest extends BaseSpringBootTest {
+
+    private ClusterWatcherManager clusterWatcherManager;
+    private ChannelHandlerContext mockChannelHandlerContext;
+    private Channel mockChannel;
+    private HttpContext<Object> httpContext;
+
+    private static final String TEST_GROUP = "test-group";
+    private static final int TEST_TIMEOUT = 5000;
+    private static final long TEST_TERM = 1000L;
+
+    @BeforeEach
+    void setUp() {
+        clusterWatcherManager = new ClusterWatcherManager();
+
+        mockChannel = mock(Channel.class);
+        mockChannelHandlerContext = mock(ChannelHandlerContext.class);
+        when(mockChannelHandlerContext.channel()).thenReturn(mockChannel);
+
+        Object mockRequest = new Object();
+        httpContext = new HttpContext<>(mockRequest, mockChannelHandlerContext, true, HttpContext.HTTP_1_1);
+
+        Map<String, Queue<Watcher<HttpContext>>> watchers = (Map<String, Queue<Watcher<HttpContext>>>)
+                ReflectionTestUtils.getField(clusterWatcherManager, "WATCHERS");
+        Map<String, Long> groupUpdateTerm =
+                (Map<String, Long>) ReflectionTestUtils.getField(clusterWatcherManager, "GROUP_UPDATE_TERM");
+        if (watchers != null) {
+            watchers.clear();
+        }
+        if (groupUpdateTerm != null) {
+            groupUpdateTerm.clear();
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        ScheduledThreadPoolExecutor executor = (ScheduledThreadPoolExecutor)
+                ReflectionTestUtils.getField(clusterWatcherManager, "scheduledThreadPoolExecutor");
+        if (executor != null && !executor.isShutdown()) {
+            executor.shutdown();
+            try {
+                executor.awaitTermination(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Test
+    void testSendWatcherResponseWithInactiveChannel() {
+        when(mockChannel.isActive()).thenReturn(false);
+
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, httpContext, TEST_TIMEOUT, TEST_TERM);
+
+        assertDoesNotThrow(() -> {
+            ReflectionTestUtils.invokeMethod(clusterWatcherManager, "notifyWatcher", watcher);
+        });
+
+        verify(mockChannel, atLeastOnce()).isActive();
+
+        verify(mockChannelHandlerContext, never()).write(any());
+        verify(mockChannelHandlerContext, never()).writeAndFlush(any());
+        verify(mockChannelHandlerContext, never()).flush();
+
+        assertTrue(watcher.isDone());
+    }
+
+    @Test
+    void testSendWatcherResponseWithActiveChannel_Http1() {
+        when(mockChannel.isActive()).thenReturn(true);
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, httpContext, TEST_TIMEOUT, TEST_TERM);
+
+        assertDoesNotThrow(() -> {
+            ReflectionTestUtils.invokeMethod(clusterWatcherManager, "notifyWatcher", watcher);
+        });
+
+        verify(mockChannel, atLeastOnce()).isActive();
+
+        verify(mockChannelHandlerContext, atLeastOnce()).writeAndFlush(any());
+
+        assertTrue(watcher.isDone());
+    }
+
+    @Test
+    void testSendWatcherResponseWithActiveChannel_Http2() {
+        // Test normal flow with active channel (HTTP/2)
+        when(mockChannel.isActive()).thenReturn(true);
+        // Create HTTP/2 context
+        HttpContext<Object> http2Context =
+                new HttpContext<>(new Object(), mockChannelHandlerContext, true, HttpContext.HTTP_2_0);
+
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, http2Context, TEST_TIMEOUT, TEST_TERM);
+
+        assertDoesNotThrow(() -> {
+            ReflectionTestUtils.invokeMethod(clusterWatcherManager, "notifyWatcher", watcher);
+        });
+
+        verify(mockChannel, atLeastOnce()).isActive();
+
+        verify(mockChannelHandlerContext, atLeastOnce()).write(any());
+        verify(mockChannelHandlerContext, atLeastOnce()).flush();
+
+        assertTrue(watcher.isDone());
+    }
+
+    @Test
+    void testOnChangeEventWithInactiveChannel() {
+        when(mockChannel.isActive()).thenReturn(false);
+
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, httpContext, TEST_TIMEOUT, TEST_TERM);
+
+        clusterWatcherManager.registryWatcher(watcher);
+
+        Map<String, Queue<Watcher<HttpContext>>> watchers = (Map<String, Queue<Watcher<HttpContext>>>)
+                ReflectionTestUtils.getField(clusterWatcherManager, "WATCHERS");
+        assertTrue(watchers.containsKey(TEST_GROUP));
+        assertEquals(1, watchers.get(TEST_GROUP).size());
+
+        ClusterChangeEvent event = new ClusterChangeEvent(this, TEST_GROUP, TEST_TERM + 1, true);
+
+        assertDoesNotThrow(() -> {
+            clusterWatcherManager.onChangeEvent(event);
+        });
+
+        verify(mockChannel, atLeastOnce()).isActive();
+
+        verify(mockChannelHandlerContext, never()).write(any());
+        verify(mockChannelHandlerContext, never()).writeAndFlush(any());
+
+        assertTrue(watcher.isDone());
+    }
+
+    @Test
+    void testTimeoutWithInactiveChannel() throws InterruptedException {
+        when(mockChannel.isActive()).thenReturn(false);
+
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, httpContext, 1000, TEST_TERM);
+
+        clusterWatcherManager.registryWatcher(watcher);
+
+        clusterWatcherManager.init();
+
+        Thread.sleep(2500);
+
+        verify(mockChannel, atLeastOnce()).isActive();
+
+        verify(mockChannelHandlerContext, never()).write(any());
+        verify(mockChannelHandlerContext, never()).writeAndFlush(any());
+
+        assertTrue(watcher.isDone());
+    }
+
+    @Test
+    void testRegistryWatcherWithInactiveChannel() {
+        when(mockChannel.isActive()).thenReturn(false);
+
+        Map<String, Long> groupUpdateTerm =
+                (Map<String, Long>) ReflectionTestUtils.getField(clusterWatcherManager, "GROUP_UPDATE_TERM");
+        groupUpdateTerm.put(TEST_GROUP, TEST_TERM + 10);
+
+        Watcher<HttpContext> watcher = new Watcher<>(TEST_GROUP, httpContext, TEST_TIMEOUT, TEST_TERM);
+
+        assertDoesNotThrow(() -> {
+            clusterWatcherManager.registryWatcher(watcher);
+        });
+
+        verify(mockChannel, atLeastOnce()).isActive();
+
+        verify(mockChannelHandlerContext, never()).write(any());
+        verify(mockChannelHandlerContext, never()).writeAndFlush(any());
+
+        assertTrue(watcher.isDone());
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -139,7 +139,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
         });
         thread.start();
         try (CloseableHttpResponse response =
-                     HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch", param, header, 30000)) {
+                HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch", param, header, 30000)) {
             if (response != null) {
                 StatusLine statusLine = response.getStatusLine();
                 Assertions.assertEquals(HttpStatus.SC_OK, statusLine.getStatusCode());

--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -151,6 +151,19 @@ class ClusterControllerTest extends BaseSpringBootTest {
 
     @Test
     @Order(4)
+    void watchWithInactiveChannel() throws Exception {
+        Map<String, String> header = new HashMap<>();
+        header.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+        header.put(HTTP.CONN_KEEP_ALIVE, "close");
+        Map<String, String> param = new HashMap<>();
+        param.put("default-test-inactive", "1");
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch?timeout=5000", param, header, 4000);
+        });
+    }
+
+    @Test
+    @Order(5)
     void watch_withHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -200,7 +213,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void testXssFilterBlocked_queryParam() throws Exception {
         String malicious = "<script>alert('xss')</script>";
         Map<String, String> header = new HashMap<>();
@@ -217,7 +230,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void testXssFilterBlocked_queryParam_withGetHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -256,7 +269,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void testXssFilterBlocked_formParam_withPostHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -293,7 +306,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void testXssFilterBlocked_bodyParam_withPostHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -328,7 +341,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void testXssFilterBlocked_formParam() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
@@ -344,7 +357,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void testXssFilterBlocked_jsonBody() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
@@ -359,7 +372,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void testXssFilterBlocked_headerParam() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
@@ -376,7 +389,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void testXssFilterBlocked_multiSource() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
@@ -396,7 +409,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void testXssFilterBlocked_formParamWithUserCustomKeyWords() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());

--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -150,19 +150,6 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(4)
-    void watchWithInactiveChannel() throws Exception {
-        Map<String, String> header = new HashMap<>();
-        header.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
-        header.put(HTTP.CONN_KEEP_ALIVE, "close");
-        Map<String, String> param = new HashMap<>();
-        param.put("default-test-inactive", "1");
-        Assertions.assertThrows(Exception.class, () -> {
-            HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch?timeout=5000", param, header, 4000);
-        });
-    }
-
-    @Test
     @Order(5)
     void watch_withHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -157,7 +157,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
         header.put(HTTP.CONN_KEEP_ALIVE, "close");
         Map<String, String> param = new HashMap<>();
         param.put("default-test-inactive", "1");
-        Assertions.assertThrows(RuntimeException.class, () -> {
+        Assertions.assertThrows(Exception.class, () -> {
             HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch?timeout=5000", param, header, 4000);
         });
     }

--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -160,17 +160,14 @@ class ClusterControllerTest extends BaseSpringBootTest {
         Map<String, String> params = new HashMap<>();
         params.put("default-test", "1");
 
-        Thread thread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(2000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                ((ApplicationEventPublisher) ObjectHolder.INSTANCE.getObject(OBJECT_KEY_SPRING_APPLICATION_CONTEXT))
-                        .publishEvent(new ClusterChangeEvent(this, "default-test", 2, true));
+        Thread thread = new Thread(() -> {
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
             }
+            ((ApplicationEventPublisher) ObjectHolder.INSTANCE.getObject(OBJECT_KEY_SPRING_APPLICATION_CONTEXT))
+                    .publishEvent(new ClusterChangeEvent(this, "default-test", 2, true));
         });
         thread.start();
 

--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -115,9 +115,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
 
         HttpClientUtil.doPostWithHttp2(
                 "http://127.0.0.1:" + port + "/metadata/v1/watch?timeout=3000", params, headers, callback);
-        // Currently, the server side does not have the ability to send http2 responses,
-        // so if no response is received here, it will definitely time out
-        Assertions.assertFalse(latch.await(5, TimeUnit.SECONDS));
+        Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
     @Test
@@ -141,7 +139,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
         });
         thread.start();
         try (CloseableHttpResponse response =
-                HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch", param, header, 30000)) {
+                     HttpClientUtil.doPost("http://127.0.0.1:" + port + "/metadata/v1/watch", param, header, 30000)) {
             if (response != null) {
                 StatusLine statusLine = response.getStatusLine();
                 Assertions.assertEquals(HttpStatus.SC_OK, statusLine.getStatusCode());
@@ -153,6 +151,56 @@ class ClusterControllerTest extends BaseSpringBootTest {
 
     @Test
     @Order(4)
+    void watch_withHttp2() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+
+        Map<String, String> params = new HashMap<>();
+        params.put("default-test", "1");
+
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                ((ApplicationEventPublisher) ObjectHolder.INSTANCE.getObject(OBJECT_KEY_SPRING_APPLICATION_CONTEXT))
+                        .publishEvent(new ClusterChangeEvent(this, "default-test", 2, true));
+            }
+        });
+        thread.start();
+
+        HttpCallback<Response> callback = new HttpCallback<Response>() {
+            @Override
+            public void onSuccess(Response response) {
+                Assertions.assertNotNull(response);
+                Assertions.assertEquals(Protocol.H2_PRIOR_KNOWLEDGE, response.protocol());
+                Assertions.assertEquals(HttpStatus.SC_OK, response.code());
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                Assertions.fail("Should not fail: " + t.getMessage());
+            }
+
+            @Override
+            public void onCancelled() {
+                Assertions.fail("Should not be cancelled");
+            }
+        };
+
+        HttpClientUtil.doPostWithHttp2(
+                "http://127.0.0.1:" + port + "/metadata/v1/watch", params, headers, callback, 30);
+        Assertions.assertTrue(latch.await(35, TimeUnit.SECONDS));
+    }
+
+    @Test
+    @Order(5)
     void testXssFilterBlocked_queryParam() throws Exception {
         String malicious = "<script>alert('xss')</script>";
         Map<String, String> header = new HashMap<>();
@@ -169,7 +217,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void testXssFilterBlocked_queryParam_withGetHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -208,7 +256,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void testXssFilterBlocked_formParam_withPostHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -245,7 +293,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void testXssFilterBlocked_bodyParam_withPostHttp2() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -280,7 +328,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void testXssFilterBlocked_formParam() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
@@ -296,7 +344,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void testXssFilterBlocked_jsonBody() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
@@ -311,7 +359,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void testXssFilterBlocked_headerParam() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
@@ -328,7 +376,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void testXssFilterBlocked_multiSource() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
@@ -348,7 +396,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void testXssFilterBlocked_formParamWithUserCustomKeyWords() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(HTTP.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This change only completes the protocol upgrade and does not include streaming push at the data frame level. HTTP/2 responses adopt the same simple response pattern as HTTP/1.1:
 1. Send the headers frame (including the status code)
 2.Send an empty data frame (endStream=true) to close the stream
 3.The response behavior is consistent with HTTP/1.1, with only the protocol layer being different

本次变更仅完成协议升级，不包含数据帧级别的流式推送。HTTP/2 响应采用与 HTTP/1.1 相同的简单响应模式：
发送 headers frame（包含状态码）
发送空的 data frame（endStream=true）关闭流
响应行为与 HTTP/1.1 一致，仅协议层不同


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
look it `org.apache.seata.server.controller.ClusterControllerTest`

### Ⅴ. Special notes for reviews

