### PR TITLE
test: Fix non-deterministic in HttpTest caused by HashMap iteration order

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -137,6 +137,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] Deflake multiple Insert Executor tests by fixing order-dependent primary key (PK) value comparison
 - [[#7815](https://github.com/apache/incubator-seata/pull/7815)] test: fix combine test to avoid failure due to ordering
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] Fix non-deteriministic in TableMetaTest#testGetPrimaryKeyOnlyName
+- [[#7858](https://github.com/apache/incubator-seata/pull/7858)] Fix flakiness in HttpTest.convertParamOfJsonStringTest caused by non-deterministic Map iteration order
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -136,6 +136,7 @@
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] 修复多个 Insert Executor 单测中因主键值比较顺序导致的间歇性失败问题
 - [[#7815](https://github.com/apache/incubator-seata/pull/7815)] 通过合并测试来修复，避免因执行顺序导致的失败
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] 修复 TableMetaTest 中因主键名称列表顺序不稳定导致的单测间歇性失败问题
+- [[#7858](https://github.com/apache/incubator-seata/pull/7858)] 修复 `HttpTest.convertParamOfJsonStringTest` 因 Map 遍历顺序不确定导致的测试用例间歇性失败问题
 
 
 ### refactor:

--- a/extensions/rpc/seata-http/src/test/java/org/apache/seata/integration/http/HttpTest.java
+++ b/extensions/rpc/seata-http/src/test/java/org/apache/seata/integration/http/HttpTest.java
@@ -206,13 +206,17 @@ class HttpTest {
 
     @Test
     void convertParamOfJsonStringTest() {
-
-        String targetParam = "{name=zhangsan, age=15}";
         String str = "{\n" + "    \"name\":\"zhangsan\",\n" + "    \"age\":15\n" + "}";
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("name", "zhangsan");
+        expected.put("age", "15");
+
         Map<String, String> map = convertParamOfJsonString(str, Person.class);
-        Assertions.assertEquals(map.toString(), targetParam);
+        Assertions.assertEquals(expected, map);
+
         Person person = JSON.parseObject(str, Person.class);
         map = convertParamOfBean(person);
-        Assertions.assertEquals(map.toString(), targetParam);
+        Assertions.assertEquals(expected, map);
     }
 }


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR fixes test flakiness in  
`org.apache.seata.integration.http.HttpTest.convertParamOfJsonStringTest`.

The test was intermittently failing because it compared the `toString()` output of a `Map`, which depends on the iteration order of the underlying `HashMap`. Since `HashMap` does not guarantee a deterministic key order, different JVM or
NonDex execution orders could produce logically equivalent but differently ordered string representations (e.g. `{age=15, name=zhangsan}` vs `{name=zhangsan, age=15}`), causing false negatives.

The fix updates the test to perform **order-independent map comparisons** by asserting map equality directly, instead of relying on `toString()` output.

**This change is test-only and does not modify any production code.**

### Ⅱ. Does this pull request fix one issue?
<!-- If applicable, add "fixes #xxx" below -->

### Ⅲ. Why don't you add test cases (unit test/integration test)?
This PR focuses on correcting an existing flaky unit test by making its assertions deterministic and order-independent. No new functionality is introduced.

### Ⅳ. Describe how to verify it
The fix can be verified by repeatedly running the affected test under a non-deterministic execution environment such as [NonDex](https://github.com/TestingResearchIllinois/NonDex).

Example command:
```bash
mvn -pl integration/http \
    -am edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.seata.integration.http.HttpTest#convertParamOfJsonStringTest \
    -DnondexRuns=10 \
    -DfailIfNoTests=false
```

### Ⅴ. Special notes for reviews 
- Test-only change in the `seata-http` module. 
- No production code modified.
- Improves CI stability under non-deterministic execution orders.