### PR TITLE
bugfix: consoleApiService that could not be found

### DIFF
--- a/changes/en-us/2.6.0.md
+++ b/changes/en-us/2.6.0.md
@@ -74,6 +74,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7891](https://github.com/apache/incubator-seata/pull/7891)] raft split-brain causes incorrect cluster information
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] handle timestamp with time zone in postgresql primary key
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] ensure the Jakarta-related package paths are correct.
+- [[#7959](https://github.com/apache/incubator-seata/pull/7959)] consoleApiService that could not be found
 
 
 ### optimize:

--- a/changes/en-us/2.6.0.md
+++ b/changes/en-us/2.6.0.md
@@ -74,7 +74,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7891](https://github.com/apache/incubator-seata/pull/7891)] raft split-brain causes incorrect cluster information
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] handle timestamp with time zone in postgresql primary key
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] ensure the Jakarta-related package paths are correct.
-- [[#7959](https://github.com/apache/incubator-seata/pull/7959)] consoleApiService that could not be found
+- [[#7959](https://github.com/apache/incubator-seata/pull/7959)] fix consoleApiService bean that could not be found
 
 
 ### optimize:

--- a/changes/zh-cn/2.6.0.md
+++ b/changes/zh-cn/2.6.0.md
@@ -74,6 +74,7 @@
 - [[#7891](https://github.com/apache/incubator-seata/pull/7891)] 修复raft重选举与心跳并发时可能导致namingserver侧的元数据存在多个leader
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] 在 PostgreSQL 主键中处理带时区的时间戳
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] 保证Jakarta相关包路径正确
+- [[#7959](https://github.com/apache/incubator-seata/pull/7959)] 修复consoleApiService bean未加载的问题
 
 
 ### optimize:

--- a/console/src/main/java/org/apache/seata/mcp/service/impl/ConsoleRemoteServiceImpl.java
+++ b/console/src/main/java/org/apache/seata/mcp/service/impl/ConsoleRemoteServiceImpl.java
@@ -17,7 +17,6 @@
 package org.apache.seata.mcp.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.seata.common.NamingServerLocalMarker;
 import org.apache.seata.common.exception.AuthenticationFailedException;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.console.config.WebSecurityConfig;
@@ -44,7 +43,7 @@ import java.util.Map;
 import static org.apache.seata.mcp.core.utils.UrlUtils.buildUrl;
 import static org.apache.seata.mcp.core.utils.UrlUtils.objectToQueryParamMap;
 
-@ConditionalOnMissingBean(NamingServerLocalMarker.class)
+@ConditionalOnMissingBean(name = "consoleLocalServiceImpl")
 @Service
 public class ConsoleRemoteServiceImpl implements ConsoleApiService {
 
@@ -65,6 +64,7 @@ public class ConsoleRemoteServiceImpl implements ConsoleApiService {
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
         this.namingServerProperties = namingServerProperties;
+        logger.info("ConsoleRemoteServiceImpl initialized.");
     }
 
     private final Logger logger = LoggerFactory.getLogger(ConsoleRemoteServiceImpl.class);

--- a/console/src/main/java/org/apache/seata/mcp/service/impl/ConsoleRemoteServiceImpl.java
+++ b/console/src/main/java/org/apache/seata/mcp/service/impl/ConsoleRemoteServiceImpl.java
@@ -47,6 +47,8 @@ import static org.apache.seata.mcp.core.utils.UrlUtils.objectToQueryParamMap;
 @Service
 public class ConsoleRemoteServiceImpl implements ConsoleApiService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleRemoteServiceImpl.class);
+
     private final JwtTokenUtils jwtTokenUtils;
 
     private final RestTemplate restTemplate;
@@ -64,10 +66,8 @@ public class ConsoleRemoteServiceImpl implements ConsoleApiService {
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
         this.namingServerProperties = namingServerProperties;
-        logger.info("ConsoleRemoteServiceImpl initialized.");
+        LOGGER.info("ConsoleRemoteServiceImpl initialized.");
     }
-
-    private final Logger logger = LoggerFactory.getLogger(ConsoleRemoteServiceImpl.class);
 
     public String getToken() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -111,13 +111,13 @@ public class ConsoleRemoteServiceImpl implements ConsoleApiService {
                 String errorMsg = String.format(
                         "MCP GET request failed with status: %s, response: %s",
                         response.getStatusCode(), response.getBody());
-                logger.warn(errorMsg);
+                LOGGER.warn(errorMsg);
                 throw new ServiceCallException(errorMsg, response.getStatusCode());
             }
             return responseBody;
         } catch (RestClientException e) {
             String errorMsg = "MCP GET Call NameSpace Failed.";
-            logger.error(errorMsg, e);
+            LOGGER.error(errorMsg, e);
             throw new ServiceCallException(errorMsg);
         }
     }
@@ -151,13 +151,13 @@ public class ConsoleRemoteServiceImpl implements ConsoleApiService {
                 String errorMsg = String.format(
                         "MCP GET request failed with status: %s, response: %s",
                         response.getStatusCode(), response.getBody());
-                logger.warn(errorMsg);
+                LOGGER.warn(errorMsg);
                 throw new ServiceCallException(errorMsg, response.getStatusCode());
             }
             return responseBody;
         } catch (RestClientException e) {
             String errorMsg = "MCP GET Call TC Failed.";
-            logger.error(errorMsg, e);
+            LOGGER.error(errorMsg, e);
             throw new ServiceCallException(errorMsg);
         }
     }
@@ -191,13 +191,13 @@ public class ConsoleRemoteServiceImpl implements ConsoleApiService {
                 String errorMsg = String.format(
                         "MCP DELETE request returned non-success status: %s, response: %s",
                         response.getStatusCode(), response.getBody());
-                logger.warn(errorMsg);
+                LOGGER.warn(errorMsg);
                 throw new ServiceCallException(errorMsg, response.getStatusCode());
             }
             return responseBody;
         } catch (RestClientException e) {
             String errorMsg = "MCP DELETE Call TC Failed.";
-            logger.error(errorMsg, e);
+            LOGGER.error(errorMsg, e);
             throw new ServiceCallException(errorMsg);
         }
     }
