### PR TITLE
feature: Exclude the packaging of the namingserver module in the build workflow of JDK versions below 25.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           ./mvnw -T 4C clean test \
                  -Dpmd.skip=false -Dlicense.skip=false -DredisCaseEnabled=true -DnacosCaseEnabled=true \
+                 -Pskip-namingserver \
                  -e -B \
                  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
                  -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=info \
@@ -97,8 +98,14 @@ jobs:
       - name: "Test with Maven and Java${{ matrix.java }}"
         if: matrix.java != '8'
         run: |
-          ./mvnw -T 4C clean test \
-                 -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          if [ ${{ matrix.java }} -lt 25 ]; then
+            ./mvnw -T 4C clean test \
+                   -Pskip-namingserver \
+                   -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          else
+            ./mvnw -T 4C clean test \
+                   -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          fi
       # step 7
       - name: "Save local maven repository cache"
         uses: actions/cache/save@v4

--- a/namingserver/pom.xml
+++ b/namingserver/pom.xml
@@ -31,7 +31,7 @@
     <description>namingserver</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>25</java.version>
         <spring-boot-for-server.version>2.7.18</spring-boot-for-server.version>
         <spring-framework-for-server.version>5.3.39</spring-framework-for-server.version>
         <snakeyaml-for-server.version>2.0</snakeyaml-for-server.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,40 @@
     </dependencyManagement>
 
     <profiles>
+        <!-- profile: skip-namingserver -->
+        <profile>
+            <id>skip-namingserver</id>
+            <activation>
+                <jdk>(,25)</jdk>
+            </activation>
+            <modules>
+                <module>build</module>
+                <module>all</module>
+                <module>bom</module>
+                <module>common</module>
+                <module>config</module>
+                <module>console</module>
+                <module>core</module>
+                <module>compatible</module>
+                <module>dependencies</module>
+                <module>discovery</module>
+                <module>rm</module>
+                <module>rm-datasource</module>
+                <module>spring</module>
+                <module>tcc</module>
+                <module>mock-server</module>
+                <module>tm</module>
+                <module>metrics</module>
+                <module>serializer</module>
+                <module>seata-spring-boot-starter</module>
+                <module>seata-spring-autoconfigure</module>
+                <module>compressor</module>
+                <module>saga</module>
+                <module>sqlparser</module>
+                <module>server</module>
+                <module>integration-tx-api</module>
+            </modules>
+        </profile>
         <!-- profile: licenseCheck -->
         <profile>
             <id>licenseCheck</id>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Exclude the packaging of the namingserver module in the build workflow of JDK versions below 25.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

