### PR TITLE
test: add unit tests for ConnectionContext class (#1714)

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -32,6 +32,7 @@ Add changes here for all PR submitted to the develop branch.
 
 ### test:
 - [[#6151](https://github.com/seata/seata/pull/6151)] add test for `MacOS` and `Windows`
+- [[#7898](https://github.com/apache/incubator-seata/pull/7898)] add unit tests for ConnectionContext class in rm-datasource module
 
 Thanks to these contributors for their code commits. Please report an unintended omission.
 
@@ -45,5 +46,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [wuwen5](https://github.com/wuwen5)
 - [caohdgege](https://github.com/caohdgege)
 - [xingfudeshi](https://github.com/xingfudeshi)
+- [NiMv1](https://github.com/NiMv1)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/ConnectionContextTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/ConnectionContextTest.java
@@ -1,0 +1,266 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.sqlparser.SQLType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ConnectionContext}.
+ *
+ * @author NiMv1
+ */
+public class ConnectionContextTest {
+
+    private ConnectionContext connectionContext;
+
+    @BeforeEach
+    public void setUp() {
+        connectionContext = new ConnectionContext();
+    }
+
+    @Test
+    public void testInGlobalTransactionReturnsFalseWhenXidIsNull() {
+        assertFalse(connectionContext.inGlobalTransaction());
+    }
+
+    @Test
+    public void testInGlobalTransactionReturnsTrueWhenXidIsSet() {
+        connectionContext.setXid("test-xid-123");
+        assertTrue(connectionContext.inGlobalTransaction());
+    }
+
+    @Test
+    public void testIsBranchRegisteredReturnsFalseWhenBranchIdIsNull() {
+        assertFalse(connectionContext.isBranchRegistered());
+    }
+
+    @Test
+    public void testIsBranchRegisteredReturnsTrueWhenBranchIdIsSet() {
+        connectionContext.setBranchId(12345L);
+        assertTrue(connectionContext.isBranchRegistered());
+    }
+
+    @Test
+    public void testBindThrowsExceptionWhenXidIsNull() {
+        assertThrows(IllegalArgumentException.class, () -> connectionContext.bind(null));
+    }
+
+    @Test
+    public void testBindSetsXidWhenNotInGlobalTransaction() {
+        connectionContext.bind("test-xid-456");
+        assertEquals("test-xid-456", connectionContext.getXid());
+    }
+
+    @Test
+    public void testBindThrowsExceptionWhenBindingDifferentXid() {
+        connectionContext.bind("xid-1");
+        assertThrows(ShouldNeverHappenException.class, () -> connectionContext.bind("xid-2"));
+    }
+
+    @Test
+    public void testBindSucceedsWhenBindingSameXid() {
+        connectionContext.bind("same-xid");
+        connectionContext.bind("same-xid");
+        assertEquals("same-xid", connectionContext.getXid());
+    }
+
+    @Test
+    public void testHasUndoLogReturnsFalseWhenEmpty() {
+        assertFalse(connectionContext.hasUndoLog());
+    }
+
+    @Test
+    public void testHasUndoLogReturnsTrueWhenUndoLogAppended() {
+        SQLUndoLog undoLog = new SQLUndoLog();
+        undoLog.setSqlType(SQLType.INSERT);
+        undoLog.setTableName("test_table");
+        connectionContext.appendUndoItem(undoLog);
+        assertTrue(connectionContext.hasUndoLog());
+    }
+
+    @Test
+    public void testHasLockKeyReturnsFalseWhenEmpty() {
+        assertFalse(connectionContext.hasLockKey());
+    }
+
+    @Test
+    public void testHasLockKeyReturnsTrueWhenLockKeyAppended() {
+        connectionContext.appendLockKey("test_table:1");
+        assertTrue(connectionContext.hasLockKey());
+    }
+
+    @Test
+    public void testBuildLockKeysReturnsNullWhenEmpty() {
+        assertNull(connectionContext.buildLockKeys());
+    }
+
+    @Test
+    public void testBuildLockKeysReturnsConcatenatedKeys() {
+        connectionContext.appendLockKey("table1:1");
+        connectionContext.appendLockKey("table1:2");
+        String lockKeys = connectionContext.buildLockKeys();
+        assertNotNull(lockKeys);
+        assertTrue(lockKeys.contains("table1:1"));
+        assertTrue(lockKeys.contains("table1:2"));
+    }
+
+    @Test
+    public void testGetUndoItemsReturnsEmptyListWhenNoItems() {
+        assertTrue(connectionContext.getUndoItems().isEmpty());
+    }
+
+    @Test
+    public void testGetUndoItemsReturnsAppendedItems() {
+        SQLUndoLog undoLog1 = new SQLUndoLog();
+        undoLog1.setSqlType(SQLType.INSERT);
+        undoLog1.setTableName("table1");
+
+        SQLUndoLog undoLog2 = new SQLUndoLog();
+        undoLog2.setSqlType(SQLType.UPDATE);
+        undoLog2.setTableName("table2");
+
+        connectionContext.appendUndoItem(undoLog1);
+        connectionContext.appendUndoItem(undoLog2);
+
+        assertEquals(2, connectionContext.getUndoItems().size());
+    }
+
+    @Test
+    public void testResetClearsAllState() {
+        connectionContext.setXid("test-xid");
+        connectionContext.setBranchId(123L);
+        connectionContext.setGlobalLockRequire(true);
+        connectionContext.appendLockKey("table:1");
+
+        SQLUndoLog undoLog = new SQLUndoLog();
+        undoLog.setSqlType(SQLType.INSERT);
+        connectionContext.appendUndoItem(undoLog);
+
+        connectionContext.reset();
+
+        assertNull(connectionContext.getXid());
+        assertNull(connectionContext.getBranchId());
+        assertFalse(connectionContext.isGlobalLockRequire());
+        assertFalse(connectionContext.hasLockKey());
+        assertFalse(connectionContext.hasUndoLog());
+    }
+
+    @Test
+    public void testResetWithXidSetsNewXid() {
+        connectionContext.setXid("old-xid");
+        connectionContext.reset("new-xid");
+        assertEquals("new-xid", connectionContext.getXid());
+    }
+
+    @Test
+    public void testAutoCommitChangedDefaultIsFalse() {
+        assertFalse(connectionContext.isAutoCommitChanged());
+    }
+
+    @Test
+    public void testSetAutoCommitChanged() {
+        connectionContext.setAutoCommitChanged(true);
+        assertTrue(connectionContext.isAutoCommitChanged());
+    }
+
+    @Test
+    public void testGlobalLockRequireDefaultIsFalse() {
+        assertFalse(connectionContext.isGlobalLockRequire());
+    }
+
+    @Test
+    public void testSetGlobalLockRequire() {
+        connectionContext.setGlobalLockRequire(true);
+        assertTrue(connectionContext.isGlobalLockRequire());
+    }
+
+    @Test
+    public void testAppendSavepointAndRemove() throws SQLException {
+        Savepoint savepoint = createSavepoint("sp1");
+        connectionContext.appendSavepoint(savepoint);
+        connectionContext.appendLockKey("table:1");
+
+        assertTrue(connectionContext.hasLockKey());
+
+        connectionContext.removeSavepoint(savepoint);
+        assertFalse(connectionContext.hasLockKey());
+    }
+
+    @Test
+    public void testReleaseSavepointMovesDataToCurrentSavepoint() throws SQLException {
+        Savepoint sp1 = createSavepoint("sp1");
+        connectionContext.appendSavepoint(sp1);
+        connectionContext.appendLockKey("table:1");
+
+        Savepoint sp2 = createSavepoint("sp2");
+        connectionContext.appendSavepoint(sp2);
+        connectionContext.appendLockKey("table:2");
+
+        connectionContext.releaseSavepoint(sp1);
+
+        assertTrue(connectionContext.hasLockKey());
+        String lockKeys = connectionContext.buildLockKeys();
+        assertTrue(lockKeys.contains("table:1"));
+        assertTrue(lockKeys.contains("table:2"));
+    }
+
+    @Test
+    public void testRemoveSavepointWithNullClearsAll() {
+        connectionContext.appendLockKey("table:1");
+
+        SQLUndoLog undoLog = new SQLUndoLog();
+        undoLog.setSqlType(SQLType.INSERT);
+        connectionContext.appendUndoItem(undoLog);
+
+        connectionContext.removeSavepoint(null);
+
+        assertFalse(connectionContext.hasLockKey());
+        assertFalse(connectionContext.hasUndoLog());
+    }
+
+    @Test
+    public void testToStringReturnsNonNull() {
+        assertNotNull(connectionContext.toString());
+    }
+
+    private Savepoint createSavepoint(String name) {
+        return new Savepoint() {
+            @Override
+            public int getSavepointId() throws SQLException {
+                return name.hashCode();
+            }
+
+            @Override
+            public String getSavepointName() throws SQLException {
+                return name;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds comprehensive unit tests for the ConnectionContext class in the rm-datasource module to improve test coverage as requested in #1714.

## About Apache Seata

**Apache Seata** is a distributed transaction solution for microservices architecture. It provides:
- **AT Mode** - Automatic transaction management with undo logs
- **TCC Mode** - Try-Confirm-Cancel pattern
- **SAGA Mode** - Long-running transactions
- **XA Mode** - Standard XA protocol support

**Use cases:** E-commerce, financial services, any system requiring data consistency across multiple databases/services.

**Future:** Cloud-native integration, better performance, more database support.

## Brief changelog

- Add ConnectionContextTest.java with 26 unit tests covering:
  - Transaction state management (inGlobalTransaction, isBranchRegistered)
  - XID binding with validation
  - Lock key operations (ppendLockKey, uildLockKeys)
  - Undo log operations (ppendUndoItem, getUndoItems)
  - Savepoint management (ppendSavepoint, emoveSavepoint, eleaseSavepoint)
  - State reset functionality
  - Auto-commit and global lock flags

## Checklist

- [x] Make sure there is a [GitHub issue](https://github.com/apache/incubator-seata/issues) filed for the change
- [x] The title of the pull request should follow the format: 	ype: description (#issue_number)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Necessary labels have been added (for bug fixes / features)
