### PR TITLE
optimize: disallow messages with delay time levels in Seata transactions and add a corresponding test.

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -56,7 +56,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] fix the NPE on ConsulConfigurationTest method
 - [[#7839](https://github.com/apache/incubator-seata/pull/7839)] resolve TransactionAutoConfiguration compatibility with Spring Boot 4.x
 - [[#7855](https://github.com/apache/incubator-seata/pull/7855)] fix comma missing in package.json/min-document
-- [[#7351](https://github.com/apache/incubator-seata/pull/7860)] Fix the issue where delayed messages in RocketMQ transactions were silently ignored, now explicitly throwing an exception
+- [[#7860](https://github.com/apache/incubator-seata/pull/7860)] Fix the issue where delayed messages in RocketMQ transactions were silently ignored, now explicitly throwing an exception
 
 
 ### optimize:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -56,7 +56,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] fix the NPE on ConsulConfigurationTest method
 - [[#7839](https://github.com/apache/incubator-seata/pull/7839)] resolve TransactionAutoConfiguration compatibility with Spring Boot 4.x
 - [[#7855](https://github.com/apache/incubator-seata/pull/7855)] fix comma missing in package.json/min-document
-- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] Fix the issue where delayed messages in RocketMQ transactions were silently ignored, now explicitly throwing an exception
+- [[#7351](https://github.com/apache/incubator-seata/pull/7860)] Fix the issue where delayed messages in RocketMQ transactions were silently ignored, now explicitly throwing an exception
 
 
 ### optimize:
@@ -138,7 +138,6 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] Deflake multiple Insert Executor tests by fixing order-dependent primary key (PK) value comparison
 - [[#7815](https://github.com/apache/incubator-seata/pull/7815)] test: fix combine test to avoid failure due to ordering
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] Fix non-deteriministic in TableMetaTest#testGetPrimaryKeyOnlyName
-- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] Add unit test for delayed message validation in RocketMQ transaction
 
 
 ### refactor:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -188,6 +188,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [xiaoxiangyeyu0](https://github.com/xiaoxiangyeyu0)
 - [jsbxyyx](https://github.com/jsbxyyx)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [aias00](https://github.com/aias00)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -56,6 +56,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] fix the NPE on ConsulConfigurationTest method
 - [[#7839](https://github.com/apache/incubator-seata/pull/7839)] resolve TransactionAutoConfiguration compatibility with Spring Boot 4.x
 - [[#7855](https://github.com/apache/incubator-seata/pull/7855)] fix comma missing in package.json/min-document
+- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] Fix the issue where delayed messages in RocketMQ transactions were silently ignored, now explicitly throwing an exception
 
 
 ### optimize:
@@ -137,6 +138,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] Deflake multiple Insert Executor tests by fixing order-dependent primary key (PK) value comparison
 - [[#7815](https://github.com/apache/incubator-seata/pull/7815)] test: fix combine test to avoid failure due to ordering
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] Fix non-deteriministic in TableMetaTest#testGetPrimaryKeyOnlyName
+- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] Add unit test for delayed message validation in RocketMQ transaction
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -186,6 +186,7 @@
 - [xiaoxiangyeyu0](https://github.com/xiaoxiangyeyu0)
 - [jsbxyyx](https://github.com/jsbxyyx)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [aias00](https://github.com/aias00)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -56,7 +56,7 @@
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] 修复 Consul 监听器空值 NPE 问题
 - [[#7839](https://github.com/apache/incubator-seata/pull/7839)] 解决TransactionAutoConfiguration与Spring Boot 4.x的兼容性问题
 - [[#7855](https://github.com/apache/incubator-seata/pull/7855)] 修复package.json中min-document的逗号缺失
-- [[#7351](https://github.com/apache/incubator-seata/pull/7860)] 修复 RocketMQ 事务中延迟消息静默失效的问题，改为显式抛出异常
+- [[#7860](https://github.com/apache/incubator-seata/pull/7860)] 修复 RocketMQ 事务中延迟消息静默失效的问题，改为显式抛出异常
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -56,7 +56,7 @@
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] 修复 Consul 监听器空值 NPE 问题
 - [[#7839](https://github.com/apache/incubator-seata/pull/7839)] 解决TransactionAutoConfiguration与Spring Boot 4.x的兼容性问题
 - [[#7855](https://github.com/apache/incubator-seata/pull/7855)] 修复package.json中min-document的逗号缺失
-- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] 修复 RocketMQ 事务中延迟消息静默失效的问题，改为显式抛出异常
+- [[#7351](https://github.com/apache/incubator-seata/pull/7860)] 修复 RocketMQ 事务中延迟消息静默失效的问题，改为显式抛出异常
 
 
 ### optimize:
@@ -137,7 +137,6 @@
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] 修复多个 Insert Executor 单测中因主键值比较顺序导致的间歇性失败问题
 - [[#7815](https://github.com/apache/incubator-seata/pull/7815)] 通过合并测试来修复，避免因执行顺序导致的失败
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] 修复 TableMetaTest 中因主键名称列表顺序不稳定导致的单测间歇性失败问题
-- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] 增加 RocketMQ 事务中延迟消息校验的单元测试
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -56,6 +56,7 @@
 - [[#7796](https://github.com/apache/incubator-seata/pull/7796)] 修复 Consul 监听器空值 NPE 问题
 - [[#7839](https://github.com/apache/incubator-seata/pull/7839)] 解决TransactionAutoConfiguration与Spring Boot 4.x的兼容性问题
 - [[#7855](https://github.com/apache/incubator-seata/pull/7855)] 修复package.json中min-document的逗号缺失
+- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] 修复 RocketMQ 事务中延迟消息静默失效的问题，改为显式抛出异常
 
 
 ### optimize:
@@ -136,6 +137,7 @@
 - [[#7808](https://github.com/apache/incubator-seata/pull/7808)] 修复多个 Insert Executor 单测中因主键值比较顺序导致的间歇性失败问题
 - [[#7815](https://github.com/apache/incubator-seata/pull/7815)] 通过合并测试来修复，避免因执行顺序导致的失败
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] 修复 TableMetaTest 中因主键名称列表顺序不稳定导致的单测间歇性失败问题
+- [[#7351](https://github.com/apache/incubator-seata/issues/7351)] 增加 RocketMQ 事务中延迟消息校验的单元测试
 
 
 ### refactor:

--- a/extensions/messaging/seata-rocketmq/src/main/java/org/apache/seata/integration/rocketmq/SeataMQProducer.java
+++ b/extensions/messaging/seata-rocketmq/src/main/java/org/apache/seata/integration/rocketmq/SeataMQProducer.java
@@ -47,10 +47,10 @@ public class SeataMQProducer extends TransactionMQProducer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SeataMQProducer.class);
 
-    private static final List<GlobalStatus> COMMIT_STATUSES =
-            Arrays.asList(GlobalStatus.Committed, GlobalStatus.Committing, GlobalStatus.CommitRetrying);
-    private static final List<GlobalStatus> ROLLBACK_STATUSES =
-            Arrays.asList(GlobalStatus.Rollbacked, GlobalStatus.Rollbacking, GlobalStatus.RollbackRetrying);
+    private static final List<GlobalStatus> COMMIT_STATUSES = Arrays.asList(GlobalStatus.Committed,
+            GlobalStatus.Committing, GlobalStatus.CommitRetrying);
+    private static final List<GlobalStatus> ROLLBACK_STATUSES = Arrays.asList(GlobalStatus.Rollbacked,
+            GlobalStatus.Rollbacking, GlobalStatus.RollbackRetrying);
 
     public static String PROPERTY_SEATA_XID = RootContext.KEY_XID;
     public static String PROPERTY_SEATA_BRANCHID = RootContext.KEY_BRANCHID;
@@ -77,8 +77,8 @@ public class SeataMQProducer extends TransactionMQProducer {
                     LOGGER.error("msg has no xid, msgTransactionId: {}, msg will be rollback", msg.getTransactionId());
                     return LocalTransactionState.ROLLBACK_MESSAGE;
                 }
-                GlobalStatus globalStatus =
-                        DefaultResourceManager.get().getGlobalStatus(SeataMQProducerFactory.ROCKET_BRANCH_TYPE, xid);
+                GlobalStatus globalStatus = DefaultResourceManager.get()
+                        .getGlobalStatus(SeataMQProducerFactory.ROCKET_BRANCH_TYPE, xid);
                 if (COMMIT_STATUSES.contains(globalStatus)) {
                     return LocalTransactionState.COMMIT_MESSAGE;
                 } else if (ROLLBACK_STATUSES.contains(globalStatus) || GlobalStatus.isOnePhaseTimeout(globalStatus)) {
@@ -115,7 +115,7 @@ public class SeataMQProducer extends TransactionMQProducer {
             throws MQClientException {
         msg.setTopic(withNamespace(msg.getTopic()));
         if (msg.getDelayTimeLevel() != 0) {
-            MessageAccessor.clearProperty(msg, MessageConst.PROPERTY_DELAY_TIME_LEVEL);
+            throw new MQClientException("Message delay time level is not supported in Seata transaction", null);
         }
         Validators.checkMessage(msg, this);
 

--- a/extensions/messaging/seata-rocketmq/src/main/java/org/apache/seata/integration/rocketmq/SeataMQProducer.java
+++ b/extensions/messaging/seata-rocketmq/src/main/java/org/apache/seata/integration/rocketmq/SeataMQProducer.java
@@ -47,10 +47,10 @@ public class SeataMQProducer extends TransactionMQProducer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SeataMQProducer.class);
 
-    private static final List<GlobalStatus> COMMIT_STATUSES = Arrays.asList(GlobalStatus.Committed,
-            GlobalStatus.Committing, GlobalStatus.CommitRetrying);
-    private static final List<GlobalStatus> ROLLBACK_STATUSES = Arrays.asList(GlobalStatus.Rollbacked,
-            GlobalStatus.Rollbacking, GlobalStatus.RollbackRetrying);
+    private static final List<GlobalStatus> COMMIT_STATUSES =
+            Arrays.asList(GlobalStatus.Committed, GlobalStatus.Committing, GlobalStatus.CommitRetrying);
+    private static final List<GlobalStatus> ROLLBACK_STATUSES =
+            Arrays.asList(GlobalStatus.Rollbacked, GlobalStatus.Rollbacking, GlobalStatus.RollbackRetrying);
 
     public static String PROPERTY_SEATA_XID = RootContext.KEY_XID;
     public static String PROPERTY_SEATA_BRANCHID = RootContext.KEY_BRANCHID;
@@ -77,8 +77,8 @@ public class SeataMQProducer extends TransactionMQProducer {
                     LOGGER.error("msg has no xid, msgTransactionId: {}, msg will be rollback", msg.getTransactionId());
                     return LocalTransactionState.ROLLBACK_MESSAGE;
                 }
-                GlobalStatus globalStatus = DefaultResourceManager.get()
-                        .getGlobalStatus(SeataMQProducerFactory.ROCKET_BRANCH_TYPE, xid);
+                GlobalStatus globalStatus =
+                        DefaultResourceManager.get().getGlobalStatus(SeataMQProducerFactory.ROCKET_BRANCH_TYPE, xid);
                 if (COMMIT_STATUSES.contains(globalStatus)) {
                     return LocalTransactionState.COMMIT_MESSAGE;
                 } else if (ROLLBACK_STATUSES.contains(globalStatus) || GlobalStatus.isOnePhaseTimeout(globalStatus)) {

--- a/extensions/messaging/seata-rocketmq/src/test/java/org/apache/seata/integration/rocketmq/SeataMQProducerTest.java
+++ b/extensions/messaging/seata-rocketmq/src/test/java/org/apache/seata/integration/rocketmq/SeataMQProducerTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -369,8 +370,10 @@ public class SeataMQProducerTest {
         String xid = "testXid";
         long branchId = 123L;
 
-        assertThrows(
+        MQClientException exception = assertThrows(
                 MQClientException.class, () -> seataMQProducer.doSendMessageInTransaction(msg, timeout, xid, branchId));
+        // RocketMQ client might append FAQ url to the exception message
+        assertTrue(exception.getMessage().startsWith("Message delay time level is not supported in Seata transaction"));
     }
 
     @Test

--- a/extensions/messaging/seata-rocketmq/src/test/java/org/apache/seata/integration/rocketmq/SeataMQProducerTest.java
+++ b/extensions/messaging/seata-rocketmq/src/test/java/org/apache/seata/integration/rocketmq/SeataMQProducerTest.java
@@ -362,6 +362,18 @@ public class SeataMQProducerTest {
     }
 
     @Test
+    void testDoSendMessageInTransactionWithDelayLevel() {
+        Message msg = new Message("testTopic", "testBody".getBytes());
+        msg.setDelayTimeLevel(1);
+        long timeout = 3000L;
+        String xid = "testXid";
+        long branchId = 123L;
+
+        assertThrows(MQClientException.class,
+                () -> seataMQProducer.doSendMessageInTransaction(msg, timeout, xid, branchId));
+    }
+
+    @Test
     void getTransactionListenerShouldReturnNonNullTransactionListener() {
         TransactionListener transactionListener = producer.getTransactionListener();
         assertNotNull(transactionListener, "TransactionListener should not be null");

--- a/extensions/messaging/seata-rocketmq/src/test/java/org/apache/seata/integration/rocketmq/SeataMQProducerTest.java
+++ b/extensions/messaging/seata-rocketmq/src/test/java/org/apache/seata/integration/rocketmq/SeataMQProducerTest.java
@@ -369,8 +369,8 @@ public class SeataMQProducerTest {
         String xid = "testXid";
         long branchId = 123L;
 
-        assertThrows(MQClientException.class,
-                () -> seataMQProducer.doSendMessageInTransaction(msg, timeout, xid, branchId));
+        assertThrows(
+                MQClientException.class, () -> seataMQProducer.doSendMessageInTransaction(msg, timeout, xid, branchId));
     }
 
     @Test


### PR DESCRIPTION

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Disallow messages with delay time levels in Seata transactions and add a corresponding test.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7351 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

