### PR TITLE
feat: add XA mode support to benchmark CLI

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -19,6 +19,8 @@ Add changes here for all PR submitted to the 2.x branch.
 <!-- Please add the `changes` to the following location(feature/bugfix/optimize/test) based on the type of PR -->
 
 ### feature:
+- [[#8014](https://github.com/apache/incubator-seata/pull/8014)] add P99.9 latency percentile to benchmark CLI
+- [[#8015](https://github.com/apache/incubator-seata/pull/8015)] add XA mode support to benchmark CLI
 - [[#7882](https://github.com/apache/incubator-seata/pull/7882)] add metrics for NamingServer
 - [[#7760](https://github.com/apache/incubator-seata/pull/7760)] unify Jackson/fastjson serialization
 - [[#7000](https://github.com/apache/incubator-seata/pull/7000)] support multi-version codec & fix not returning client registration failure msg.
@@ -27,6 +29,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] add Grafana dashboard JSON for NamingServer metrics
 
 ### bugfix:
+- [[#8013](https://github.com/apache/incubator-seata/pull/8013)] fix duplicate columns in undo_log afterImage for composite primary key tables
 
 - [[#7929](https://github.com/apache/incubator-seata/pull/7929)] fix KingbaseUndoLogManager INSERT_UNDO_LOG_SQL error
 - [[#7940](https://github.com/apache/incubator-seata/pull/7940)] ensure the Jakarta-related package paths are correct
@@ -65,6 +68,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 
+- [DoChaoing](https://github.com/DoChaoing)
 - [slievrly](https://github.com/slievrly)
 - [contrueCT](https://github.com/contrueCT)
 - [lokidundun](https://github.com/lokidundun)

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkRunner.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkRunner.java
@@ -22,6 +22,7 @@ import org.apache.seata.benchmark.executor.SagaModeExecutor;
 import org.apache.seata.benchmark.executor.TCCModeExecutor;
 import org.apache.seata.benchmark.executor.TransactionExecutor;
 import org.apache.seata.benchmark.executor.WorkloadGenerator;
+import org.apache.seata.benchmark.executor.XAModeExecutor;
 import org.apache.seata.benchmark.model.BenchmarkMetrics;
 import org.apache.seata.benchmark.monitor.MetricsCollector;
 import org.apache.seata.core.model.BranchType;
@@ -132,9 +133,13 @@ public class BenchmarkRunner {
                 String sagaMode = isRealMode ? " (state machine engine)" : " (empty transaction)";
                 System.out.println("Creating Saga mode executor" + sagaMode + "\n");
                 return new SagaModeExecutor(config);
+            case XA:
+                String xaMode = isRealMode ? " (MySQL via Testcontainers)" : " (empty transaction)";
+                System.out.println("Creating XA mode executor" + xaMode + "\n");
+                return new XAModeExecutor(config);
             default:
                 throw new IllegalArgumentException(
-                        "Unsupported mode: " + branchType + ". Only AT, TCC, and SAGA are supported.");
+                        "Unsupported mode: " + branchType + ". Only AT, TCC, SAGA, and XA are supported.");
         }
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -134,8 +134,8 @@ public class BenchmarkConfig {
     }
 
     private void validateMode() {
-        if (mode != BranchType.AT && mode != BranchType.TCC && mode != BranchType.SAGA) {
-            throw new IllegalArgumentException("Unsupported mode: " + mode + ". Only AT, TCC, and SAGA are supported.");
+        if (mode != BranchType.AT && mode != BranchType.TCC && mode != BranchType.SAGA && mode != BranchType.XA) {
+            throw new IllegalArgumentException("Unsupported mode: " + mode + ". Only AT, TCC, SAGA, and XA are supported.");
         }
     }
 

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/XAModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/XAModeExecutor.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.benchmark.executor;
+
+import com.mysql.cj.jdbc.MysqlXADataSource;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.seata.benchmark.config.BenchmarkConfig;
+import org.apache.seata.benchmark.constant.BenchmarkConstants;
+import org.apache.seata.rm.datasource.xa.DataSourceProxyXA;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * XA mode transaction executor supporting both empty and real transaction modes
+ * - branches == 0: Empty transaction mode (pure Seata protocol overhead testing)
+ * - branches > 0: Real mode with MySQL database (via Testcontainers)
+ */
+public class XAModeExecutor extends AbstractTransactionExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(XAModeExecutor.class);
+
+    private MySQLContainer<?> mysqlContainer;
+    private HikariDataSource rawDataSource;
+    private DataSourceProxyXA dataSourceProxyXA;
+
+    public XAModeExecutor(BenchmarkConfig config) {
+        super(config);
+    }
+
+    private boolean isRealMode() {
+        return config.getBranches() > 0;
+    }
+
+    @Override
+    public void init() {
+        if (isRealMode()) {
+            LOGGER.info("Initializing XA mode executor (MySQL via Testcontainers)");
+            initRealMode();
+        } else {
+            LOGGER.info("XA mode executor initialized (empty transaction mode)");
+        }
+    }
+
+    private void initRealMode() {
+        try {
+            // Start MySQL container
+            startMySQLContainer();
+
+            // Create XA DataSource
+            createXADataSource();
+
+            // Initialize database schema and data
+            initDatabase();
+
+            // Wrap with Seata DataSourceProxyXA for XA mode
+            MysqlXADataSource xaDataSource = createMysqlXADataSource();
+            dataSourceProxyXA = new DataSourceProxyXA(xaDataSource);
+
+            LOGGER.info("DataSourceProxyXA initialized");
+            LOGGER.info("Real XA mode executor initialized with {} accounts", BenchmarkConstants.ACCOUNT_COUNT);
+        } catch (Exception e) {
+            // Cleanup resources on initialization failure
+            cleanupOnFailure();
+            throw e instanceof RuntimeException
+                    ? (RuntimeException) e
+                    : new RuntimeException("Failed to initialize real XA mode executor", e);
+        }
+    }
+
+    private void cleanupOnFailure() {
+        LOGGER.warn("Cleaning up resources due to initialization failure");
+        if (rawDataSource != null && !rawDataSource.isClosed()) {
+            try {
+                rawDataSource.close();
+            } catch (Exception e) {
+                LOGGER.warn("Failed to close DataSource during cleanup", e);
+            }
+        }
+        if (mysqlContainer != null && mysqlContainer.isRunning()) {
+            try {
+                mysqlContainer.stop();
+            } catch (Exception e) {
+                LOGGER.warn("Failed to stop MySQL container during cleanup", e);
+            }
+        }
+    }
+
+    private void startMySQLContainer() {
+        LOGGER.info("Starting MySQL container...");
+        mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                .withDatabaseName("benchmark")
+                .withUsername("test")
+                .withPassword("test")
+                .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
+
+        mysqlContainer.start();
+
+        LOGGER.info("MySQL container started: {}", mysqlContainer.getJdbcUrl());
+    }
+
+    private void createXADataSource() {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(mysqlContainer.getJdbcUrl());
+        hikariConfig.setUsername(mysqlContainer.getUsername());
+        hikariConfig.setPassword(mysqlContainer.getPassword());
+        hikariConfig.setDriverClassName("com.mysql.cj.jdbc.Driver");
+        hikariConfig.setMaximumPoolSize(config.getThreads() * 2);
+        hikariConfig.setMinimumIdle(config.getThreads());
+        hikariConfig.setConnectionTimeout(30000);
+        hikariConfig.setIdleTimeout(600000);
+        hikariConfig.setMaxLifetime(1800000);
+
+        rawDataSource = new HikariDataSource(hikariConfig);
+        LOGGER.info("HikariCP DataSource created");
+    }
+
+    private MysqlXADataSource createMysqlXADataSource() {
+        MysqlXADataSource xaDataSource = new MysqlXADataSource();
+        xaDataSource.setUrl(mysqlContainer.getJdbcUrl());
+        xaDataSource.setUser(mysqlContainer.getUsername());
+        xaDataSource.setPassword(mysqlContainer.getPassword());
+        return xaDataSource;
+    }
+
+    private void initDatabase() {
+        try (Connection conn = rawDataSource.getConnection();
+                Statement stmt = conn.createStatement()) {
+
+            // Create accounts table
+            stmt.execute("CREATE TABLE IF NOT EXISTS accounts ("
+                    + "id BIGINT PRIMARY KEY, "
+                    + "balance INT NOT NULL, "
+                    + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+            // Insert test data
+            stmt.execute("TRUNCATE TABLE accounts");
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO accounts (id, balance) VALUES (?, ?)")) {
+                for (int i = 1; i <= BenchmarkConstants.ACCOUNT_COUNT; i++) {
+                    pstmt.setLong(1, i);
+                    pstmt.setInt(2, BenchmarkConstants.INITIAL_BALANCE);
+                    pstmt.addBatch();
+                    if (i % 100 == 0) {
+                        pstmt.executeBatch();
+                    }
+                }
+                pstmt.executeBatch();
+            }
+
+            LOGGER.info(
+                    "Database initialized: {} accounts with balance {}",
+                    BenchmarkConstants.ACCOUNT_COUNT,
+                    BenchmarkConstants.INITIAL_BALANCE);
+
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize database", e);
+        }
+    }
+
+    @Override
+    protected String getTransactionName() {
+        return isRealMode() ? "benchmark-real-xa-tx" : "benchmark-xa-tx";
+    }
+
+    @Override
+    protected int getBranchCount() {
+        return config.getBranches();
+    }
+
+    @Override
+    protected void executeBusinessLogic() throws Exception {
+        if (isRealMode()) {
+            executeBranchOperations(config.getBranches());
+        }
+        // Empty mode: do nothing (pure Seata protocol overhead testing)
+    }
+
+    private void executeBranchOperations(int branchCount) throws SQLException {
+        // Execute N branch operations (simulating distributed transaction branches)
+        for (int i = 0; i < branchCount; i++) {
+            executeSingleBranch();
+        }
+    }
+
+    private void executeSingleBranch() throws SQLException {
+        // Use DataSourceProxyXA connection to enable XA mode
+        try (Connection conn = dataSourceProxyXA.getConnection()) {
+            conn.setAutoCommit(false);
+
+            // Select two different accounts for transfer
+            long fromAccount = (ThreadLocalRandom.current().nextInt(BenchmarkConstants.ACCOUNT_COUNT) + 1);
+            // Ensure toAccount is different by selecting from remaining accounts
+            long toAccount = (fromAccount % BenchmarkConstants.ACCOUNT_COUNT) + 1;
+            int amount = ThreadLocalRandom.current().nextInt(BenchmarkConstants.MAX_TRANSFER_AMOUNT)
+                    + BenchmarkConstants.MIN_TRANSFER_AMOUNT;
+
+            // Debit from source account
+            try (PreparedStatement pstmt =
+                    conn.prepareStatement("UPDATE accounts SET balance = balance - ? WHERE id = ?")) {
+                pstmt.setInt(1, amount);
+                pstmt.setLong(2, fromAccount);
+                pstmt.executeUpdate();
+            }
+
+            // Credit to destination account
+            try (PreparedStatement pstmt =
+                    conn.prepareStatement("UPDATE accounts SET balance = balance + ? WHERE id = ?")) {
+                pstmt.setInt(1, amount);
+                pstmt.setLong(2, toAccount);
+                pstmt.executeUpdate();
+            }
+
+            conn.commit();
+        }
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+    @Override
+    public void destroy() {
+        if (isRealMode()) {
+            destroyRealMode();
+        }
+        LOGGER.info("XA mode executor destroyed");
+    }
+
+    private void destroyRealMode() {
+        LOGGER.info("Destroying Real XA mode resources");
+
+        if (rawDataSource != null && !rawDataSource.isClosed()) {
+            rawDataSource.close();
+            LOGGER.info("DataSource closed");
+        }
+
+        if (mysqlContainer != null && mysqlContainer.isRunning()) {
+            mysqlContainer.stop();
+            LOGGER.info("MySQL container stopped");
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR adds XA transaction mode support to the benchmark CLI, completing the coverage of all four Seata transaction modes (AT/TCC/SAGA/XA).

### Ⅱ. Does this pull request fix one issue?

Fixes #8010

### Ⅲ. Why don't you add test cases (unit test/integration test)?

The benchmark CLI itself is a testing tool. Running `--mode XA` with various parameters serves as the test.

### Ⅳ. Describe how to verify it

1. Build the benchmark CLI: `mvn clean package -pl test-suite/seata-benchmark-cli -DskipTests`
2. Run XA mode with empty transaction: `java -jar seata-benchmark-cli.jar --mode XA --branches 0 --threads 10 --duration 60`
3. Run XA mode with real transactions (requires Docker): `java -jar seata-benchmark-cli.jar --mode XA --branches 2 --threads 10 --duration 60`

### Ⅴ. Special notes for reviewers

**Changes:**

1. **XAModeExecutor.java** (new file)
   - Follows the same pattern as `ATModeExecutor`
   - Supports `--branches 0` for empty transaction mode (pure protocol overhead testing)
   - Supports `--branches N` for real mode with MySQL via Testcontainers
   - Uses `DataSourceProxyXA` for XA transaction support

2. **BenchmarkConfig.java**
   - Updated `validateMode()` to accept XA mode

3. **BenchmarkRunner.java**
   - Added `XAModeExecutor` import
   - Added XA case in `createExecutor()` method

**Key Differences from AT Mode:**
- AT mode uses `DataSourceProxy` with automatic undo log
- XA mode uses `DataSourceProxyXA` with XA protocol (2PC)
- Both support empty and real transaction modes for comprehensive performance testing
