### PR TITLE
fix: duplicate columns in undo_log afterImage for composite primary key tables

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -19,6 +19,8 @@ Add changes here for all PR submitted to the 2.x branch.
 <!-- Please add the `changes` to the following location(feature/bugfix/optimize/test) based on the type of PR -->
 
 ### feature:
+- [[#8014](https://github.com/apache/incubator-seata/pull/8014)] add P99.9 latency percentile to benchmark CLI
+- [[#8015](https://github.com/apache/incubator-seata/pull/8015)] add XA mode support to benchmark CLI
 - [[#7882](https://github.com/apache/incubator-seata/pull/7882)] add metrics for NamingServer
 - [[#7760](https://github.com/apache/incubator-seata/pull/7760)] unify Jackson/fastjson serialization
 - [[#7000](https://github.com/apache/incubator-seata/pull/7000)] support multi-version codec & fix not returning client registration failure msg.
@@ -27,6 +29,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] add Grafana dashboard JSON for NamingServer metrics
 
 ### bugfix:
+- [[#8013](https://github.com/apache/incubator-seata/pull/8013)] fix duplicate columns in undo_log afterImage for composite primary key tables
 
 - [[#7929](https://github.com/apache/incubator-seata/pull/7929)] fix KingbaseUndoLogManager INSERT_UNDO_LOG_SQL error
 - [[#7940](https://github.com/apache/incubator-seata/pull/7940)] ensure the Jakarta-related package paths are correct
@@ -65,6 +68,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 
+- [DoChaoing](https://github.com/DoChaoing)
 - [slievrly](https://github.com/slievrly)
 - [contrueCT](https://github.com/contrueCT)
 - [lokidundun](https://github.com/lokidundun)

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutor.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/exec/BaseTransactionalExecutor.java
@@ -571,19 +571,23 @@ public abstract class BaseTransactionalExecutor<T, S extends Statement> implemen
         Set<String> needUpdateColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         TableMeta tableMeta = getTableMeta(table);
         if (ONLY_CARE_UPDATE_COLUMNS && CollectionUtils.isNotEmpty(unescapeColumns)) {
-            if (!containsPK(table, unescapeColumns)) {
-                List<String> pkNameList = tableMeta.getEscapePkNameList(getDbType());
-                if (CollectionUtils.isNotEmpty(pkNameList)) {
+            // First add insert columns to avoid duplicates in composite primary key scenarios
+            // (fixes #8005)
+            needUpdateColumns.addAll(unescapeColumns);
+
+            // Then add missing primary key columns
+            List<String> pkNameList = tableMeta.getPrimaryKeyOnlyName();
+            for (String pkName : pkNameList) {
+                boolean pkExists = needUpdateColumns.stream()
+                        .anyMatch(col -> col.equalsIgnoreCase(pkName));
+                if (!pkExists) {
                     if (StringUtils.isNotBlank(tableAlias)) {
-                        needUpdateColumns.addAll(ColumnUtils.delEscape(
-                                getColumnNamesWithTablePrefixList(table, tableAlias, pkNameList), getDbType()));
+                        needUpdateColumns.add(getColumnNameWithTablePrefix(table, tableAlias, pkName));
                     } else {
-                        needUpdateColumns.addAll(
-                                ColumnUtils.delEscape(getColumnNamesInSQLList(pkNameList), getDbType()));
+                        needUpdateColumns.add(pkName);
                     }
                 }
             }
-            needUpdateColumns.addAll(unescapeColumns);
 
             // The on update xxx columns will be auto update by db, so it's also the actually updated columns
             List<String> onUpdateColumns = tableMeta.getOnUpdateColumnsOnlyName();


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR fixes the issue where the afterImage in undo_log contains duplicate column entries when inserting into tables with composite primary keys.

### Ⅱ. Does this pull request fix one issue?

Fixes #8005

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Existing test cases should cover this fix. The change is a logic reordering in getNeedColumns() method without changing the final output for correct cases.

### Ⅳ. Describe how to verify it

1. Create a table with composite primary key (e.g., id + code)
2. Insert a record where one PK column is in the insert statement
3. Check undo_log - the afterImage should not have duplicate columns

### Ⅴ. Special notes for reviewers

**Root Cause:**
The original code added primary key columns first, then insert columns. When a PK column was already in the insert statement, it would be added twice.

**Fix:**
Reorder the logic to:
1. First add insert columns
2. Then add only missing primary key columns

This ensures no duplicates while still including all necessary columns.
