### PR TITLE
test:add unit tests for seata-spring-boot-starter module

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -32,6 +32,7 @@ Add changes here for all PR submitted to the develop branch.
 
 ### test:
 - [[#6151](https://github.com/seata/seata/pull/6151)] add test for `MacOS` and `Windows`
+- [[#7875](https://github.com/apache/incubator-seata/pull/7875)] add unit tests for seata-spring-boot-starter module
 
 Thanks to these contributors for their code commits. Please report an unintended omission.
 
@@ -45,5 +46,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [wuwen5](https://github.com/wuwen5)
 - [caohdgege](https://github.com/caohdgege)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [NiMv1](https://github.com/NiMv1)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationTest.java
+++ b/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.boot.autoconfigure;
+
+import io.seata.tm.api.DefaultFailureHandlerImpl;
+import io.seata.tm.api.FailureHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SeataAutoConfiguration}.
+ */
+class SeataAutoConfigurationTest {
+
+    @Test
+    void testFailureHandlerCreation() {
+        SeataAutoConfiguration config = new SeataAutoConfiguration();
+        FailureHandler handler = config.failureHandler();
+        
+        assertNotNull(handler);
+        assertTrue(handler instanceof DefaultFailureHandlerImpl);
+    }
+
+    @Test
+    void testFailureHandlerIsDefaultImpl() {
+        SeataAutoConfiguration config = new SeataAutoConfiguration();
+        FailureHandler handler = config.failureHandler();
+        
+        assertEquals(DefaultFailureHandlerImpl.class, handler.getClass());
+    }
+}

--- a/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/StarterConstantsTest.java
+++ b/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/StarterConstantsTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.boot.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StarterConstants}.
+ */
+class StarterConstantsTest {
+
+    @Test
+    void testSeataPrefixConstant() {
+        assertEquals("seata", StarterConstants.SEATA_PREFIX);
+    }
+
+    @Test
+    void testPropertyBeanMapConstant() {
+        assertNotNull(StarterConstants.PROPERTY_BEAN_MAP);
+    }
+
+    @Test
+    void testServicePrefixConstant() {
+        assertEquals("seata.service", StarterConstants.SERVICE_PREFIX);
+    }
+
+    @Test
+    void testClientPrefixConstant() {
+        assertEquals("seata.client", StarterConstants.CLIENT_PREFIX);
+    }
+
+    @Test
+    void testTransportPrefixConstant() {
+        assertEquals("seata.transport", StarterConstants.TRANSPORT_PREFIX);
+    }
+
+    @Test
+    void testConfigPrefixConstant() {
+        assertEquals("seata.config", StarterConstants.CONFIG_PREFIX);
+    }
+
+    @Test
+    void testRegistryPrefixConstant() {
+        assertEquals("seata.registry", StarterConstants.REGISTRY_PREFIX);
+    }
+}


### PR DESCRIPTION
Closes #6505 - Added unit tests for SeataAutoConfiguration and StarterConstants to improve test coverage of seata-spring-boot-starter module