### PR TITLE
test: fixes CI errors caused by timing issues in ZkConfigurationTest

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -156,6 +156,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] Fix non-deteriministic in TableMetaTest#testGetPrimaryKeyOnlyName
 - [[#7859](https://github.com/apache/incubator-seata/pull/7859)] Fix flaky tests in MetadataTest caused by shared state and brittle toString assertions
 - [[#7858](https://github.com/apache/incubator-seata/pull/7858)] Fix flakiness in HttpTest.convertParamOfJsonStringTest caused by non-deterministic Map iteration order
+- [[#7907](https://github.com/apache/incubator-seata/pull/7907)] test: fixes CI errors caused by timing issues in ZkConfigurationTest
 
 
 ### refactor:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -156,6 +156,7 @@
 - [[#7827](https://github.com/apache/incubator-seata/pull/7827)] 修复 TableMetaTest 中因主键名称列表顺序不稳定导致的单测间歇性失败问题
 - [[#7859](https://github.com/apache/incubator-seata/pull/7859)] 修复 `MetadataTest` 因共享状态与依赖 `toString()` 输出不稳定导致的测试用例间歇性失败问题
 - [[#7858](https://github.com/apache/incubator-seata/pull/7858)] 修复 `HttpTest.convertParamOfJsonStringTest` 因 Map 遍历顺序不确定导致的测试用例间歇性失败问题
+- [[#7907](https://github.com/apache/incubator-seata/pull/7907)] test: 修复ZkConfigurationTest的时序问题导致的ci错误
 
 
 ### refactor:

--- a/config/seata-config-zk/src/test/java/org/apache/seata/config/zk/ZkConfigurationTest.java
+++ b/config/seata-config-zk/src/test/java/org/apache/seata/config/zk/ZkConfigurationTest.java
@@ -93,6 +93,12 @@ public class ZkConfigurationTest {
         };
         zookeeperConfiguration.createPersistent(zookeeperConfiguration.buildPath(dataId), "value");
         zookeeperConfiguration.addConfigListener(dataId, changeListener);
+        // Wait for listener to be fully registered
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         zookeeperConfiguration.putConfig(dataId, "value2");
         try {
             countDownLatch.await(10000, TimeUnit.MILLISECONDS);
@@ -128,6 +134,12 @@ public class ZkConfigurationTest {
 
         zookeeperConfiguration.addConfigListener(dataId, changeListener);
         zookeeperConfiguration.putConfig(dataId, "value2");
+        // Wait for listener to be fully registered
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         boolean remove = zookeeperConfiguration.removeConfig(dataId);
         Assertions.assertTrue(remove);
         try {


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
The code here likely has a timing issue. The test code executes the configuration change operation immediately after calling addConfigListener, and the listener may miss the event notification before it is fully registered. In a CI environment, this timing issue may occur intermittently due to changes in system load.

```java
zookeeperConfiguration.addConfigListener(dataId, changeListener);
zookeeperConfiguration.putConfig(dataId, "value2");
```
I solved this problem by increasing the wait time. A 200-millisecond wait time is sufficient for Zookeeper to complete the listener registration, preventing the timing issue from occurring. I also correctly handled the interruption exception using `Thread.currentThread().interrupt()`.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7890 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

