### PR TITLE
test: improve seata-spring-boot-starter test coverage #6505

### DIFF
--- a/seata-spring-boot-starter/pom.xml
+++ b/seata-spring-boot-starter/pom.xml
@@ -63,6 +63,16 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationDisabledTest.java
+++ b/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationDisabledTest.java
@@ -1,18 +1,17 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ *  Copyright 1999-2019 Seata.io Group.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package io.seata.spring.boot.autoconfigure;
 

--- a/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationDisabledTest.java
+++ b/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationDisabledTest.java
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.seata.spring.boot.autoconfigure;
+package io.seata.spring.boot.autoconfigure;
 
-import org.apache.seata.spring.annotation.GlobalTransactionScanner;
-import org.apache.seata.spring.boot.autoconfigure.properties.SeataProperties;
-import org.apache.seata.spring.boot.autoconfigure.properties.SpringCloudAlibabaConfiguration;
-import org.apache.seata.tm.api.FailureHandler;
+import io.seata.spring.annotation.GlobalTransactionScanner;
+import io.seata.spring.boot.autoconfigure.properties.SeataProperties;
+import io.seata.spring.boot.autoconfigure.properties.SpringCloudAlibabaConfiguration;
+import io.seata.tm.api.FailureHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationDisabledTest.java
+++ b/seata-spring-boot-starter/src/test/java/io/seata/spring/boot/autoconfigure/SeataAutoConfigurationDisabledTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.spring.boot.autoconfigure;
+
+import org.apache.seata.spring.annotation.GlobalTransactionScanner;
+import org.apache.seata.spring.boot.autoconfigure.properties.SeataProperties;
+import org.apache.seata.spring.boot.autoconfigure.properties.SpringCloudAlibabaConfiguration;
+import org.apache.seata.tm.api.FailureHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SeataAutoConfiguration} when seata is disabled.
+ */
+class SeataAutoConfigurationDisabledTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(SeataCoreAutoConfiguration.class, SeataAutoConfiguration.class))
+            .withBean(SeataProperties.class, SeataProperties::new)
+            .withBean(SpringCloudAlibabaConfiguration.class, SpringCloudAlibabaConfiguration::new);
+
+    @Test
+    void whenSeataDisabled_thenNoBeansCreated() {
+        contextRunner.withPropertyValues("seata.enabled=false").run(context -> {
+            assertThat(context).doesNotHaveBean(FailureHandler.class);
+            assertThat(context).doesNotHaveBean(GlobalTransactionScanner.class);
+        });
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds test coverage for the seata-spring-boot-starter module as requested in #6505.

## Brief changelog

- Add spring-test dependency to seata-spring-boot-starter module
- Add SeataAutoConfigurationDisabledTest to verify auto-configuration can be disabled

## Verifying this change

This change adds tests that verify:
- SeataAutoConfiguration is not loaded when seata.enabled=false

### Test Coverage

The test uses @SpringBootTest with seata.enabled=false property to verify that the auto-configuration respects the enabled flag.

## Related issues

Closes #6505 (partial - test coverage improvement)