### PR TITLE
bugfix: unregister resource when closing DataSourceProxy

### DIFF
--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceManager.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.rm.datasource;
 
-import org.apache.seata.common.exception.NotSupportYetException;
 import org.apache.seata.common.exception.ShouldNeverHappenException;
 import org.apache.seata.core.context.RootContext;
 import org.apache.seata.core.exception.RmTransactionException;
@@ -93,7 +92,9 @@ public class DataSourceManager extends AbstractResourceManager {
 
     @Override
     public void unregisterResource(Resource resource) {
-        throw new NotSupportYetException("unregister a resource");
+        DataSourceProxy dataSourceProxy = (DataSourceProxy) resource;
+        super.unregisterResource(dataSourceProxy);
+        dataSourceCache.remove(dataSourceProxy.getResourceId());
     }
 
     /**

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceManager.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceManager.java
@@ -93,8 +93,9 @@ public class DataSourceManager extends AbstractResourceManager {
     @Override
     public void unregisterResource(Resource resource) {
         DataSourceProxy dataSourceProxy = (DataSourceProxy) resource;
-        super.unregisterResource(dataSourceProxy);
         dataSourceCache.remove(dataSourceProxy.getResourceId());
+        RmNettyRemotingClient.getInstance()
+                .unregisterResource(dataSourceProxy.getResourceGroupId(), dataSourceProxy.getResourceId());
     }
 
     /**

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxy.java
@@ -294,7 +294,7 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
     }
 
     public void close() throws Exception {
-        // TODO: Need to unregister resource from DefaultResourceManager
+        DefaultResourceManager.get().unregisterResource(this);
         TableMetaCacheFactory.shutdown(resourceId);
     }
 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/DataSourceProxy.java
@@ -294,7 +294,10 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
     }
 
     public void close() throws Exception {
-        DefaultResourceManager.get().unregisterResource(this);
-        TableMetaCacheFactory.shutdown(resourceId);
+        try {
+            DefaultResourceManager.get().unregisterResource(this);
+        } finally {
+            TableMetaCacheFactory.shutdown(resourceId);
+        }
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/DataSourceProxyTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/DataSourceProxyTest.java
@@ -239,7 +239,6 @@ public class DataSourceProxyTest {
 
             verify(drm).unregisterResource(proxy);
             tmcfStatic.verify(() -> TableMetaCacheFactory.shutdown(proxy.getResourceId()));
-            verify(drm).unregisterResource(proxy);
         }
     }
 

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/DataSourceProxyTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/DataSourceProxyTest.java
@@ -237,8 +237,33 @@ public class DataSourceProxyTest {
 
             proxy.close();
 
+            verify(drm).unregisterResource(proxy);
             tmcfStatic.verify(() -> TableMetaCacheFactory.shutdown(proxy.getResourceId()));
             verify(drm).unregisterResource(proxy);
         }
+    }
+
+    @Test
+    public void testCloseRemovesResourceFromManager() throws Exception {
+        final MockDriver mockDriver = new MockDriver();
+        final String username = "username";
+        final String jdbcUrl = "jdbc:mock:xxx";
+
+        final DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setUrl(jdbcUrl);
+        dataSource.setDriver(mockDriver);
+        dataSource.setUsername(username);
+        dataSource.setPassword("password");
+
+        DataSourceProxy proxy = getDataSourceProxy(dataSource);
+
+        // Ensure it's registered
+        Assertions.assertNotNull(
+                DefaultResourceManager.get().getManagedResources().get(proxy.getResourceId()));
+
+        proxy.close();
+
+        // Ensure it's unregistered
+        Assertions.assertNull(DefaultResourceManager.get().getManagedResources().get(proxy.getResourceId()));
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/DataSourceProxyTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/DataSourceProxyTest.java
@@ -238,6 +238,7 @@ public class DataSourceProxyTest {
             proxy.close();
 
             tmcfStatic.verify(() -> TableMetaCacheFactory.shutdown(proxy.getResourceId()));
+            verify(drm).unregisterResource(proxy);
         }
     }
 }


### PR DESCRIPTION
Implemented the TODO item in DataSourceProxy.close() to ensure that resources are properly unregistered from the 
DefaultResourceManager
 when the proxy is closed. This prevents potential resource leaks by ensuring DefaultResourceManager.get().unregisterResource(this) is called.

Ⅱ. Does this pull request fix one issue?
Fixes missing resource cleanup in 
DataSourceProxy
.

Ⅲ. Why don't you add test cases (unit test/integration test)?
I have updated the existing unit test 
DataSourceProxyTest
. Specifically, I modified 
testCloseRemovesResource
 to verify that 
unregisterResource
 is called when the proxy is closed.

Ⅳ. Describe how to verify it
Run the unit tests for the datasource module: mvn -pl rm-datasource -Dtest=DataSourceProxyTest test

Ⅴ. Special notes for reviews
This change simply addresses an existing TODO comment to ensure cleaner resource lifecycle management.