### PR TITLE
optimize: mark deprecated JSON parsers in tcc, saga, common and integration-tx-api modules

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -45,6 +45,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7955](https://github.com/apache/incubator-seata/pull/7955)] change the getProperty call to resolvePlaceholders
 - [[#7971](https://github.com/apache/incubator-seata/pull/7971)] upgrade some dependencies
 - [[#7970](https://github.com/apache/incubator-seata/pull/7970)] Remove unnecessary refreshLeader from ClusterController cluster endpoint
+- [[#8019](https://github.com/apache/incubator-seata/pull/8019)] mark deprecated JSON parsers
 
 
 ### security:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -47,7 +47,7 @@
 - [[#7955](https://github.com/apache/incubator-seata/pull/7955)] 将 getProperty 调用改为 resolvePlaceholders
 - [[#7971](https://github.com/apache/incubator-seata/pull/7971)] 升级一些依赖
 - [[#7970](https://github.com/apache/incubator-seata/pull/7970)] 移除 ClusterController 中不必要的 refreshLeader 调用
-
+- [[#8019](https://github.com/apache/incubator-seata/pull/8019)] 标记弃用的json解析器
 
 
 

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/json/JsonParser.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/json/JsonParser.java
@@ -18,6 +18,10 @@ package org.apache.seata.integration.tx.api.json;
 
 import java.io.IOException;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.JsonSerializer} in json-common module instead.
+ */
+@Deprecated
 public interface JsonParser {
 
     String toJSONString(Object object) throws IOException;

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/json/JsonParserFactory.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/json/JsonParserFactory.java
@@ -24,6 +24,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.JsonSerializerFactory} in json-common module instead.
+ */
+@Deprecated
 public class JsonParserFactory {
 
     private static final Map<String, JsonParserWrap> JSON_PARSER_INSTANCES = new ConcurrentHashMap<>();

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/json/JsonParserWrap.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/json/JsonParserWrap.java
@@ -18,6 +18,10 @@ package org.apache.seata.integration.tx.api.json;
 
 import org.apache.seata.common.exception.JsonParseException;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.JsonSerializer} in json-common module instead.
+ */
+@Deprecated
 public class JsonParserWrap implements JsonParser {
 
     private JsonParser jsonParser;

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/util/JsonUtil.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/util/JsonUtil.java
@@ -24,6 +24,10 @@ import org.apache.seata.integration.tx.api.json.JsonParserFactory;
 
 import java.util.Objects;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.JsonUtil} in json-common module instead.
+ */
+@Deprecated
 public class JsonUtil {
 
     private static final String CONFIG_JSON_PARSER_NAME = ConfigurationFactory.getInstance()

--- a/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/JsonParser.java
+++ b/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/JsonParser.java
@@ -19,7 +19,9 @@ package org.apache.seata.saga.statelang.parser;
 /**
  * Json Parser
  *
+ * @deprecated use {@link org.apache.seata.common.json.JsonSerializer} in json-common module instead.
  */
+@Deprecated
 public interface JsonParser {
 
     /**

--- a/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/JsonParserFactory.java
+++ b/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/JsonParserFactory.java
@@ -25,7 +25,9 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * JsonParserFactory
  *
+ * @deprecated use {@link org.apache.seata.common.json.JsonSerializerFactory} in json-common module instead.
  */
+@Deprecated
 public class JsonParserFactory {
 
     private JsonParserFactory() {}

--- a/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/impl/FastjsonParser.java
+++ b/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/impl/FastjsonParser.java
@@ -25,7 +25,9 @@ import org.apache.seata.saga.statelang.parser.JsonParser;
 /**
  * JsonParser implement by Fastjson
  *
+ * @deprecated use {@link org.apache.seata.common.json.impl.FastjsonJsonSerializer} in json-common module instead.
  */
+@Deprecated
 @LoadLevel(name = FastjsonParser.NAME)
 public class FastjsonParser implements JsonParser {
 

--- a/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/impl/JacksonJsonParser.java
+++ b/saga/seata-saga-statelang/src/main/java/org/apache/seata/saga/statelang/parser/impl/JacksonJsonParser.java
@@ -32,7 +32,9 @@ import java.util.List;
 /**
  * JsonParser implement by Jackson
  *
+ * @deprecated use {@link org.apache.seata.common.json.impl.JacksonJsonSerializer} in json-common module instead.
  */
+@Deprecated
 @LoadLevel(name = JacksonJsonParser.NAME)
 public class JacksonJsonParser implements JsonParser {
 

--- a/tcc/src/main/java/org/apache/seata/rm/tcc/json/FastJsonParser.java
+++ b/tcc/src/main/java/org/apache/seata/rm/tcc/json/FastJsonParser.java
@@ -21,6 +21,10 @@ import org.apache.seata.common.Constants;
 import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.integration.tx.api.json.JsonParser;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.impl.FastjsonJsonSerializer} in json-common module instead.
+ */
+@Deprecated
 @LoadLevel(name = Constants.FASTJSON_JSON_PARSER_NAME)
 public class FastJsonParser implements JsonParser {
 

--- a/tcc/src/main/java/org/apache/seata/rm/tcc/json/GsonJsonParser.java
+++ b/tcc/src/main/java/org/apache/seata/rm/tcc/json/GsonJsonParser.java
@@ -24,6 +24,10 @@ import org.apache.seata.integration.tx.api.json.JsonParser;
 
 import java.lang.reflect.Modifier;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.impl.GsonJsonSerializer} in json-common module instead.
+ */
+@Deprecated
 @LoadLevel(name = Constants.GSON_JSON_PARSER_NAME)
 public class GsonJsonParser implements JsonParser {
 

--- a/tcc/src/main/java/org/apache/seata/rm/tcc/json/JacksonJsonParser.java
+++ b/tcc/src/main/java/org/apache/seata/rm/tcc/json/JacksonJsonParser.java
@@ -27,6 +27,10 @@ import org.apache.seata.integration.tx.api.json.JsonParser;
 
 import java.io.IOException;
 
+/**
+ * @deprecated use {@link org.apache.seata.common.json.impl.JacksonJsonSerializer} in json-common module instead.
+ */
+@Deprecated
 @LoadLevel(name = Constants.JACKSON_JSON_PARSER_NAME)
 public class JacksonJsonParser implements JsonParser {
 


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
mark deprecated json parser

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

