### PR TITLE
bugfix: different element order in two lists causes failure to set the index as primary key index

### DIFF
--- a/changes/en-us/2.6.0.md
+++ b/changes/en-us/2.6.0.md
@@ -75,6 +75,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] handle timestamp with time zone in postgresql primary key
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] ensure the Jakarta-related package paths are correct.
 - [[#7959](https://github.com/apache/incubator-seata/pull/7959)] fix consoleApiService bean that could not be found
+- [[#7965](https://github.com/apache/incubator-seata/pull/7965)] fix different element order in two lists causes failure to set the index as primary key index
 
 
 ### optimize:

--- a/changes/en-us/2.6.0.md
+++ b/changes/en-us/2.6.0.md
@@ -75,7 +75,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] handle timestamp with time zone in postgresql primary key
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] ensure the Jakarta-related package paths are correct.
 - [[#7959](https://github.com/apache/incubator-seata/pull/7959)] fix consoleApiService bean that could not be found
-- [[#7965](https://github.com/apache/incubator-seata/pull/7965)] fix different element order in two lists causes failure to set the index as primary key index
+- [[#7966](https://github.com/apache/incubator-seata/pull/7966)] fix different element order in two lists causes failure to set the index as primary key index
 
 
 ### optimize:

--- a/changes/zh-cn/2.6.0.md
+++ b/changes/zh-cn/2.6.0.md
@@ -75,7 +75,7 @@
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] 在 PostgreSQL 主键中处理带时区的时间戳
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] 保证Jakarta相关包路径正确
 - [[#7959](https://github.com/apache/incubator-seata/pull/7959)] 修复consoleApiService bean未加载的问题
-- [[#7966](https://github.com/apache/incubator-seata/pull/7966)] 修复dm和kingbase中当没有将索引设置为主键索引
+- [[#7966](https://github.com/apache/incubator-seata/pull/7966)] 修复dm和kingbase中因列顺序不同导致索引未被识别为主键索引的问题
 
 
 ### optimize:

--- a/changes/zh-cn/2.6.0.md
+++ b/changes/zh-cn/2.6.0.md
@@ -75,7 +75,7 @@
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] 在 PostgreSQL 主键中处理带时区的时间戳
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] 保证Jakarta相关包路径正确
 - [[#7959](https://github.com/apache/incubator-seata/pull/7959)] 修复consoleApiService bean未加载的问题
-- [[#7965](https://github.com/apache/incubator-seata/pull/7965)] 修复dm和kingbase中当没有将索引设置为主键索引
+- [[#7966](https://github.com/apache/incubator-seata/pull/7966)] 修复dm和kingbase中当没有将索引设置为主键索引
 
 
 ### optimize:

--- a/changes/zh-cn/2.6.0.md
+++ b/changes/zh-cn/2.6.0.md
@@ -75,6 +75,7 @@
 - [[#7908](https://github.com/apache/incubator-seata/pull/7908)] 在 PostgreSQL 主键中处理带时区的时间戳
 - [[#7938](https://github.com/apache/incubator-seata/pull/7938)] 保证Jakarta相关包路径正确
 - [[#7959](https://github.com/apache/incubator-seata/pull/7959)] 修复consoleApiService bean未加载的问题
+- [[#7965](https://github.com/apache/incubator-seata/pull/7965)] 修复dm和kingbase中当没有将索引设置为主键索引
 
 
 ### optimize:

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCache.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCache.java
@@ -28,8 +28,8 @@ import org.apache.seata.sqlparser.util.JdbcConstants;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -124,25 +124,44 @@ public class DmTableMetaCache extends OracleTableMetaCache {
     }
 
     protected void processPrimaries(TableMeta tableMeta, ResultSet rs) throws SQLException {
-        List<String> primaryKeyColumns = new ArrayList<>();
+        // Collect primary key column names that couldn't be matched directly by PK_NAME
+        Set<String> unmatchedPkColumns = new LinkedHashSet<>();
+
+        // Iterate through each row of getPrimaryKeys() result set
         while (rs.next()) {
-            String pkColName;
-            try {
-                pkColName = rs.getString("COLUMN_NAME");
-            } catch (Exception e) {
-                pkColName = rs.getString("PK_NAME");
+            String pkConstraintName = getStringSafely(rs, "PK_NAME");
+            String pkColName = getStringSafely(rs, "COLUMN_NAME");
+            if (StringUtils.isBlank(pkColName)) {
+                pkColName = pkConstraintName;
             }
-            primaryKeyColumns.add(pkColName);
+
+            // Strategy 1: Try direct match by PK constraint name
+            if (StringUtils.isNotBlank(pkConstraintName)
+                    && tableMeta.getAllIndexes().containsKey(pkConstraintName)) {
+                IndexMeta index = tableMeta.getAllIndexes().get(pkConstraintName);
+                index.setIndextype(IndexType.PRIMARY);
+            } else {
+                // Save columns for fallback column-based matching
+                if (StringUtils.isNotBlank(pkColName)) {
+                    unmatchedPkColumns.add(pkColName.toUpperCase());
+                }
+            }
         }
 
-        for (IndexMeta index : tableMeta.getAllIndexes().values()) {
-            List<String> indexColumns = index.getValues().stream()
-                    .filter(col -> col != null && StringUtils.isNotBlank(col.getColumnName()))
-                    .map(ColumnMeta::getColumnName)
-                    .collect(Collectors.toList());
+        // Strategy 2: fallback - match by column set equality (order-insensitive, deduped)
+        if (!unmatchedPkColumns.isEmpty()) {
+            for (IndexMeta index : tableMeta.getAllIndexes().values()) {
+                if (index.getIndextype().value() == IndexType.UNIQUE.value()) {
+                    Set<String> indexColsSet = index.getValues().stream()
+                            .filter(col -> col != null && StringUtils.isNotBlank(col.getColumnName()))
+                            .map(col -> col.getColumnName().toUpperCase())
+                            .collect(Collectors.toSet());
 
-            if (indexColumns.equals(primaryKeyColumns)) {
-                index.setIndextype(IndexType.PRIMARY);
+                    if (indexColsSet.equals(unmatchedPkColumns)) {
+                        index.setIndextype(IndexType.PRIMARY);
+                        break;
+                    }
+                }
             }
         }
     }
@@ -185,5 +204,13 @@ public class DmTableMetaCache extends OracleTableMetaCache {
             result.setIndextype(IndexType.NORMAL);
         }
         return result;
+    }
+
+    private static String getStringSafely(ResultSet rs, String columnLabel) {
+        try {
+            return rs.getString(columnLabel);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCache.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCache.java
@@ -125,9 +125,12 @@ public class DmTableMetaCache extends OracleTableMetaCache {
 
     protected void processPrimaries(TableMeta tableMeta, ResultSet rs) throws SQLException {
         // Collect primary key column names that couldn't be matched directly by PK_NAME
+        // In Oracle/DM: when primary key constraint name differs from unique index name,
+        // we need to match by column names instead
         Set<String> unmatchedPkColumns = new LinkedHashSet<>();
 
         // Iterate through each row of getPrimaryKeys() result set
+        // For composite primary key, there will be multiple rows with same PK_NAME
         while (rs.next()) {
             String pkConstraintName = getStringSafely(rs, "PK_NAME");
             String pkColName = getStringSafely(rs, "COLUMN_NAME");
@@ -136,29 +139,35 @@ public class DmTableMetaCache extends OracleTableMetaCache {
             }
 
             // Strategy 1: Try direct match by PK constraint name
+            // If the index name matches the primary key constraint name, mark it as PRIMARY
             if (StringUtils.isNotBlank(pkConstraintName)
                     && tableMeta.getAllIndexes().containsKey(pkConstraintName)) {
                 IndexMeta index = tableMeta.getAllIndexes().get(pkConstraintName);
                 index.setIndextype(IndexType.PRIMARY);
             } else {
-                // Save columns for fallback column-based matching
+                // Save columns for Strategy 2: fallback column-based matching
                 if (StringUtils.isNotBlank(pkColName)) {
                     unmatchedPkColumns.add(pkColName.toUpperCase());
                 }
             }
         }
 
-        // Strategy 2: fallback - match by column set equality (order-insensitive, deduped)
+        // Strategy 2: Fallback - find index whose columns match the primary key columns
+        // This handles the case where PK constraint name differs from unique index name
         if (!unmatchedPkColumns.isEmpty()) {
             for (IndexMeta index : tableMeta.getAllIndexes().values()) {
+                // Only check UNIQUE indexes as candidates (primary key is always unique)
                 if (index.getIndextype().value() == IndexType.UNIQUE.value()) {
+                    // Build index column set, normalized to uppercase and deduplicated
                     Set<String> indexColsSet = index.getValues().stream()
                             .filter(col -> col != null && StringUtils.isNotBlank(col.getColumnName()))
                             .map(col -> col.getColumnName().toUpperCase())
                             .collect(Collectors.toSet());
 
+                    // If sets are equal, this index exactly matches primary key columns
                     if (indexColsSet.equals(unmatchedPkColumns)) {
                         index.setIndextype(IndexType.PRIMARY);
+                        // Each table has only one primary key
                         break;
                     }
                 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCache.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCache.java
@@ -28,8 +28,8 @@ import org.apache.seata.sqlparser.util.JdbcConstants;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -123,25 +123,44 @@ public class KingbaseTableMetaCache extends OracleTableMetaCache {
     }
 
     protected void processPrimaries(TableMeta tableMeta, ResultSet rs) throws SQLException {
-        List<String> primaryKeyColumns = new ArrayList<>();
+        // Collect primary key column names that couldn't be matched directly by PK_NAME
+        Set<String> unmatchedPkColumns = new LinkedHashSet<>();
+
+        // Iterate through each row of getPrimaryKeys() result set
         while (rs.next()) {
-            String pkColName;
-            try {
-                pkColName = rs.getString("COLUMN_NAME");
-            } catch (Exception e) {
-                pkColName = rs.getString("PK_NAME");
+            String pkConstraintName = getStringSafely(rs, "PK_NAME");
+            String pkColName = getStringSafely(rs, "COLUMN_NAME");
+            if (StringUtils.isBlank(pkColName)) {
+                pkColName = pkConstraintName;
             }
-            primaryKeyColumns.add(pkColName);
+
+            // Strategy 1: Try direct match by PK constraint name
+            if (StringUtils.isNotBlank(pkConstraintName)
+                    && tableMeta.getAllIndexes().containsKey(pkConstraintName)) {
+                IndexMeta index = tableMeta.getAllIndexes().get(pkConstraintName);
+                index.setIndextype(IndexType.PRIMARY);
+            } else {
+                // Save columns for fallback column-based matching
+                if (StringUtils.isNotBlank(pkColName)) {
+                    unmatchedPkColumns.add(pkColName.toUpperCase());
+                }
+            }
         }
 
-        for (IndexMeta index : tableMeta.getAllIndexes().values()) {
-            List<String> indexColumns = index.getValues().stream()
-                    .filter(col -> col != null && StringUtils.isNotBlank(col.getColumnName()))
-                    .map(ColumnMeta::getColumnName)
-                    .collect(Collectors.toList());
+        // Strategy 2: fallback - match by column set equality (order-insensitive, deduped)
+        if (!unmatchedPkColumns.isEmpty()) {
+            for (IndexMeta index : tableMeta.getAllIndexes().values()) {
+                if (index.getIndextype().value() == IndexType.UNIQUE.value()) {
+                    Set<String> indexColsSet = index.getValues().stream()
+                            .filter(col -> col != null && StringUtils.isNotBlank(col.getColumnName()))
+                            .map(col -> col.getColumnName().toUpperCase())
+                            .collect(Collectors.toSet());
 
-            if (indexColumns.equals(primaryKeyColumns)) {
-                index.setIndextype(IndexType.PRIMARY);
+                    if (indexColsSet.equals(unmatchedPkColumns)) {
+                        index.setIndextype(IndexType.PRIMARY);
+                        break;
+                    }
+                }
             }
         }
     }
@@ -184,5 +203,13 @@ public class KingbaseTableMetaCache extends OracleTableMetaCache {
             result.setIndextype(IndexType.NORMAL);
         }
         return result;
+    }
+
+    private static String getStringSafely(ResultSet rs, String columnLabel) {
+        try {
+            return rs.getString(columnLabel);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
@@ -348,8 +348,8 @@ public class DmTableMetaCacheTest {
             new Object[] {"idx_id_userid", "user_id", false, "", 3, 2, "A", 34} // column order 2
         };
         Object[][] compositePKMetas = new Object[][] {
-            new Object[] {"id"}, // PK column order 1
-            new Object[] {"user_id"} // PK column order 2
+            new Object[] {"user_id"}, // PK column order 1 (intentionally different from index order)
+            new Object[] {"id"} // PK column order 2
         };
         Object[][] compositeColumnMetas = new Object[][] {
             new Object[] {"", "", "dt2", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
@@ -332,4 +332,31 @@ public class DmTableMetaCacheTest {
         Assertions.assertNotNull(tableMeta);
         Assertions.assertEquals(originalName, tableMeta.getOriginalTableName());
     }
+
+    @Test
+    public void testGetTableMetaWithPrimaryKeyConstraintDifferentName() throws SQLException {
+        // PK_NAME is "pk_constraint", but the corresponding index name is "idx_id"
+        Object[][] constraintPKMetas =
+                new Object[][] {new Object[] {"pk_constraint", "id"} // PK_NAME="pk_constraint", COLUMN_NAME="id"
+                };
+        Object[][] constraintIndexMetas = new Object[][] {
+            new Object[] {"idx_id", "id", false, "", 3, 0, "A", 34} // Index name is "idx_id", not "pk_constraint"
+        };
+
+        MockDriver mockDriver = new MockDriver(columnMetas, constraintIndexMetas, constraintPKMetas, tableMetas);
+        DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setUrl("jdbc:mock:dm");
+        dataSource.setDriver(mockDriver);
+
+        DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
+        TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.DM);
+
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.dt1", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
+        // The index "idx_id" should be marked as PRIMARY even though PK_NAME is "pk_constraint"
+        IndexMeta idxId = tableMeta.getAllIndexes().get("idx_id");
+        Assertions.assertNotNull(idxId);
+        Assertions.assertEquals(IndexType.PRIMARY, idxId.getIndextype());
+    }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
@@ -386,7 +386,7 @@ public class DmTableMetaCacheTest {
         // Regression test for a bug fix: a composite unique index that contains primary key columns plus extra columns
         // should NOT be marked as PRIMARY.
         // Scenario: primary key (ID), unique index (ID, NAME) — unique index contains PK column but has extra NAME.
-        // Before the fix: Oracle implementation matched by count (matchCols == pkcol.size()) and could misidentify
+        // Before the fix: the previous DM implementation matched by count (matchCols == pkcol.size()) and could misidentify
         // PRIMARY.
         // After the fix: using Set equality ({ID, NAME} != {ID}) prevents the index from being marked as PRIMARY
 

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/DmTableMetaCacheTest.java
@@ -334,16 +334,34 @@ public class DmTableMetaCacheTest {
     }
 
     @Test
-    public void testGetTableMetaWithPrimaryKeyConstraintDifferentName() throws SQLException {
-        // PK_NAME is "pk_constraint", but the corresponding index name is "idx_id"
-        Object[][] constraintPKMetas =
-                new Object[][] {new Object[] {"pk_constraint", "id"} // PK_NAME="pk_constraint", COLUMN_NAME="id"
-                };
-        Object[][] constraintIndexMetas = new Object[][] {
-            new Object[] {"idx_id", "id", false, "", 3, 0, "A", 34} // Index name is "idx_id", not "pk_constraint"
-        };
+    public void testCompositeIndexWithDifferentColumnOrder() throws SQLException {
+        // Regression test for a bug fix: different column order caused List.equals to fail, which could lead to
+        // failing to recognize a primary key index.
+        // Scenario: composite primary key (ID, USER_ID) while a unique index lists the same columns in reverse order
+        // (USER_ID, ID).
+        // Before the fix: List.equals returned FALSE because of the different order, causing the primary key index to
+        // be unrecognized.
+        // After the fix: using Set.equals should return TRUE and correctly identify the index as PRIMARY.
 
-        MockDriver mockDriver = new MockDriver(columnMetas, constraintIndexMetas, constraintPKMetas, tableMetas);
+        Object[][] compositeIndexDiffOrder = new Object[][] {
+            new Object[] {"idx_id_userid", "id", false, "", 3, 1, "A", 34}, // column order 1
+            new Object[] {"idx_id_userid", "user_id", false, "", 3, 2, "A", 34} // column order 2
+        };
+        Object[][] compositePKMetas = new Object[][] {
+            new Object[] {"id"}, // PK column order 1
+            new Object[] {"user_id"} // PK column order 2
+        };
+        Object[][] compositeColumnMetas = new Object[][] {
+            new Object[] {"", "", "dt2", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"
+            },
+            new Object[] {
+                "", "", "dt2", "user_id", Types.INTEGER, "INTEGER", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES", "NO"
+            }
+        };
+        Object[][] compositeTableMetas = new Object[][] {new Object[] {"", "t", "dt2"}};
+
+        MockDriver mockDriver =
+                new MockDriver(compositeColumnMetas, compositeIndexDiffOrder, compositePKMetas, compositeTableMetas);
         DruidDataSource dataSource = new DruidDataSource();
         dataSource.setUrl("jdbc:mock:dm");
         dataSource.setDriver(mockDriver);
@@ -351,12 +369,65 @@ public class DmTableMetaCacheTest {
         DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
         TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.DM);
 
-        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.dt1", proxy.getResourceId());
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.dt2", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
-        // The index "idx_id" should be marked as PRIMARY even though PK_NAME is "pk_constraint"
-        IndexMeta idxId = tableMeta.getAllIndexes().get("idx_id");
-        Assertions.assertNotNull(idxId);
-        Assertions.assertEquals(IndexType.PRIMARY, idxId.getIndextype());
+        IndexMeta compositeIndex = tableMeta.getAllIndexes().get("idx_id_userid");
+        Assertions.assertNotNull(compositeIndex);
+        // Key assertion: should be recognized as PRIMARY (after the fix), not mistakenly treated as UNIQUE
+        Assertions.assertEquals(
+                IndexType.PRIMARY,
+                compositeIndex.getIndextype(),
+                "Composite index with different column order should be recognized as PRIMARY");
+    }
+
+    @Test
+    public void testCompositeIndexWithExtraColumnsNotMarkedAsPrimary() throws SQLException {
+        // Regression test for a bug fix: a composite unique index that contains primary key columns plus extra columns
+        // should NOT be marked as PRIMARY.
+        // Scenario: primary key (ID), unique index (ID, NAME) — unique index contains PK column but has extra NAME.
+        // Before the fix: Oracle implementation matched by count (matchCols == pkcol.size()) and could misidentify
+        // PRIMARY.
+        // After the fix: using Set equality ({ID, NAME} != {ID}) prevents the index from being marked as PRIMARY
+
+        Object[][] mixedIndexMetas = new Object[][] {
+            new Object[] {"idx_id", "id", false, "", 3, 1, "A", 34},
+            new Object[] {"uk_id_name", "id", false, "", 3, 1, "A", 34}, // unique index contains the primary key column
+            new Object[] {"uk_id_name", "name1", false, "", 3, 2, "A", 34} // but it also has extra columns
+        };
+
+        // Use a dedicated table name to avoid cache hits from earlier tests
+        Object[][] extraColumnMetas = new Object[][] {
+            new Object[] {"", "", "dt3", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"
+            },
+            new Object[] {
+                "", "", "dt3", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES", "NO"
+            }
+        };
+        Object[][] extraPkMetas = new Object[][] {new Object[] {"id"}};
+        Object[][] extraTableMetas = new Object[][] {new Object[] {"", "t", "dt3"}};
+
+        MockDriver mockDriver = new MockDriver(extraColumnMetas, mixedIndexMetas, extraPkMetas, extraTableMetas);
+        DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setUrl("jdbc:mock:dm");
+        dataSource.setDriver(mockDriver);
+
+        DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
+        TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.DM);
+
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.dt3", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
+        IndexMeta pkIndex = tableMeta.getAllIndexes().get("idx_id");
+        Assertions.assertNotNull(pkIndex);
+        Assertions.assertEquals(IndexType.PRIMARY, pkIndex.getIndextype(), "Single column PK index should be PRIMARY");
+
+        IndexMeta mixedIndex = tableMeta.getAllIndexes().get("uk_id_name");
+        Assertions.assertNotNull(mixedIndex);
+        // Key assertion: should remain UNIQUE (should not be misidentified as PRIMARY)
+        Assertions.assertEquals(
+                IndexType.UNIQUE,
+                mixedIndex.getIndextype(),
+                "Composite index with extra columns should NOT be marked as PRIMARY");
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCacheTest.java
@@ -348,8 +348,8 @@ public class KingbaseTableMetaCacheTest {
             new Object[] {"idx_id_userid", "user_id", false, "", 3, 2, "A", 34} // column order 2
         };
         Object[][] compositePKMetas = new Object[][] {
-            new Object[] {"id"}, // PK column order 1
-            new Object[] {"user_id"} // PK column order 2
+            new Object[] {"user_id"}, // PK column order 1 (reverse of index)
+            new Object[] {"id"} // PK column order 2
         };
         Object[][] compositeColumnMetas = new Object[][] {
             new Object[] {"", "", "kt2", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCacheTest.java
@@ -334,16 +334,34 @@ public class KingbaseTableMetaCacheTest {
     }
 
     @Test
-    public void testGetTableMetaWithPrimaryKeyConstraintDifferentName() throws SQLException {
-        // PK_NAME is "pk_constraint", but the corresponding index name is "idx_id"
-        Object[][] constraintPKMetas =
-                new Object[][] {new Object[] {"pk_constraint", "id"} // PK_NAME="pk_constraint", COLUMN_NAME="id"
-                };
-        Object[][] constraintIndexMetas = new Object[][] {
-            new Object[] {"idx_id", "id", false, "", 3, 0, "A", 34} // Index name is "idx_id", not "pk_constraint"
-        };
+    public void testCompositeIndexWithDifferentColumnOrder() throws SQLException {
+        // Regression test for a bug fix: different column order caused List.equals to fail, which could lead to
+        // failing to recognize a primary key index.
+        // Scenario: composite primary key (ID, USER_ID) while a unique index lists the same columns in reverse order
+        // (USER_ID, ID).
+        // Before the fix: List.equals returned FALSE because of the different order, causing the primary key index to
+        // be unrecognized.
+        // After the fix: using Set.equals should return TRUE and correctly identify the index as PRIMARY.
 
-        MockDriver mockDriver = new MockDriver(COLUMN_METAS, constraintIndexMetas, constraintPKMetas, TABLE_METAS);
+        Object[][] compositeIndexDiffOrder = new Object[][] {
+            new Object[] {"idx_id_userid", "id", false, "", 3, 1, "A", 34}, // column order 1
+            new Object[] {"idx_id_userid", "user_id", false, "", 3, 2, "A", 34} // column order 2
+        };
+        Object[][] compositePKMetas = new Object[][] {
+            new Object[] {"id"}, // PK column order 1
+            new Object[] {"user_id"} // PK column order 2
+        };
+        Object[][] compositeColumnMetas = new Object[][] {
+            new Object[] {"", "", "kt2", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"
+            },
+            new Object[] {
+                "", "", "kt2", "user_id", Types.INTEGER, "INTEGER", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES", "NO"
+            }
+        };
+        Object[][] compositeTableMetas = new Object[][] {new Object[] {"", "kb", "kt2"}};
+
+        MockDriver mockDriver =
+                new MockDriver(compositeColumnMetas, compositeIndexDiffOrder, compositePKMetas, compositeTableMetas);
         DruidDataSource dataSource = new DruidDataSource();
         dataSource.setUrl("jdbc:mock:kingbase");
         dataSource.setDriver(mockDriver);
@@ -351,12 +369,65 @@ public class KingbaseTableMetaCacheTest {
         DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
         TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.KINGBASE);
 
-        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "kb.kt1", proxy.getResourceId());
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "kb.kt2", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
-        // The index "idx_id" should be marked as PRIMARY even though PK_NAME is "pk_constraint"
-        IndexMeta idxId = tableMeta.getAllIndexes().get("idx_id");
-        Assertions.assertNotNull(idxId);
-        Assertions.assertEquals(IndexType.PRIMARY, idxId.getIndextype());
+        IndexMeta compositeIndex = tableMeta.getAllIndexes().get("idx_id_userid");
+        Assertions.assertNotNull(compositeIndex);
+        // Key assertion: should be recognized as PRIMARY (after the fix), not mistakenly treated as UNIQUE
+        Assertions.assertEquals(
+                IndexType.PRIMARY,
+                compositeIndex.getIndextype(),
+                "Composite index with different column order should be recognized as PRIMARY");
+    }
+
+    @Test
+    public void testCompositeIndexWithExtraColumnsNotMarkedAsPrimary() throws SQLException {
+        // Regression test for a bug fix: a composite unique index that contains primary key columns plus extra columns
+        // should NOT be marked as PRIMARY.
+        // Scenario: primary key (ID), unique index (ID, NAME) — unique index contains PK column but has extra NAME.
+        // Before the fix: previous implementation matched by count (matchCols == pkcol.size()) and could misidentify
+        // PRIMARY.
+        // After the fix: match by Set equality ({ID, NAME} != {ID}) so it won't be marked as PRIMARY
+
+        Object[][] mixedIndexMetas = new Object[][] {
+            new Object[] {"idx_id", "id", false, "", 3, 1, "A", 34},
+            new Object[] {"uk_id_name", "id", false, "", 3, 1, "A", 34}, // unique index contains the primary key column
+            new Object[] {"uk_id_name", "name1", false, "", 3, 2, "A", 34} // but it also has extra columns
+        };
+
+        // Use a dedicated table name to avoid cache hits from earlier tests
+        Object[][] extraColumnMetas = new Object[][] {
+            new Object[] {"", "", "kt3", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"
+            },
+            new Object[] {
+                "", "", "kt3", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES", "NO"
+            }
+        };
+        Object[][] extraPkMetas = new Object[][] {new Object[] {"id"}};
+        Object[][] extraTableMetas = new Object[][] {new Object[] {"", "kb", "kt3"}};
+
+        MockDriver mockDriver = new MockDriver(extraColumnMetas, mixedIndexMetas, extraPkMetas, extraTableMetas);
+        DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setUrl("jdbc:mock:kingbase");
+        dataSource.setDriver(mockDriver);
+
+        DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
+        TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.KINGBASE);
+
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "kb.kt3", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
+        IndexMeta pkIndex = tableMeta.getAllIndexes().get("idx_id");
+        Assertions.assertNotNull(pkIndex);
+        Assertions.assertEquals(IndexType.PRIMARY, pkIndex.getIndextype(), "Single column PK index should be PRIMARY");
+
+        IndexMeta mixedIndex = tableMeta.getAllIndexes().get("uk_id_name");
+        Assertions.assertNotNull(mixedIndex);
+        // Key assertion: should remain UNIQUE (should not be misidentified as PRIMARY)
+        Assertions.assertEquals(
+                IndexType.UNIQUE,
+                mixedIndex.getIndextype(),
+                "Composite index with extra columns should NOT be marked as PRIMARY");
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/sql/struct/cache/KingbaseTableMetaCacheTest.java
@@ -332,4 +332,31 @@ public class KingbaseTableMetaCacheTest {
         Assertions.assertNotNull(tableMeta);
         Assertions.assertEquals(originalName, tableMeta.getOriginalTableName());
     }
+
+    @Test
+    public void testGetTableMetaWithPrimaryKeyConstraintDifferentName() throws SQLException {
+        // PK_NAME is "pk_constraint", but the corresponding index name is "idx_id"
+        Object[][] constraintPKMetas =
+                new Object[][] {new Object[] {"pk_constraint", "id"} // PK_NAME="pk_constraint", COLUMN_NAME="id"
+                };
+        Object[][] constraintIndexMetas = new Object[][] {
+            new Object[] {"idx_id", "id", false, "", 3, 0, "A", 34} // Index name is "idx_id", not "pk_constraint"
+        };
+
+        MockDriver mockDriver = new MockDriver(COLUMN_METAS, constraintIndexMetas, constraintPKMetas, TABLE_METAS);
+        DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setUrl("jdbc:mock:kingbase");
+        dataSource.setDriver(mockDriver);
+
+        DataSourceProxy proxy = DataSourceProxyTest.getDataSourceProxy(dataSource);
+        TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.KINGBASE);
+
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "kb.kt1", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
+        // The index "idx_id" should be marked as PRIMARY even though PK_NAME is "pk_constraint"
+        IndexMeta idxId = tableMeta.getAllIndexes().get("idx_id");
+        Assertions.assertNotNull(idxId);
+        Assertions.assertEquals(IndexType.PRIMARY, idxId.getIndextype());
+    }
 }


### PR DESCRIPTION
…e index as primary key index

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
https://github.com/apache/incubator-seata/pull/7965

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