@@ -231,13 +231,13 @@ public class ConsoleRemoteServiceImpl implements ConsoleApiService {
                 String errorMsg = String.format(
                         "MCP PUT request returned non-success status: %s, response: %s",
                         response.getStatusCode(), response.getBody());
-                logger.warn(errorMsg);
+                LOGGER.warn(errorMsg);
                 throw new ServiceCallException(errorMsg, response.getStatusCode());
             }
             return responseBody;
         } catch (RestClientException e) {
             String errorMsg = "MCP PUT Call TC Failed.";
-            logger.error(errorMsg, e);
+            LOGGER.error(errorMsg, e);
             throw new ServiceCallException(errorMsg);
         }
     }

--- a/namingserver/src/main/java/org/apache/seata/namingserver/service/ConsoleLocalServiceImpl.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/service/ConsoleLocalServiceImpl.java
@@ -52,7 +52,7 @@ import static org.apache.seata.mcp.core.utils.UrlUtils.objectToQueryParamMap;
 @Service
 public class ConsoleLocalServiceImpl implements ConsoleApiService {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleLocalServiceImpl.class);
 
     private final NamingManager namingManager;
 
@@ -64,7 +64,7 @@ public class ConsoleLocalServiceImpl implements ConsoleApiService {
         this.namingManager = namingManager;
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
-        logger.info("ConsoleLocalServiceImpl initialized.");
+        LOGGER.info("ConsoleLocalServiceImpl initialized.");
     }
 
     public String getResult(
@@ -109,13 +109,13 @@ public class ConsoleLocalServiceImpl implements ConsoleApiService {
                             String errorMsg = String.format(
                                     "MCP request failed with status: %s, response: %s",
                                     response.getStatusCode(), response.getBody());
-                            logger.warn(errorMsg);
+                            LOGGER.warn(errorMsg);
                             throw new ServiceCallException(errorMsg, response.getStatusCode());
                         }
                         return responseBody;
                     } catch (RestClientException e) {
                         String errorMsg = "MCP Call TC Failed.";
-                        logger.error(errorMsg, e);
+                        LOGGER.error(errorMsg, e);
                         throw new ServiceCallException(errorMsg);
                     }
                 }
