### PR TITLE
fix #7963 ClusterControllerTest.watch_withHttp2: use 30000ms timeout

### DIFF
--- a/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
+++ b/server/src/test/java/org/apache/seata/server/controller/ClusterControllerTest.java
@@ -188,7 +188,7 @@ class ClusterControllerTest extends BaseSpringBootTest {
         };
 
         HttpClientUtil.doPostWithHttp2(
-                "http://127.0.0.1:" + port + "/metadata/v1/watch", params, headers, callback, 30);
+                "http://127.0.0.1:" + port + "/metadata/v1/watch", params, headers, callback, 30000);
         Assertions.assertTrue(latch.await(35, TimeUnit.SECONDS));
     }
 


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Fix `ClusterControllerTest.watch_withHttp2()` flaky failure. The test was calling `doPostWithHttp2(..., callback, 30)`, which passes **30 milliseconds** as the client timeout (`timeoutMillis` in `HttpClientUtil`). The watch endpoint holds the connection until a cluster change event (published after ~2 seconds), so the client was timing out before the server responded, the callback never ran, and `latch.await(35, TimeUnit.SECONDS)` returned false. This PR changes the timeout to **30000 ms** (30 seconds) to align with the blocking `watch()` test, so the HTTP/2 client waits long enough for the response and the callback runs, allowing the latch to count down and the assertion to pass.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #7963

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This PR fixes an existing test (`watch_withHttp2`). No new test was added; the change makes the current test stable by correcting the client timeout so the test can complete successfully.

### Ⅳ. Describe how to verify it

Run the cluster controller tests:

mvn test -pl server -Dtest=ClusterControllerTest#watch_withHttp2
