### PR TITLE
optimize:Remove unnecessary refreshLeader from ClusterController cluster endpoint

### DIFF
--- a/server/src/main/java/org/apache/seata/server/controller/ClusterController.java
+++ b/server/src/main/java/org/apache/seata/server/controller/ClusterController.java
@@ -18,7 +18,6 @@ package org.apache.seata.server.controller;
 
 import com.alipay.sofa.jraft.RouteTable;
 import com.alipay.sofa.jraft.conf.Configuration;
-import com.alipay.sofa.jraft.entity.PeerId;
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.metadata.MetadataResponse;
 import org.apache.seata.common.metadata.Node;
@@ -85,18 +84,12 @@ public class ClusterController {
         if (raftServer != null) {
             String mode = ConfigurationFactory.getInstance().getConfig(STORE_MODE);
             metadataResponse.setStoreMode(mode);
-            RouteTable routeTable = RouteTable.getInstance();
             try {
-                routeTable.refreshLeader(RaftServerManager.getCliClientServiceInstance(), group, 1000);
-                PeerId leader = routeTable.selectLeader(group);
-                if (leader != null) {
+                RaftClusterMetadata raftClusterMetadata =
+                        raftServer.getRaftStateMachine().getRaftLeaderMetadata();
+                Node leaderNode = raftClusterMetadata.getLeader();
+                if (leaderNode != null) {
                     Set<Node> nodes = new HashSet<>();
-                    RaftClusterMetadata raftClusterMetadata =
-                            raftServer.getRaftStateMachine().getRaftLeaderMetadata();
-                    Node leaderNode = raftServer
-                            .getRaftStateMachine()
-                            .getRaftLeaderMetadata()
-                            .getLeader();
                     leaderNode.setGroup(group);
                     nodes.add(leaderNode);
                     nodes.addAll(raftClusterMetadata.getLearner());


### PR DESCRIPTION
## What's changed
- Remove `RouteTable.refreshLeader()` and `RouteTable.selectLeader()` from `GET /metadata/v1/cluster` in `ClusterController`.
- Use only `RaftStateMachine.getRaftLeaderMetadata()` for cluster metadata (leader, followers, learners, term).
- Remove unused `PeerId` import.

## Why
The cluster endpoint already builds the response from `RaftStateMachine.getRaftLeaderMetadata()`. The `refreshLeader`/`selectLeader` calls only checked "is there a leader?" via JRaft's RouteTable, duplicating info we already have. Removing them:
- Drops the extra JRaft round-trip on every `/cluster` call
- Keeps the same `MetadataResponse` shape and semantics
- Leaves `changeCluster` unchanged (still uses RouteTable for `changePeers`/`updateConfiguration`)

## Testing
- `ClusterControllerTest` (run `mvn test -pl server -Dtest=ClusterControllerTest`)
- No changes to `RaftRegistryServiceImpl` or other callers; response contract unchanged.

fix #7967