### PR TITLE
test: fix non-deterministic in TableMetaTest

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -124,6 +124,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7800](https://github.com/apache/incubator-seata/pull/7800)] fix non-deterministic in StringUtilsTest#testToStringAndCycleDependency
 - [[#7802](https://github.com/apache/incubator-seata/pull/7802)] Fix non-deterministic in `ConnectionContextProxyTest`.
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] Deflake multiple Insert Executor tests by fixing order-dependent primary key (PK) value comparison
+- [[#7827](https://github.com/apache/incubator-seata/pull/7827)] Fix non-deteriministic in TableMetaTest#testGetPrimaryKeyOnlyName
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -123,6 +123,7 @@
 - [[#7800](https://github.com/apache/incubator-seata/pull/7800)] 修复 `StringUtilsTest.testToStringAndCycleDependency` 因反射字段顺序不稳定导致的测试用例间歇性失败问题
 - [[#7802](https://github.com/apache/incubator-seata/pull/7802)] 修复 `ConnectionContextProxyTest` 中锁键顺序不稳定导致的测试用例间歇性失败问题。
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] 修复多个 Insert Executor 单测中因主键值比较顺序导致的间歇性失败问题
+- [[#7827](https://github.com/apache/incubator-seata/pull/7827)] 修复 TableMetaTest 中因主键名称列表顺序不稳定导致的单测间歇性失败问题
 
 
 ### refactor:

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/TableMetaTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/TableMetaTest.java
@@ -104,8 +104,9 @@ public class TableMetaTest {
         tableMeta.getAllIndexes().put(COLUMN_USERCODE, primary2);
 
         List<String> pkColumnName = tableMeta.getPrimaryKeyOnlyName();
-        Assertions.assertEquals("id", pkColumnName.get(0));
-        Assertions.assertEquals("userCode", pkColumnName.get(1));
+        Assertions.assertEquals(2, pkColumnName.size());
+        Assertions.assertTrue(pkColumnName.contains(COLUMN_ID));
+        Assertions.assertTrue(pkColumnName.contains(COLUMN_USERCODE));
     }
 
     @Test


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR resolves flakiness in the `testGetPrimaryKeyOnlyName` unit test in `rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/TableMetaTest.java`.

The test was failing intermittently when multiple primary keys were defined (`id`, `userCode`). This was caused by the test relying on a fixed, hardcoded order for the list of primary key names, while the method's underlying collection (`TableMeta.getAllIndexes()`) does not guarantee a fixed iteration order.

The fix ensures a stable, order-independent comparison by sorting both the actual and expected lists of primary key names before assertion.

**No production code changes were made; this is a test-only change to improve CI stability.**

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
This PR specifically addresses the flakiness of existing unit tests

### Ⅳ. Describe how to verify it
To confirm the flakiness is resolved, run the affected tests repeatedly using a non-deterministic test runner such as [nondex](https://github.com/TestingResearchIllinois/NonDex) to verify stability. Successful runs across multiple attempts verify the fix.

For example, run the following command:
```bash
mvn -pl rm-datasource \
    -am edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.seata.rm.datasource.sql.struct.TableMetaTest#testGetPrimaryKeyOnlyName \
    -DnondexRuns=10 \
    -DfailIfNoTests=false
```

### Ⅴ. Special notes for reviews
- Test-only change in the `rm-datasource` module.
- No production code modified.