### PR TITLE
feature: Exclude namingserver and console module builds from build workflows with JDK versions less than 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
                  -e -B \
                  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
                  -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=info \
+                 -pl '!namingserver' -am \
                  2>&1 | tee build.log | while read line; do
                    echo "$line"
                    if [[ "$line" == *"PMD Failure"* ]]; then
@@ -97,8 +98,14 @@ jobs:
       - name: "Test with Maven and Java${{ matrix.java }}"
         if: matrix.java != '8'
         run: |
-          ./mvnw -T 4C clean test \
-                 -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          if [ ${{ matrix.java }} -lt 25 ]; then
+            ./mvnw -T 4C clean test \
+                   -pl '!namingserver' -am \
+                   -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          else
+            ./mvnw -T 4C clean test \
+                    -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          fi
       # step 7
       - name: "Save local maven repository cache"
         uses: actions/cache/save@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
                  -e -B \
                  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
                  -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=info \
-                 -pl '!namingserver' -am \
+                 -pl '!namingserver,!console' -am \
                  2>&1 | tee build.log | while read line; do
                    echo "$line"
                    if [[ "$line" == *"PMD Failure"* ]]; then
@@ -100,7 +100,7 @@ jobs:
         run: |
           if [ ${{ matrix.java }} -lt 25 ]; then
             ./mvnw -T 4C clean test \
-                   -pl '!namingserver' -am \
+                   -pl '!namingserver,!console' -am \
                    -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           else
             ./mvnw -T 4C clean test \


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Exclude namingserver and console builds from build workflows with JDK versions less than 25，prepare for the subsequent JDK upgrades of the namingserver and console modules

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

