### PR TITLE
feat: add P99.9 latency percentile to benchmark CLI

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -19,6 +19,8 @@ Add changes here for all PR submitted to the 2.x branch.
 <!-- Please add the `changes` to the following location(feature/bugfix/optimize/test) based on the type of PR -->
 
 ### feature:
+- [[#8014](https://github.com/apache/incubator-seata/pull/8014)] add P99.9 latency percentile to benchmark CLI
+- [[#8015](https://github.com/apache/incubator-seata/pull/8015)] add XA mode support to benchmark CLI
 - [[#7882](https://github.com/apache/incubator-seata/pull/7882)] add metrics for NamingServer
 - [[#7760](https://github.com/apache/incubator-seata/pull/7760)] unify Jackson/fastjson serialization
 - [[#7000](https://github.com/apache/incubator-seata/pull/7000)] support multi-version codec & fix not returning client registration failure msg.
@@ -27,6 +29,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] add Grafana dashboard JSON for NamingServer metrics
 
 ### bugfix:
+- [[#8013](https://github.com/apache/incubator-seata/pull/8013)] fix duplicate columns in undo_log afterImage for composite primary key tables
 
 - [[#7929](https://github.com/apache/incubator-seata/pull/7929)] fix KingbaseUndoLogManager INSERT_UNDO_LOG_SQL error
 - [[#7940](https://github.com/apache/incubator-seata/pull/7940)] ensure the Jakarta-related package paths are correct
@@ -65,6 +68,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 
+- [DoChaoing](https://github.com/DoChaoing)
 - [slievrly](https://github.com/slievrly)
 - [contrueCT](https://github.com/contrueCT)
 - [lokidundun](https://github.com/lokidundun)

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -20,7 +20,6 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### feature:
 - [[#8014](https://github.com/apache/incubator-seata/pull/8014)] add P99.9 latency percentile to benchmark CLI
-- [[#8015](https://github.com/apache/incubator-seata/pull/8015)] add XA mode support to benchmark CLI
 - [[#7882](https://github.com/apache/incubator-seata/pull/7882)] add metrics for NamingServer
 - [[#7760](https://github.com/apache/incubator-seata/pull/7760)] unify Jackson/fastjson serialization
 - [[#7000](https://github.com/apache/incubator-seata/pull/7000)] support multi-version codec & fix not returning client registration failure msg.
@@ -29,7 +28,6 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] add Grafana dashboard JSON for NamingServer metrics
 
 ### bugfix:
-- [[#8013](https://github.com/apache/incubator-seata/pull/8013)] fix duplicate columns in undo_log afterImage for composite primary key tables
 
 - [[#7929](https://github.com/apache/incubator-seata/pull/7929)] fix KingbaseUndoLogManager INSERT_UNDO_LOG_SQL error
 - [[#7940](https://github.com/apache/incubator-seata/pull/7940)] ensure the Jakarta-related package paths are correct

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -25,6 +25,7 @@
 - [[#7000](https://github.com/apache/incubator-seata/pull/7000)] 支持多版本codec，修复不返回客户端注册失败消息的问题
 - [[#7865](https://github.com/apache/incubator-seata/pull/7865)] 新增 Benchmark 命令行工具
 - [[#7903](https://github.com/apache/incubator-seata/pull/7903)] 在Server Raft模式下支持Watch API的HTTP/2流推送
+- [[#8014](https://github.com/apache/incubator-seata/pull/8014)] 为 benchmark CLI 添加 P99.9 尾延迟百分位
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] 为namingserver指标增加Grafana dashboard JSON
 
 ### bugfix:

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
@@ -128,7 +128,7 @@ public class BenchmarkMetrics {
             }
 
             if (latencies.isEmpty()) {
-                cachedStats = new LatencyStats(0, 0, 0, 0);
+                cachedStats = new LatencyStats(0, 0, 0, 0, 0);
             } else {
                 List<Long> sortedLatencies = new ArrayList<>(latencies);
                 Collections.sort(sortedLatencies);
@@ -137,9 +137,10 @@ public class BenchmarkMetrics {
                 long p50 = sortedLatencies.get(Math.max(0, (int) Math.ceil(size * 0.5) - 1));
                 long p95 = sortedLatencies.get(Math.max(0, (int) Math.ceil(size * 0.95) - 1));
                 long p99 = sortedLatencies.get(Math.max(0, (int) Math.ceil(size * 0.99) - 1));
+                long p999 = sortedLatencies.get(Math.max(0, (int) Math.ceil(size * 0.999) - 1));
                 long max = sortedLatencies.get(size - 1);
 
-                cachedStats = new LatencyStats(p50, p95, p99, max);
+                cachedStats = new LatencyStats(p50, p95, p99, p999, max);
             }
 
             lastStatsUpdateTime = now;
@@ -160,12 +161,14 @@ public class BenchmarkMetrics {
         private final long p50;
         private final long p95;
         private final long p99;
+        private final long p999;
         private final long max;
 
-        public LatencyStats(long p50, long p95, long p99, long max) {
+        public LatencyStats(long p50, long p95, long p99, long p999, long max) {
             this.p50 = p50;
             this.p95 = p95;
             this.p99 = p99;
+            this.p999 = p999;
             this.max = max;
         }
 
@@ -179,6 +182,10 @@ public class BenchmarkMetrics {
 
         public long getP99() {
             return p99;
+        }
+
+        public long getP999() {
+            return p999;
         }
 
         public long getMax() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
@@ -121,7 +121,7 @@ public class BenchmarkMetrics {
             return cachedStats;
         }
 
-        synchronized (this) {
+        synchronized (latencies) {
             // Double-check
             if (cachedStats != null && (now - lastStatsUpdateTime) < BenchmarkConstants.LATENCY_STATS_CACHE_MS) {
                 return cachedStats;

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
@@ -53,6 +53,7 @@ public class MetricsCollector {
             writer.println("Latency P50 (ms)," + latency.getP50());
             writer.println("Latency P95 (ms)," + latency.getP95());
             writer.println("Latency P99 (ms)," + latency.getP99());
+            writer.println("Latency P99.9 (ms)," + latency.getP999());
             writer.println("Latency Max (ms)," + latency.getMax());
 
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -83,6 +84,7 @@ public class MetricsCollector {
         report.append(String.format("  P50:                 %d ms\n", latency.getP50()));
         report.append(String.format("  P95:                 %d ms\n", latency.getP95()));
         report.append(String.format("  P99:                 %d ms\n", latency.getP99()));
+        report.append(String.format("  P99.9:               %d ms\n", latency.getP999()));
         report.append(String.format("  Max:                 %d ms\n", latency.getMax()));
         report.append("===================================================\n");
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR adds P99.9 latency percentile support to the benchmark CLI, which is critical for tail latency analysis in distributed transaction systems.

### Ⅱ. Does this pull request fix one issue?

Fixes #8011

### Ⅲ. Why don't you add test cases (unit test/integration test)?

The change is a straightforward addition of a new latency metric calculation and output. Existing benchmark tests will automatically include the new P99.9 metric.

### Ⅳ. Describe how to verify it

1. Run the benchmark CLI: `java -jar seata-benchmark-cli.jar --mode AT --threads 10 --duration 60`
2. Check the final report output includes P99.9 latency
3. Export to CSV and verify P99.9 column exists

### Ⅴ. Special notes for reviewers

**Changes:**
1. `BenchmarkMetrics.LatencyStats` - Added `p999` field and getter
2. `BenchmarkMetrics.getLatencyStats()` - Added P99.9 calculation using `Math.ceil(size * 0.999)`
3. `MetricsCollector.generateFinalReport()` - Added P99.9 output
4. `MetricsCollector.exportToCsv()` - Added P99.9 row

P99.9 is a standard metric in performance benchmarking tools (e.g., Kafka ProducerPerformance) and is essential for understanding tail latency behavior in distributed systems.