@@ -161,7 +161,7 @@ public class ConsoleLocalServiceImpl implements ConsoleApiService {
         try {
             namespace = objectMapper.writeValueAsString(namingManager.namespace());
         } catch (JsonProcessingException e) {
-            logger.error("Get NameSpace failed: {}", e.getMessage());
+            LOGGER.error("Get NameSpace failed: {}", e.getMessage());
             return "Failed to get namespace";
         }
         return namespace;

--- a/namingserver/src/main/java/org/apache/seata/namingserver/service/ConsoleLocalServiceImpl.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/service/ConsoleLocalServiceImpl.java
@@ -26,7 +26,6 @@ import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.mcp.core.props.NameSpaceDetail;
 import org.apache.seata.mcp.exception.ServiceCallException;
 import org.apache.seata.mcp.service.ConsoleApiService;
-import org.apache.seata.mcp.service.impl.ConsoleRemoteServiceImpl;
 import org.apache.seata.namingserver.manager.NamingManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +47,7 @@ import static org.apache.seata.common.Constants.RAFT_GROUP_HEADER;
 import static org.apache.seata.mcp.core.utils.UrlUtils.buildUrl;
 import static org.apache.seata.mcp.core.utils.UrlUtils.objectToQueryParamMap;
 
-@ConditionalOnBean(ConsoleRemoteServiceImpl.class)
+@ConditionalOnBean(NamingServerLocalMarkerImpl.class)
 @Primary
 @Service
 public class ConsoleLocalServiceImpl implements ConsoleApiService {
@@ -65,6 +64,7 @@ public class ConsoleLocalServiceImpl implements ConsoleApiService {
         this.namingManager = namingManager;
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
+        logger.info("ConsoleLocalServiceImpl initialized.");
     }
 
     public String getResult(


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
```
2026-01-25 17:27:11.915  INFO --- [main] [org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext] [prepareWebApplicationContext] []: Root WebApplicationContext: initialization completed in 790 ms
2026-01-25 17:27:12.097  INFO --- [main] [org.apache.seata.console.security.CustomUserDetailsServiceImpl] [init] []: No password was configured. A random password has been generated for security purposes. You may either:
1. Use the auto-generated password: [a79a0b20]
2. Set a custom password in the configuration.
2026-01-25 17:27:12.336  INFO --- [main] [org.apache.seata.namingserver.service.ConsoleLocalServiceImpl] [<init>] []: ConsoleLocalServiceImpl initialized.
2026-01-25 17:27:12.395  INFO --- [main] [org.springframework.boot.autoconfigure.web.servlet.WelcomePageHandlerMapping] [<init>] []: Adding welcome page: class path resource [static/index.html]
2026-01-25 17:27:12.519  INFO --- [main] [org.springframework.security.config.annotation.authentication.configuration.InitializeAuthenticationProviderBeanManagerConfigurer$InitializeAuthenticationProviderManagerConfigurer] [configure] []: Global AuthenticationManager configured with AuthenticationProvider bean with name customAuthenticationProvider
2026-01-25 17:27:12.519  WARN --- [main] [org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer$InitializeUserDetailsManagerConfigurer] [configure] []: Global AuthenticationManager configured with an AuthenticationProvider bean. UserDetailsService beans will not be used by Spring Security for automatically configuring username/password login. Consider removing the AuthenticationProvider bean. Alternatively, consider using the UserDetailsService in a manually instantiated DaoAuthenticationProvider. If the current configuration is intentional, to turn off this warning, increase the logging level of 'org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer' to ERROR
2026-01-25 17:27:12.772  INFO --- [main] [org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration] [info] []: Enable tools capabilities, notification: true
2026-01-25 17:27:12.772  INFO --- [main] [org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration] [info] []: Registered tools: 15
2026-01-25 17:27:12.772  INFO --- [main] [org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration] [info] []: Enable resources capabilities, notification: true
2026-01-25 17:27:12.773  INFO --- [main] [org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration] [info] []: Enable resources templates capabilities, notification: true
2026-01-25 17:27:12.773  INFO --- [main] [org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration] [info] []: Enable prompts capabilities, notification: true
2026-01-25 17:27:12.774  INFO --- [main] [org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration] [info] []: Enable completions capabilities
2026-01-25 17:27:12.887  INFO --- [main] [org.apache.coyote.http11.Http11NioProtocol] [log] []: Starting ProtocolHandler ["http-nio-8081"]
2026-01-25 17:27:12.902  INFO --- [main] [org.springframework.boot.web.embedded.tomcat.TomcatWebServer] [start] []: Tomcat started on port 8081 (http) with context path '/'
2026-01-25 17:27:12.910  INFO --- [main] [org.apache.seata.namingserver.NamingserverApplication] [logStarted] []: Started NamingserverApplication in 2.428 seconds (process running for 2.7)
2026-01-25 17:27:12.912  INFO --- [main] [org.apache.seata.namingserver.NamingserverApplication] [run] []: Seata Console can be accessed at http://localhost:8081
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7958 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

