### PR TITLE
bugfix: empty jacoco report on local when jdk above 17

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -29,6 +29,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7929](https://github.com/apache/incubator-seata/pull/7929)] fix KingbaseUndoLogManager INSERT_UNDO_LOG_SQL error
 - [[#7940](https://github.com/apache/incubator-seata/pull/7940)] ensure the Jakarta-related package paths are correct
 - [[#7960](https://github.com/apache/incubator-seata/pull/7960)] fix consoleApiService bean that could not be found
+- [[#7956](https://github.com/apache/incubator-seata/pull/7956)] fix empty jacoco report on local when jdk above 17
 
 
 ### optimize:
@@ -64,6 +65,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [maple525866](https://github.com/maple525866)
 - [neronsoda](https://github.com/neronsoda)
 - [aias00](https://github.com/Aias00)
-
+- [sddtc](https://github.com/sddtc)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -29,6 +29,7 @@
 - [[#7929](https://github.com/apache/incubator-seata/pull/7929)] 修复 KingbaseUndoLogManager INSERT_UNDO_LOG_SQL 错误
 - [[#7940](https://github.com/apache/incubator-seata/pull/7940)] 保证Jakarta相关包路径正确
 - [[#7960](https://github.com/apache/incubator-seata/pull/7960)] 修复consoleApiService bean未加载的问题
+- [[#7956](https://github.com/apache/incubator-seata/pull/7956)] 修复本地JDK17以上jacoco报告为空的问题
 
 ### optimize:
 
@@ -63,5 +64,6 @@
 - [maple525866](https://github.com/maple525866)
 - [neronsoda](https://github.com/neronsoda)
 - [aias00](https://github.com/Aias00)
+- [sddtc](https://github.com/sddtc)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <argLine>${maven.surefire.argLine}</argLine>
+                    <argLine>@{argLine} ${maven.surefire.argLine}</argLine>
                     <excludes>${maven.surefire.excludes}</excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
my env:
```
Maven home: /usr/local/Cellar/maven/3.9.12/libexec
Java version: 25.0.1, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk/25.0.1/libexec/openjdk.jdk/Contents/Home
Default locale: en_CN, platform encoding: UTF-8
OS name: "mac os x", version: "26.2", arch: "x86_64", family: "mac"
```

**No impact when JDK version under 17 with `@{argLine}`**, because the root cause is the profile `args-for-test-by-jdk17-and-above` will overwrited the default argLine. and the solution is append customized argLine.


Currently, when run 
```shell
# generate jacoco report for common module with its dependencies module
mvn clean test -pl common -am -X
```
the value of `argLine`:

<img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/115b7fd0-2606-4746-b5cf-d9ebe0429cee" />

then the resolved argLine in the forking command line:

<img width="1200" height="486" alt="image" src="https://github.com/user-attachments/assets/c3dfb44a-3e95-49ed-8773-1e00223a6885" />

⚠️ missing the **default argLine** of `maven-surefire-plugin`, so the report won't be generated `jacoco` folder under `target/site` folder:

<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/9140e190-9438-4569-bc21-fc5d561302b4" />

After adding `@{argLine}` and run `mvn clean test -pl common -am -X` again, the `@{argLine}` will be passed as a placeholder:

<img width="3568" height="864" alt="image" src="https://github.com/user-attachments/assets/dad7ac92-5353-4d07-ac90-6edfe343463e" />

then the `@{argLine}` will be resolved in the forking command line:

<img width="1200" height="548" alt="image" src="https://github.com/user-attachments/assets/4f965c98-37b0-416b-8f61-3dc856cebc45" />

🍏 the default args `-javaagent xxx`(the green box above) will be added when the command ran. and customised args will be **append** after `-javaagent xxx`. the jacoco report will be generated as well:

<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/d394bbe4-ec16-4006-9dbd-fe5195af5399" />


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
Nope.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
no additional code wrote; It focus on fixing empty jacoco report for any modules when JDK version above 17; 

### Ⅳ. Describe how to verify it
run 
```shell
# generate jacoco report for common module with its dependencies module
# fast, only run common module test cases
mvn clean test -pl common -am -X
# slow command, it will run all the test cases
mvn clean test
```
and the jacoco report will be generated successfully under `common/target/site` folder and the coverage is correct.

### Ⅴ. Special notes for reviews
the `maven-surefire-plugin` version in the repo: 
`<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>`

https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine
> Since the Version 2.17 using an alternate syntax for argLine, @{...} allows late replacement of properties when the plugin is executed, so properties that have been modified by other plugins will be picked up correctly. 

