### PR TITLE
bugfix: resolve TransactionAutoConfiguration compatibility with Spring Boot 4.x

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -54,6 +54,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7771](https://github.com/apache/incubator-seata/pull/7771)] Shentongdata xa mode should be hold the same connection
 - [[#7785](https://github.com/apache/incubator-seata/pull/7785)] fix the failure test
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] fix the NPE on ConsulConfigurationTest method
+- [[#7839](https://github.com/apache/incubator-seata/pull/7839)] resolve TransactionAutoConfiguration compatibility with Spring Boot 4.x
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -54,6 +54,7 @@
 - [[#7771](https://github.com/apache/incubator-seata/pull/7771)] 确保神通XA模式相同的事务使用相同的XAConnection
 - [[#7785](https://github.com/apache/incubator-seata/pull/7785)] 修复失败的测试方法
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] 修复 Consul 监听器空值 NPE 问题
+- [[#7839](https://github.com/apache/incubator-seata/pull/7839)] 解决TransactionAutoConfiguration与Spring Boot 4.x的兼容性问题
 
 
 ### optimize:

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/AbstractConfigurationTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/AbstractConfigurationTest.java
@@ -145,13 +145,11 @@ class AbstractConfigurationTest {
         Assertions.assertEquals(defaultDuration, value);
     }
 
-
     @Test
     void testGetConfigWithDefaultValue() {
         String defaultValue = "default-value";
         String value = configuration.getConfig("test.nonexistent.key", defaultValue);
         Assertions.assertEquals(defaultValue, value);
-        
         String valueCached = configuration.getConfig("test.nonexistent.key");
         // due to configuration cache, may return default value instead of null
         Assertions.assertNotNull(valueCached);

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSpringFenceAutoConfiguration.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSpringFenceAutoConfiguration.java
@@ -44,8 +44,10 @@ import static org.apache.seata.common.Constants.BEAN_NAME_SPRING_FENCE_CONFIG;
 @AutoConfigureAfter(
     value = {SeataCoreAutoConfiguration.class},
     name = {
-        "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration",  // Spring Boot 2.x, 3.x
-        "org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration"   // Spring Boot 4.x
+        // Spring Boot 2.x, 3.x
+        "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration",
+        // Spring Boot 4.x
+        "org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration"
     })
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class SeataSpringFenceAutoConfiguration {

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSpringFenceAutoConfiguration.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSpringFenceAutoConfiguration.java
@@ -42,13 +42,13 @@ import static org.apache.seata.common.Constants.BEAN_NAME_SPRING_FENCE_CONFIG;
 @ConditionalOnBean(type = {"javax.sql.DataSource", "org.springframework.transaction.PlatformTransactionManager"})
 @ConditionalOnMissingBean(SpringFenceConfig.class)
 @AutoConfigureAfter(
-    value = {SeataCoreAutoConfiguration.class},
-    name = {
-        // Spring Boot 2.x, 3.x
-        "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration",
-        // Spring Boot 4.x
-        "org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration"
-    })
+        value = {SeataCoreAutoConfiguration.class},
+        name = {
+            // Spring Boot 2.x, 3.x
+            "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration",
+            // Spring Boot 4.x
+            "org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration"
+        })
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class SeataSpringFenceAutoConfiguration {
 

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSpringFenceAutoConfiguration.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSpringFenceAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
@@ -42,7 +41,12 @@ import static org.apache.seata.common.Constants.BEAN_NAME_SPRING_FENCE_CONFIG;
 @ConditionalOnExpression("${seata.enabled:true}")
 @ConditionalOnBean(type = {"javax.sql.DataSource", "org.springframework.transaction.PlatformTransactionManager"})
 @ConditionalOnMissingBean(SpringFenceConfig.class)
-@AutoConfigureAfter({SeataCoreAutoConfiguration.class, TransactionAutoConfiguration.class})
+@AutoConfigureAfter(
+    value = {SeataCoreAutoConfiguration.class},
+    name = {
+        "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration",  // Spring Boot 2.x, 3.x
+        "org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration"   // Spring Boot 4.x
+    })
 @AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class SeataSpringFenceAutoConfiguration {
 


### PR DESCRIPTION
…on compatibility

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR resolves the Spring Boot 4.x compatibility issue caused by the relocation of TransactionAutoConfiguration. I modified SeataSpringFenceAutoConfiguration to replace the hard import with string-based class names in the @AutoConfigureAfter annotation. By including both the legacy (Spring Boot 2.x/3.x) and new (Spring Boot 4.x) package paths, this approach ensures full backward compatibility and prevents compilation errors, consistent with the existing implementation in SeataDataSourceAutoConfiguration.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixed #7805 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

