### PR TITLE
feature: add UnregisterRM protocol to notify server on client destroy

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -26,6 +26,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7865](https://github.com/apache/incubator-seata/pull/7865)] add Benchmark CLI tool
 - [[#7903](https://github.com/apache/incubator-seata/pull/7903)] Support HTTP/2 stream push for the Watch API in Server Raft mode
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] add Grafana dashboard JSON for NamingServer metrics
+- [[#8020](https://github.com/apache/incubator-seata/pull/8020)] add UnregisterRM protocol to notify server on client destroy
 
 ### bugfix:
 
@@ -80,6 +81,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [xingfudeshi](https://github.com/xingfudeshi)
 - [Sumit6307](https://github.com/Sumit6307)
 - [xiaoxiangyeyu0](https://github.com/xiaoxiangyeyu0)
+- [WangzJi](https://github.com/WangzJi)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,6 +27,7 @@
 - [[#7903](https://github.com/apache/incubator-seata/pull/7903)] 在Server Raft模式下支持Watch API的HTTP/2流推送
 - [[#8014](https://github.com/apache/incubator-seata/pull/8014)] 为 benchmark CLI 添加 P99.9 尾延迟百分位
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] 为namingserver指标增加Grafana dashboard JSON
+- [[#8020](https://github.com/apache/incubator-seata/pull/8020)] 新增 UnregisterRM 协议，在客户端销毁时通知服务端
 
 ### bugfix:
 
@@ -85,5 +86,6 @@
 - [xingfudeshi](https://github.com/xingfudeshi)
 - [Sumit6307](https://github.com/Sumit6307)
 - [xiaoxiangyeyu0](https://github.com/xiaoxiangyeyu0)
+- [WangzJi](https://github.com/WangzJi)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/core/src/main/java/org/apache/seata/core/protocol/MessageType.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/MessageType.java
@@ -139,6 +139,14 @@ public interface MessageType {
      */
     short TYPE_REG_RM_RESULT = 104;
     /**
+     * The constant TYPE_UNREG_RM.
+     */
+    short TYPE_UNREG_RM = 105;
+    /**
+     * The constant TYPE_UNREG_RM_RESULT.
+     */
+    short TYPE_UNREG_RM_RESULT = 106;
+    /**
      * The constant TYPE_RM_DELETE_UNDOLOG.
      */
     short TYPE_RM_DELETE_UNDOLOG = 111;

--- a/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
@@ -21,6 +21,10 @@ package org.apache.seata.core.protocol;
  */
 public class UnregisterRMRequest extends AbstractIdentifyRequest {
 
+    public UnregisterRMRequest() {
+        this(null, null);
+    }
+
     public UnregisterRMRequest(String applicationId, String transactionServiceGroup) {
         super(applicationId, transactionServiceGroup);
     }

--- a/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
@@ -16,12 +16,10 @@
  */
 package org.apache.seata.core.protocol;
 
-import java.io.Serializable;
-
 /**
  * The type Unregister rm request.
  */
-public class UnregisterRMRequest extends AbstractIdentifyRequest implements Serializable {
+public class UnregisterRMRequest extends AbstractIdentifyRequest {
 
     public UnregisterRMRequest() {
         this(null, null);

--- a/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.protocol;
+
+import java.io.Serializable;
+
+/**
+ * The type Unregister rm request.
+ */
+public class UnregisterRMRequest extends AbstractIdentifyRequest implements Serializable {
+
+    public UnregisterRMRequest() {
+        this(null, null);
+    }
+
+    public UnregisterRMRequest(String applicationId, String transactionServiceGroup) {
+        super(applicationId, transactionServiceGroup);
+    }
+
+    private String resourceIds;
+
+    public String getResourceIds() {
+        return resourceIds;
+    }
+
+    public void setResourceIds(String resourceIds) {
+        this.resourceIds = resourceIds;
+    }
+
+    @Override
+    public short getTypeCode() {
+        return MessageType.TYPE_UNREG_RM;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("UnregisterRMRequest{");
+        sb.append("resourceIds='").append(resourceIds).append('\'');
+        sb.append(", version='").append(version).append('\'');
+        sb.append(", applicationId='").append(applicationId).append('\'');
+        sb.append(", transactionServiceGroup='").append(transactionServiceGroup).append('\'');
+        sb.append(", extraData='").append(extraData).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
@@ -21,9 +21,6 @@ package org.apache.seata.core.protocol;
  */
 public class UnregisterRMRequest extends AbstractIdentifyRequest {
 
-    public UnregisterRMRequest() {
-        this(null, null);
-    }
 
     public UnregisterRMRequest(String applicationId, String transactionServiceGroup) {
         super(applicationId, transactionServiceGroup);

--- a/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMRequest.java
@@ -21,7 +21,6 @@ package org.apache.seata.core.protocol;
  */
 public class UnregisterRMRequest extends AbstractIdentifyRequest {
 
-
     public UnregisterRMRequest(String applicationId, String transactionServiceGroup) {
         super(applicationId, transactionServiceGroup);
     }

--- a/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMResponse.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/UnregisterRMResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.protocol;
+
+import java.io.Serializable;
+
+/**
+ * The type Unregister rm response.
+ */
+public class UnregisterRMResponse extends AbstractIdentifyResponse implements Serializable {
+
+    public UnregisterRMResponse() {
+        this(true);
+    }
+
+    public UnregisterRMResponse(boolean result) {
+        super();
+        setIdentified(result);
+        setResultCode(result ? ResultCode.Success : ResultCode.Failed);
+    }
+
+    @Override
+    public short getTypeCode() {
+        return MessageType.TYPE_UNREG_RM_RESULT;
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/protocol/Version.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/Version.java
@@ -41,6 +41,7 @@ public class Version {
     private static final String VERSION_0_7_1 = "0.7.1";
     private static final String VERSION_1_5_0 = "1.5.0";
     private static final String VERSION_2_3_0 = "2.3.0";
+    private static final String VERSION_2_6_0 = "2.6.0";
 
     public static final String VERSION_0_7_0 = "0.7.0";
 
@@ -50,6 +51,11 @@ public class Version {
      * The constant VERSION_MAP.
      */
     public static final Map<String, String> VERSION_MAP = new ConcurrentHashMap<>();
+
+    /**
+     * Cache server version from RegisterRMResponse, keyed by server address.
+     */
+    public static final Map<String, String> SERVER_VERSION_MAP = new ConcurrentHashMap<>();
 
     private Version() {}
 
@@ -94,6 +100,22 @@ public class Version {
 
     public static boolean isAboveOrEqualVersion230(String version) {
         return isAboveOrEqualVersion(version, VERSION_2_3_0);
+    }
+
+    public static boolean isAboveOrEqualVersion260(String version) {
+        return isAboveOrEqualVersion(version, VERSION_2_6_0);
+    }
+
+    public static void putServerVersion(String serverAddress, String version) {
+        SERVER_VERSION_MAP.put(serverAddress, version);
+    }
+
+    public static String getServerVersion(String serverAddress) {
+        return SERVER_VERSION_MAP.get(serverAddress);
+    }
+
+    public static void removeServerVersion(String serverAddress) {
+        SERVER_VERSION_MAP.remove(serverAddress);
     }
 
     public static boolean isV0(String version) {

--- a/core/src/main/java/org/apache/seata/core/protocol/Version.java
+++ b/core/src/main/java/org/apache/seata/core/protocol/Version.java
@@ -52,11 +52,6 @@ public class Version {
      */
     public static final Map<String, String> VERSION_MAP = new ConcurrentHashMap<>();
 
-    /**
-     * Cache server version from RegisterRMResponse, keyed by server address.
-     */
-    public static final Map<String, String> SERVER_VERSION_MAP = new ConcurrentHashMap<>();
-
     private Version() {}
 
     /**
@@ -104,18 +99,6 @@ public class Version {
 
     public static boolean isAboveOrEqualVersion260(String version) {
         return isAboveOrEqualVersion(version, VERSION_2_6_0);
-    }
-
-    public static void putServerVersion(String serverAddress, String version) {
-        SERVER_VERSION_MAP.put(serverAddress, version);
-    }
-
-    public static String getServerVersion(String serverAddress) {
-        return SERVER_VERSION_MAP.get(serverAddress);
-    }
-
-    public static void removeServerVersion(String serverAddress) {
-        SERVER_VERSION_MAP.remove(serverAddress);
     }
 
     public static boolean isV0(String version) {

--- a/core/src/main/java/org/apache/seata/core/rpc/RpcContext.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/RpcContext.java
@@ -285,6 +285,20 @@ public class RpcContext {
     }
 
     /**
+     * Remove resource.
+     *
+     * @param resourceId the resource id
+     */
+    public void removeResource(String resourceId) {
+        if (resourceSets != null) {
+            resourceSets.remove(resourceId);
+        }
+        if (clientRMHolderMap != null) {
+            clientRMHolderMap.remove(resourceId);
+        }
+    }
+
+    /**
      * Add resource.
      *
      * @param resource the resource

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -696,7 +696,9 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
             }
             timerExecutor.execute(() -> {
                 try {
-                    clientChannelManager.releaseChannel(ctx.channel(), getAddressFromChannel(ctx.channel()));
+                    String serverAddress = getAddressFromChannel(ctx.channel());
+                    clientChannelManager.releaseChannel(ctx.channel(), serverAddress);
+                    clientChannelManager.cleanupDisconnectedChannelMetadata(serverAddress);
                 } catch (Throwable throwable) {
                     LOGGER.error("release channel error: {}", throwable.getMessage(), throwable);
                 }

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
@@ -200,10 +200,10 @@ public class ChannelManager {
      * @param channel     the channel
      * @param resourceIds the resource ids to unregister
      */
-    public static void unregisterRMChannel(Channel channel, Set<String> resourceIds) {
+    public static boolean unregisterRMChannel(Channel channel, Set<String> resourceIds) {
         RpcContext rpcContext = IDENTIFIED_CHANNELS.get(channel);
         if (rpcContext == null) {
-            return;
+            return false;
         }
         String applicationId = rpcContext.getApplicationId();
         String clientIp = ChannelUtil.getClientIpFromChannel(channel);
@@ -238,6 +238,7 @@ public class ChannelManager {
         if (rpcContext.getResourceSets() == null || rpcContext.getResourceSets().isEmpty()) {
             IDENTIFIED_CHANNELS.remove(channel);
         }
+        return true;
     }
 
     private static void updateChannelsResource(String resourceId, String clientIp, String applicationId) {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
@@ -223,14 +223,14 @@ public class ChannelManager {
             if (portMap != null) {
                 portMap.remove(clientPort);
                 if (portMap.isEmpty()) {
-                    ipMap.remove(clientIp);
+                    ipMap.remove(clientIp, portMap);
                 }
             }
             if (ipMap.isEmpty()) {
-                applicationIdMap.remove(applicationId);
+                applicationIdMap.remove(applicationId, ipMap);
             }
             if (applicationIdMap.isEmpty()) {
-                RM_CHANNELS.remove(resourceId);
+                RM_CHANNELS.remove(resourceId, applicationIdMap);
             }
             rpcContext.removeResource(resourceId);
         }

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
@@ -194,6 +194,52 @@ public class ChannelManager {
         }
     }
 
+    /**
+     * Unregister rm channel for the specified resource ids.
+     *
+     * @param channel     the channel
+     * @param resourceIds the resource ids to unregister
+     */
+    public static void unregisterRMChannel(Channel channel, Set<String> resourceIds) {
+        RpcContext rpcContext = IDENTIFIED_CHANNELS.get(channel);
+        if (rpcContext == null) {
+            return;
+        }
+        String applicationId = rpcContext.getApplicationId();
+        String clientIp = ChannelUtil.getClientIpFromChannel(channel);
+        Integer clientPort = ChannelUtil.getClientPortFromChannel(channel);
+
+        for (String resourceId : resourceIds) {
+            ConcurrentMap<String, ConcurrentMap<String, ConcurrentMap<Integer, RpcContext>>> applicationIdMap =
+                    RM_CHANNELS.get(resourceId);
+            if (applicationIdMap == null) {
+                continue;
+            }
+            ConcurrentMap<String, ConcurrentMap<Integer, RpcContext>> ipMap = applicationIdMap.get(applicationId);
+            if (ipMap == null) {
+                continue;
+            }
+            ConcurrentMap<Integer, RpcContext> portMap = ipMap.get(clientIp);
+            if (portMap != null) {
+                portMap.remove(clientPort);
+                if (portMap.isEmpty()) {
+                    ipMap.remove(clientIp);
+                }
+            }
+            if (ipMap.isEmpty()) {
+                applicationIdMap.remove(applicationId);
+            }
+            if (applicationIdMap.isEmpty()) {
+                RM_CHANNELS.remove(resourceId);
+            }
+            rpcContext.removeResource(resourceId);
+        }
+
+        if (rpcContext.getResourceSets() == null || rpcContext.getResourceSets().isEmpty()) {
+            IDENTIFIED_CHANNELS.remove(channel);
+        }
+    }
+
     private static void updateChannelsResource(String resourceId, String clientIp, String applicationId) {
         ConcurrentMap<Integer, RpcContext> sourcePortMap =
                 RM_CHANNELS.get(resourceId).get(applicationId).get(clientIp);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -160,6 +160,7 @@ class NettyClientChannelManager {
         try {
             if (channel.equals(channels.get(serverAddress))) {
                 channels.remove(serverAddress);
+                serverVersionMap.remove(serverAddress);
             }
             nettyClientKeyPool.returnObject(poolKeyMap.get(serverAddress), channel);
         } catch (Exception exx) {
@@ -283,6 +284,7 @@ class NettyClientChannelManager {
             } else {
                 RegistryFactory.getInstance().refreshAliveLookup(transactionServiceGroup, Collections.emptyList());
             }
+            cleanupStaleAddresses(availList);
         }
     }
 
@@ -309,6 +311,37 @@ class NettyClientChannelManager {
 
     void clearServerVersions() {
         serverVersionMap.clear();
+    }
+
+    /**
+     * Remove entries from internal maps for addresses that are no longer
+     * in the available server list and have no active channel.
+     * This prevents unbounded map growth in environments like Kubernetes
+     * where server IPs change frequently.
+     */
+    private void cleanupStaleAddresses(List<String> availList) {
+        Set<String> availSet = new HashSet<>(availList);
+        Set<String> staleAddresses = serverVersionMap.keySet().stream()
+                .filter(address -> !availSet.contains(address) && !channels.containsKey(address))
+                .collect(Collectors.toSet());
+
+        poolKeyMap.keySet().stream()
+                .filter(address -> !availSet.contains(address) && !channels.containsKey(address))
+                .forEachOrdered(staleAddresses::add);
+
+        channelLocks.keySet().stream()
+                .filter(address -> !availSet.contains(address) && !channels.containsKey(address))
+                .forEachOrdered(staleAddresses::add);
+
+        staleAddresses.forEach(address -> {
+            serverVersionMap.remove(address);
+            poolKeyMap.remove(address);
+            channelLocks.remove(address);
+        });
+        
+        if (!staleAddresses.isEmpty() && LOGGER.isInfoEnabled()) {
+            LOGGER.info("Cleaned up stale channel metadata for addresses: {}", staleAddresses);
+        }
     }
 
     private Channel doConnect(String serverAddress) {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -127,7 +127,8 @@ class NettyClientChannelManager {
             return;
         }
         try {
-            synchronized (channelLocks.get(serverAddress)) {
+            Object lockObj = CollectionUtils.computeIfAbsent(channelLocks, serverAddress, key -> new Object());
+            synchronized (lockObj) {
                 Channel ch = channels.get(serverAddress);
                 if (ch == null) {
                     nettyClientKeyPool.returnObject(poolKeyMap.get(serverAddress), channel);
@@ -284,7 +285,6 @@ class NettyClientChannelManager {
             } else {
                 RegistryFactory.getInstance().refreshAliveLookup(transactionServiceGroup, Collections.emptyList());
             }
-            cleanupStaleAddresses(availList);
         }
     }
 
@@ -314,33 +314,26 @@ class NettyClientChannelManager {
     }
 
     /**
-     * Remove entries from internal maps for addresses that are no longer
-     * in the available server list and have no active channel.
-     * This prevents unbounded map growth in environments like Kubernetes
-     * where server IPs change frequently.
+     * Clean up metadata for a disconnected channel's address.
+     * Called from the channelInactive event handler after the channel
+     * has been released. Skips cleanup if a new channel already exists
+     * for the same address (reconnection happened before cleanup).
+     *
+     * @param serverAddress the address whose metadata should be cleaned
      */
-    private void cleanupStaleAddresses(List<String> availList) {
-        Set<String> availSet = new HashSet<>(availList);
-        Set<String> staleAddresses = serverVersionMap.keySet().stream()
-                .filter(address -> !availSet.contains(address) && !channels.containsKey(address))
-                .collect(Collectors.toSet());
-
-        poolKeyMap.keySet().stream()
-                .filter(address -> !availSet.contains(address) && !channels.containsKey(address))
-                .forEachOrdered(staleAddresses::add);
-
-        channelLocks.keySet().stream()
-                .filter(address -> !availSet.contains(address) && !channels.containsKey(address))
-                .forEachOrdered(staleAddresses::add);
-
-        staleAddresses.forEach(address -> {
-            serverVersionMap.remove(address);
-            poolKeyMap.remove(address);
-            channelLocks.remove(address);
-        });
-
-        if (!staleAddresses.isEmpty() && LOGGER.isInfoEnabled()) {
-            LOGGER.info("Cleaned up stale channel metadata for addresses: {}", staleAddresses);
+    void cleanupDisconnectedChannelMetadata(String serverAddress) {
+        if (serverAddress == null) {
+            return;
+        }
+        if (channels.containsKey(serverAddress)) {
+            return;
+        }
+        boolean removed = false;
+        removed |= serverVersionMap.remove(serverAddress) != null;
+        removed |= poolKeyMap.remove(serverAddress) != null;
+        removed |= channelLocks.remove(serverAddress) != null;
+        if (removed && LOGGER.isInfoEnabled()) {
+            LOGGER.info("Cleaned up channel metadata for disconnected address: {}", serverAddress);
         }
     }
 

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -58,6 +58,8 @@ class NettyClientChannelManager {
 
     private final ConcurrentMap<String, Channel> channels = new ConcurrentHashMap<>();
 
+    private final ConcurrentMap<String, String> serverVersionMap = new ConcurrentHashMap<>();
+
     private final GenericKeyedObjectPool<NettyPoolKey, Channel> nettyClientKeyPool;
 
     private Function<String, NettyPoolKey> poolKeyFunction;
@@ -295,6 +297,18 @@ class NettyClientChannelManager {
         }
         channels.put(serverAddress, channel);
         Version.putChannelVersion(channel, version);
+    }
+
+    void putServerVersion(String serverAddress, String version) {
+        serverVersionMap.put(serverAddress, version);
+    }
+
+    String getServerVersion(String serverAddress) {
+        return serverVersionMap.get(serverAddress);
+    }
+
+    void clearServerVersions() {
+        serverVersionMap.clear();
     }
 
     private Channel doConnect(String serverAddress) {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -338,7 +338,7 @@ class NettyClientChannelManager {
             poolKeyMap.remove(address);
             channelLocks.remove(address);
         });
-        
+
         if (!staleAddresses.isEmpty() && LOGGER.isInfoEnabled()) {
             LOGGER.info("Cleaned up stale channel metadata for addresses: {}", staleAddresses);
         }

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyRemotingServer.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyRemotingServer.java
@@ -26,6 +26,7 @@ import org.apache.seata.core.rpc.processor.server.RegTmProcessor;
 import org.apache.seata.core.rpc.processor.server.ServerHeartbeatProcessor;
 import org.apache.seata.core.rpc.processor.server.ServerOnRequestProcessor;
 import org.apache.seata.core.rpc.processor.server.ServerOnResponseProcessor;
+import org.apache.seata.core.rpc.processor.server.UnregRmProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +122,9 @@ public class NettyRemotingServer extends AbstractNettyRemotingServer {
         // 3. registry rm message processor
         RegRmProcessor regRmProcessor = new RegRmProcessor(this);
         super.registerProcessor(MessageType.TYPE_REG_RM, regRmProcessor, messageExecutor);
+        // 3.1 registry rm unregister message processor
+        UnregRmProcessor unregRmProcessor = new UnregRmProcessor(this);
+        super.registerProcessor(MessageType.TYPE_UNREG_RM, unregRmProcessor, messageExecutor);
         // 4. registry tm message processor
         RegTmProcessor regTmProcessor = new RegTmProcessor(this);
         super.registerProcessor(MessageType.TYPE_REG_CLT, regTmProcessor, null);

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -218,7 +218,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                     channel);
         }
         getClientChannelManager().registerChannel(serverAddress, channel, registerRMRequest.getVersion());
-        Version.putServerVersion(serverAddress, registerRMResponse.getVersion());
+        getClientChannelManager().putServerVersion(serverAddress, registerRMResponse.getVersion());
         String dbKey = getMergedResourceKeys();
         if (registerRMRequest.getResourceIds() != null) {
             if (!registerRMRequest.getResourceIds().equals(dbKey)) {
@@ -311,7 +311,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                 if (!channel.isActive()) {
                     continue;
                 }
-                String serverVersion = Version.getServerVersion(serverAddress);
+                String serverVersion = getClientChannelManager().getServerVersion(serverAddress);
                 if (serverVersion == null || !Version.isAboveOrEqualVersion260(serverVersion)) {
                     LOGGER.warn(
                             "Server {} does not support UnregisterRMRequest (version: {})",
@@ -370,7 +370,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                 sendUnregisterToServers(allResourceIds);
             }
         }
-        Version.SERVER_VERSION_MAP.clear();
+        getClientChannelManager().clearServerVersions();
         super.destroy();
         initialized.getAndSet(false);
         instance = null;

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -299,10 +299,11 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         if (StringUtils.isBlank(transactionServiceGroup) || StringUtils.isBlank(resourceId)) {
             return;
         }
-        if (getClientChannelManager().getChannels().isEmpty()) {
-            return;
-        }
-        synchronized (getClientChannelManager().getChannels()) {
+        sendUnregisterToServers(resourceId);
+    }
+
+    private void sendUnregisterToServers(String resourceIds) {
+        try {
             for (Map.Entry<String, Channel> entry :
                     getClientChannelManager().getChannels().entrySet()) {
                 String serverAddress = entry.getKey();
@@ -319,7 +320,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                     continue;
                 }
                 UnregisterRMRequest message = new UnregisterRMRequest(applicationId, transactionServiceGroup);
-                message.setResourceIds(resourceId);
+                message.setResourceIds(resourceIds);
                 try {
                     super.sendAsyncRequest(channel, message);
                 } catch (FrameworkException e) {
@@ -329,10 +330,12 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                             LOGGER.info("remove not writable channel:{}", channel);
                         }
                     } else {
-                        LOGGER.error("unregister resource failed, channel:{},resourceId:{}", channel, resourceId, e);
+                        LOGGER.error("unregister resource failed, channel:{},resourceIds:{}", channel, resourceIds, e);
                     }
                 }
             }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to send unregister request for resource {}", resourceIds, e);
         }
     }
 
@@ -364,29 +367,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         if (resourceManager != null && StringUtils.isNotBlank(transactionServiceGroup)) {
             String allResourceIds = getMergedResourceKeys();
             if (StringUtils.isNotBlank(allResourceIds)) {
-                for (Map.Entry<String, Channel> entry :
-                        getClientChannelManager().getChannels().entrySet()) {
-                    String serverAddress = entry.getKey();
-                    Channel channel = entry.getValue();
-                    if (!channel.isActive()) {
-                        continue;
-                    }
-                    String serverVersion = Version.getServerVersion(serverAddress);
-                    if (serverVersion == null || !Version.isAboveOrEqualVersion260(serverVersion)) {
-                        LOGGER.warn(
-                                "Server {} does not support UnregisterRMRequest (version: {})",
-                                serverAddress,
-                                serverVersion);
-                        continue;
-                    }
-                    UnregisterRMRequest message = new UnregisterRMRequest(applicationId, transactionServiceGroup);
-                    message.setResourceIds(allResourceIds);
-                    try {
-                        super.sendAsyncRequest(channel, message);
-                    } catch (Exception e) {
-                        LOGGER.warn("Failed to send unregister request to server {}", serverAddress, e);
-                    }
-                }
+                sendUnregisterToServers(allResourceIds);
             }
         }
         Version.SERVER_VERSION_MAP.clear();

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -17,6 +17,7 @@
 package org.apache.seata.core.rpc.netty;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import org.apache.seata.common.DefaultValues;
 import org.apache.seata.common.exception.FrameworkErrorCode;
 import org.apache.seata.common.exception.FrameworkException;
@@ -31,8 +32,10 @@ import org.apache.seata.core.model.Resource;
 import org.apache.seata.core.model.ResourceManager;
 import org.apache.seata.core.protocol.AbstractMessage;
 import org.apache.seata.core.protocol.MessageType;
+import org.apache.seata.core.protocol.ProtocolConstants;
 import org.apache.seata.core.protocol.RegisterRMRequest;
 import org.apache.seata.core.protocol.RegisterRMResponse;
+import org.apache.seata.core.protocol.RpcMessage;
 import org.apache.seata.core.protocol.UnregisterRMRequest;
 import org.apache.seata.core.protocol.Version;
 import org.apache.seata.core.rpc.netty.NettyPoolKey.TransactionRole;
@@ -44,6 +47,8 @@ import org.apache.seata.core.rpc.processor.client.RmUndoLogProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -302,7 +307,10 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         sendUnregisterToServers(resourceId);
     }
 
-    private void sendUnregisterToServers(String resourceIds) {
+    private static final long UNREGISTER_FLUSH_TIMEOUT_MS = 1000;
+
+    private List<ChannelFuture> sendUnregisterToServers(String resourceIds) {
+        List<ChannelFuture> futures = new ArrayList<>();
         try {
             for (Map.Entry<String, Channel> entry :
                     getClientChannelManager().getChannels().entrySet()) {
@@ -322,7 +330,12 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                 UnregisterRMRequest message = new UnregisterRMRequest(applicationId, transactionServiceGroup);
                 message.setResourceIds(resourceIds);
                 try {
-                    super.sendAsyncRequest(channel, message);
+                    if (!channel.isWritable()) {
+                        throw new FrameworkException(
+                                "msg:" + message.toString(), FrameworkErrorCode.ChannelIsNotWritable);
+                    }
+                    RpcMessage rpcMessage = buildRequestMessage(message, ProtocolConstants.MSGTYPE_RESQUEST_ONEWAY);
+                    futures.add(channel.writeAndFlush(rpcMessage));
                 } catch (FrameworkException e) {
                     if (e.getErrcode() == FrameworkErrorCode.ChannelIsNotWritable && serverAddress != null) {
                         getClientChannelManager().releaseChannel(channel, serverAddress);
@@ -337,6 +350,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         } catch (Exception e) {
             LOGGER.warn("Failed to send unregister request for resource {}", resourceIds, e);
         }
+        return futures;
     }
 
     public String getMergedResourceKeys() {
@@ -367,7 +381,15 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         if (resourceManager != null && StringUtils.isNotBlank(transactionServiceGroup)) {
             String allResourceIds = getMergedResourceKeys();
             if (StringUtils.isNotBlank(allResourceIds)) {
-                sendUnregisterToServers(allResourceIds);
+                List<ChannelFuture> futures = sendUnregisterToServers(allResourceIds);
+                for (ChannelFuture future : futures) {
+                    try {
+                        future.await(UNREGISTER_FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
             }
         }
         getClientChannelManager().clearServerVersions();

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -33,6 +33,8 @@ import org.apache.seata.core.protocol.AbstractMessage;
 import org.apache.seata.core.protocol.MessageType;
 import org.apache.seata.core.protocol.RegisterRMRequest;
 import org.apache.seata.core.protocol.RegisterRMResponse;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.core.protocol.Version;
 import org.apache.seata.core.rpc.netty.NettyPoolKey.TransactionRole;
 import org.apache.seata.core.rpc.processor.client.ClientHeartbeatProcessor;
 import org.apache.seata.core.rpc.processor.client.ClientOnResponseProcessor;
@@ -216,6 +218,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
                     channel);
         }
         getClientChannelManager().registerChannel(serverAddress, channel, registerRMRequest.getVersion());
+        Version.putServerVersion(serverAddress, registerRMResponse.getVersion());
         String dbKey = getMergedResourceKeys();
         if (registerRMRequest.getResourceIds() != null) {
             if (!registerRMRequest.getResourceIds().equals(dbKey)) {
@@ -292,6 +295,47 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         }
     }
 
+    public void unregisterResource(String resourceGroupId, String resourceId) {
+        if (StringUtils.isBlank(transactionServiceGroup) || StringUtils.isBlank(resourceId)) {
+            return;
+        }
+        if (getClientChannelManager().getChannels().isEmpty()) {
+            return;
+        }
+        synchronized (getClientChannelManager().getChannels()) {
+            for (Map.Entry<String, Channel> entry :
+                    getClientChannelManager().getChannels().entrySet()) {
+                String serverAddress = entry.getKey();
+                Channel channel = entry.getValue();
+                if (!channel.isActive()) {
+                    continue;
+                }
+                String serverVersion = Version.getServerVersion(serverAddress);
+                if (serverVersion == null || !Version.isAboveOrEqualVersion260(serverVersion)) {
+                    LOGGER.warn(
+                            "Server {} does not support UnregisterRMRequest (version: {})",
+                            serverAddress,
+                            serverVersion);
+                    continue;
+                }
+                UnregisterRMRequest message = new UnregisterRMRequest(applicationId, transactionServiceGroup);
+                message.setResourceIds(resourceId);
+                try {
+                    super.sendAsyncRequest(channel, message);
+                } catch (FrameworkException e) {
+                    if (e.getErrcode() == FrameworkErrorCode.ChannelIsNotWritable && serverAddress != null) {
+                        getClientChannelManager().releaseChannel(channel, serverAddress);
+                        if (LOGGER.isInfoEnabled()) {
+                            LOGGER.info("remove not writable channel:{}", channel);
+                        }
+                    } else {
+                        LOGGER.error("unregister resource failed, channel:{},resourceId:{}", channel, resourceId, e);
+                    }
+                }
+            }
+        }
+    }
+
     public String getMergedResourceKeys() {
         Map<String, Resource> managedResources = resourceManager.getManagedResources();
         Set<String> resourceIds = managedResources.keySet();
@@ -317,6 +361,35 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
 
     @Override
     public void destroy() {
+        if (resourceManager != null && StringUtils.isNotBlank(transactionServiceGroup)) {
+            String allResourceIds = getMergedResourceKeys();
+            if (StringUtils.isNotBlank(allResourceIds)) {
+                for (Map.Entry<String, Channel> entry :
+                        getClientChannelManager().getChannels().entrySet()) {
+                    String serverAddress = entry.getKey();
+                    Channel channel = entry.getValue();
+                    if (!channel.isActive()) {
+                        continue;
+                    }
+                    String serverVersion = Version.getServerVersion(serverAddress);
+                    if (serverVersion == null || !Version.isAboveOrEqualVersion260(serverVersion)) {
+                        LOGGER.warn(
+                                "Server {} does not support UnregisterRMRequest (version: {})",
+                                serverAddress,
+                                serverVersion);
+                        continue;
+                    }
+                    UnregisterRMRequest message = new UnregisterRMRequest(applicationId, transactionServiceGroup);
+                    message.setResourceIds(allResourceIds);
+                    try {
+                        super.sendAsyncRequest(channel, message);
+                    } catch (Exception e) {
+                        LOGGER.warn("Failed to send unregister request to server {}", serverAddress, e);
+                    }
+                }
+            }
+        }
+        Version.SERVER_VERSION_MAP.clear();
         super.destroy();
         initialized.getAndSet(false);
         instance = null;
@@ -371,6 +444,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         super.registerProcessor(MessageType.TYPE_BRANCH_STATUS_REPORT_RESULT, onResponseProcessor, null);
         super.registerProcessor(MessageType.TYPE_GLOBAL_LOCK_QUERY_RESULT, onResponseProcessor, null);
         super.registerProcessor(MessageType.TYPE_REG_RM_RESULT, onResponseProcessor, null);
+        super.registerProcessor(MessageType.TYPE_UNREG_RM_RESULT, onResponseProcessor, null);
         super.registerProcessor(MessageType.TYPE_BATCH_RESULT_MSG, onResponseProcessor, null);
         // 5.registry heartbeat message processor
         ClientHeartbeatProcessor clientHeartbeatProcessor = new ClientHeartbeatProcessor();

--- a/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
@@ -65,8 +65,14 @@ public class UnregRmProcessor implements RemotingProcessor {
             Set<String> resourceIdSet = new HashSet<>(Arrays.asList(resourceIdStr.split(Constants.DBKEYS_SPLIT_CHAR)));
             resourceIdSet.removeIf(StringUtils::isBlank);
             isSuccess = ChannelManager.unregisterRMChannel(ctx.channel(), resourceIdSet);
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("RM unregister success, message:{}, channel:{}", message, ctx.channel());
+            if (isSuccess) {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("RM unregister success, message:{}, channel:{}", message, ctx.channel());
+                }
+            } else {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("RM unregister not successful, message:{}, channel:{}", message, ctx.channel());
+                }
             }
         } catch (Exception exx) {
             LOGGER.error("RM unregister fail, client:{}, error message:{}", ipAndPort, exx.getMessage());

--- a/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
@@ -19,6 +19,7 @@ package org.apache.seata.core.rpc.processor.server;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.seata.common.Constants;
 import org.apache.seata.common.util.NetUtil;
+import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.core.protocol.RpcMessage;
 import org.apache.seata.core.protocol.UnregisterRMRequest;
 import org.apache.seata.core.protocol.UnregisterRMResponse;
@@ -55,6 +56,12 @@ public class UnregRmProcessor implements RemotingProcessor {
         boolean isSuccess = false;
         try {
             String resourceIdStr = message.getResourceIds();
+            if (StringUtils.isBlank(resourceIdStr)) {
+                LOGGER.warn("RM unregister request has empty resourceIds, client:{}", ipAndPort);
+                UnregisterRMResponse response = new UnregisterRMResponse(false);
+                remotingServer.sendAsyncResponse(rpcMessage, ctx.channel(), response);
+                return;
+            }
             Set<String> resourceIdSet = new HashSet<>(Arrays.asList(resourceIdStr.split(Constants.DBKEYS_SPLIT_CHAR)));
             ChannelManager.unregisterRMChannel(ctx.channel(), resourceIdSet);
             isSuccess = true;

--- a/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.rpc.processor.server;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.util.NetUtil;
+import org.apache.seata.core.protocol.RpcMessage;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.core.protocol.UnregisterRMResponse;
+import org.apache.seata.core.rpc.RemotingServer;
+import org.apache.seata.core.rpc.netty.ChannelManager;
+import org.apache.seata.core.rpc.processor.RemotingProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Process RM client unregister message.
+ * <p>
+ * process message type:
+ * {@link UnregisterRMRequest}
+ */
+public class UnregRmProcessor implements RemotingProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnregRmProcessor.class);
+
+    private RemotingServer remotingServer;
+
+    public UnregRmProcessor(RemotingServer remotingServer) {
+        this.remotingServer = remotingServer;
+    }
+
+    @Override
+    public void process(ChannelHandlerContext ctx, RpcMessage rpcMessage) throws Exception {
+        UnregisterRMRequest message = (UnregisterRMRequest) rpcMessage.getBody();
+        String ipAndPort = NetUtil.toStringAddress(ctx.channel().remoteAddress());
+        boolean isSuccess = false;
+        try {
+            String resourceIdStr = message.getResourceIds();
+            Set<String> resourceIdSet = new HashSet<>(Arrays.asList(resourceIdStr.split(Constants.DBKEYS_SPLIT_CHAR)));
+            ChannelManager.unregisterRMChannel(ctx.channel(), resourceIdSet);
+            isSuccess = true;
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("RM unregister success, message:{}, channel:{}", message, ctx.channel());
+            }
+        } catch (Exception exx) {
+            LOGGER.error("RM unregister fail, client:{}, error message:{}", ipAndPort, exx.getMessage());
+        }
+        UnregisterRMResponse response = new UnregisterRMResponse(isSuccess);
+        remotingServer.sendAsyncResponse(rpcMessage, ctx.channel(), response);
+    }
+}

--- a/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
@@ -63,8 +63,8 @@ public class UnregRmProcessor implements RemotingProcessor {
                 return;
             }
             Set<String> resourceIdSet = new HashSet<>(Arrays.asList(resourceIdStr.split(Constants.DBKEYS_SPLIT_CHAR)));
-            ChannelManager.unregisterRMChannel(ctx.channel(), resourceIdSet);
-            isSuccess = true;
+            resourceIdSet.removeIf(StringUtils::isBlank);
+            isSuccess = ChannelManager.unregisterRMChannel(ctx.channel(), resourceIdSet);
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("RM unregister success, message:{}, channel:{}", message, ctx.channel());
             }

--- a/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessor.java
@@ -75,7 +75,7 @@ public class UnregRmProcessor implements RemotingProcessor {
                 }
             }
         } catch (Exception exx) {
-            LOGGER.error("RM unregister fail, client:{}, error message:{}", ipAndPort, exx.getMessage());
+            LOGGER.error("RM unregister fail, client:{}, error message:{}", ipAndPort, exx.getMessage(), exx);
         }
         UnregisterRMResponse response = new UnregisterRMResponse(isSuccess);
         remotingServer.sendAsyncResponse(rpcMessage, ctx.channel(), response);

--- a/core/src/test/java/org/apache/seata/core/protocol/VersionTest.java
+++ b/core/src/test/java/org/apache/seata/core/protocol/VersionTest.java
@@ -35,6 +35,27 @@ public class VersionTest {
     }
 
     @Test
+    public void putAndGetServerVersionTest() {
+        String serverAddress = "127.0.0.1:8091";
+        Assertions.assertNull(Version.getServerVersion(serverAddress));
+
+        Version.putServerVersion(serverAddress, "2.6.0");
+        Assertions.assertEquals("2.6.0", Version.getServerVersion(serverAddress));
+
+        Version.removeServerVersion(serverAddress);
+        Assertions.assertNull(Version.getServerVersion(serverAddress));
+    }
+
+    @Test
+    public void isAboveOrEqualVersion260Test() {
+        Assertions.assertFalse(Version.isAboveOrEqualVersion260("2.5.0"));
+        Assertions.assertTrue(Version.isAboveOrEqualVersion260("2.6.0"));
+        Assertions.assertTrue(Version.isAboveOrEqualVersion260("3.0.0"));
+        Assertions.assertFalse(Version.isAboveOrEqualVersion260(""));
+        Assertions.assertFalse(Version.isAboveOrEqualVersion260("1.0.0"));
+    }
+
+    @Test
     public void testConvertVersion() {
         // case: success
         Assertions.assertDoesNotThrow(() -> {

--- a/core/src/test/java/org/apache/seata/core/protocol/VersionTest.java
+++ b/core/src/test/java/org/apache/seata/core/protocol/VersionTest.java
@@ -35,18 +35,6 @@ public class VersionTest {
     }
 
     @Test
-    public void putAndGetServerVersionTest() {
-        String serverAddress = "127.0.0.1:8091";
-        Assertions.assertNull(Version.getServerVersion(serverAddress));
-
-        Version.putServerVersion(serverAddress, "2.6.0");
-        Assertions.assertEquals("2.6.0", Version.getServerVersion(serverAddress));
-
-        Version.removeServerVersion(serverAddress);
-        Assertions.assertNull(Version.getServerVersion(serverAddress));
-    }
-
-    @Test
     public void isAboveOrEqualVersion260Test() {
         Assertions.assertFalse(Version.isAboveOrEqualVersion260("2.5.0"));
         Assertions.assertTrue(Version.isAboveOrEqualVersion260("2.6.0"));

--- a/core/src/test/java/org/apache/seata/core/rpc/RpcContextTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/RpcContextTest.java
@@ -262,6 +262,29 @@ public class RpcContextTest {
     }
 
     @Test
+    void removeResourceTest() {
+        rpcContext.addResource("db1");
+        rpcContext.addResource("db2");
+        rpcContext.holdInResourceManagerChannels("db1", 8080);
+        rpcContext.holdInResourceManagerChannels("db2", 8080);
+
+        rpcContext.removeResource("db1");
+
+        assertNotNull(rpcContext.getResourceSets());
+        assertEquals(1, rpcContext.getResourceSets().size());
+        assertTrue(rpcContext.getResourceSets().contains("db2"));
+        assertNull(rpcContext.getClientRMHolderMap().get("db1"));
+        assertNotNull(rpcContext.getClientRMHolderMap().get("db2"));
+    }
+
+    @Test
+    void removeResourceWithNullSetsTest() {
+        rpcContext.setResourceSets(null);
+        rpcContext.removeResource("db1");
+        assertNull(rpcContext.getResourceSets());
+    }
+
+    @Test
     void testRelease() {
         Channel mockChannel = Mockito.mock(Channel.class);
         rpcContext.setChannel(mockChannel);

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/ChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/ChannelManagerTest.java
@@ -1060,4 +1060,65 @@ public class ChannelManagerTest {
 
         assertFalse(ChannelManager.isRegistered(ch));
     }
+
+    @Test
+    public void unregisterRMChannelWithUnknownChannelReturnsFalseTest() {
+        Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 9999));
+
+        Set<String> toRemove = new HashSet<>();
+        toRemove.add("resource1");
+        boolean result = ChannelManager.unregisterRMChannel(ch, toRemove);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void unregisterRMChannelWithNonExistentResourceIdTest() throws Exception {
+        Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 9092));
+        when(ch.isActive()).thenReturn(true);
+
+        RegisterRMRequest request = new RegisterRMRequest();
+        request.setApplicationId("test-app");
+        request.setTransactionServiceGroup("test-group");
+        request.setVersion("2.6.0");
+        request.setResourceIds("resource1");
+        ChannelManager.registerRMChannel(request, ch);
+
+        assertTrue(ChannelManager.isRegistered(ch));
+
+        Set<String> toRemove = new HashSet<>();
+        toRemove.add("nonExistentResource");
+        boolean result = ChannelManager.unregisterRMChannel(ch, toRemove);
+
+        assertTrue(result);
+        assertTrue(ChannelManager.isRegistered(ch));
+        RpcContext ctx = ChannelManager.getContextFromIdentified(ch);
+        assertNotNull(ctx);
+        assertTrue(ctx.getResourceSets().contains("resource1"));
+    }
+
+    @Test
+    public void unregisterRMChannelCleanupEmptyMapsTest() throws Exception {
+        Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 9093));
+        when(ch.isActive()).thenReturn(true);
+
+        RegisterRMRequest request = new RegisterRMRequest();
+        request.setApplicationId("test-app");
+        request.setTransactionServiceGroup("test-group");
+        request.setVersion("2.6.0");
+        request.setResourceIds("singleResource");
+        ChannelManager.registerRMChannel(request, ch);
+
+        assertTrue(ChannelManager.isRegistered(ch));
+
+        Set<String> toRemove = new HashSet<>();
+        toRemove.add("singleResource");
+        boolean result = ChannelManager.unregisterRMChannel(ch, toRemove);
+
+        assertTrue(result);
+        assertFalse(ChannelManager.isRegistered(ch));
+    }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/ChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/ChannelManagerTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1006,5 +1008,56 @@ public class ChannelManagerTest {
         assertNotNull(resultApp2, "Should find channel for app2");
 
         assertNotEquals(resultApp1, resultApp2, "Different apps should have different channels");
+    }
+
+    @Test
+    public void unregisterPartialResourcesTest() throws Exception {
+        Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 9090));
+        when(ch.isActive()).thenReturn(true);
+
+        RegisterRMRequest request = new RegisterRMRequest();
+        request.setApplicationId("test-app");
+        request.setTransactionServiceGroup("test-group");
+        request.setVersion("2.6.0");
+        request.setResourceIds("resource1,resource2");
+        ChannelManager.registerRMChannel(request, ch);
+
+        assertTrue(ChannelManager.isRegistered(ch));
+
+        Set<String> toRemove = new HashSet<>();
+        toRemove.add("resource1");
+        ChannelManager.unregisterRMChannel(ch, toRemove);
+
+        // Channel should still be registered because resource2 remains
+        assertTrue(ChannelManager.isRegistered(ch));
+        RpcContext ctx = ChannelManager.getContextFromIdentified(ch);
+        assertNotNull(ctx);
+        assertNotNull(ctx.getResourceSets());
+        assertFalse(ctx.getResourceSets().contains("resource1"));
+        assertTrue(ctx.getResourceSets().contains("resource2"));
+    }
+
+    @Test
+    public void unregisterAllResourcesRemovesChannelTest() throws Exception {
+        Channel ch = mock(Channel.class);
+        when(ch.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 9091));
+        when(ch.isActive()).thenReturn(true);
+
+        RegisterRMRequest request = new RegisterRMRequest();
+        request.setApplicationId("test-app");
+        request.setTransactionServiceGroup("test-group");
+        request.setVersion("2.6.0");
+        request.setResourceIds("resource1,resource2");
+        ChannelManager.registerRMChannel(request, ch);
+
+        assertTrue(ChannelManager.isRegistered(ch));
+
+        Set<String> toRemove = new HashSet<>();
+        toRemove.add("resource1");
+        toRemove.add("resource2");
+        ChannelManager.unregisterRMChannel(ch, toRemove);
+
+        assertFalse(ChannelManager.isRegistered(ch));
     }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
@@ -527,4 +527,14 @@ class NettyClientChannelManagerTest {
         assertTrue(channelLocks.containsKey(serverAddress));
         assertTrue(poolKeyMap.containsKey(serverAddress));
     }
+
+    @Test
+    void testCleanupDisconnectedChannelMetadataWithNullAddressTest() {
+        channelManager.putServerVersion("10.0.0.1:8091", "2.1.0");
+
+        channelManager.cleanupDisconnectedChannelMetadata(null);
+
+        // Should not throw and metadata should remain unchanged
+        assertEquals("2.1.0", channelManager.getServerVersion("10.0.0.1:8091"));
+    }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
@@ -418,4 +418,29 @@ class NettyClientChannelManagerTest {
             Assertions.fail("Should not throw exception: " + e.getMessage());
         }
     }
+
+    @Test
+    void putAndGetServerVersionTest() {
+        channelManager.putServerVersion("127.0.0.1:8091", "2.1.0");
+        assertEquals("2.1.0", channelManager.getServerVersion("127.0.0.1:8091"));
+
+        channelManager.putServerVersion("127.0.0.1:8091", "2.2.0");
+        assertEquals("2.2.0", channelManager.getServerVersion("127.0.0.1:8091"));
+    }
+
+    @Test
+    void getServerVersionReturnNullWhenNotExistTest() {
+        Assertions.assertNull(channelManager.getServerVersion("127.0.0.1:9999"));
+    }
+
+    @Test
+    void clearServerVersionsTest() {
+        channelManager.putServerVersion("127.0.0.1:8091", "2.1.0");
+        channelManager.putServerVersion("127.0.0.1:8092", "2.2.0");
+
+        channelManager.clearServerVersions();
+
+        Assertions.assertNull(channelManager.getServerVersion("127.0.0.1:8091"));
+        Assertions.assertNull(channelManager.getServerVersion("127.0.0.1:8092"));
+    }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
@@ -443,4 +443,78 @@ class NettyClientChannelManagerTest {
         Assertions.assertNull(channelManager.getServerVersion("127.0.0.1:8091"));
         Assertions.assertNull(channelManager.getServerVersion("127.0.0.1:8092"));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDestroyChannelCleansUpServerVersionMap() throws Exception {
+        String serverAddress = "127.0.0.1:8091";
+        setNettyClientKeyPool();
+        ConcurrentMap<String, NettyPoolKey> poolKeyMap =
+                (ConcurrentMap<String, NettyPoolKey>) getFieldValue("poolKeyMap", channelManager);
+        poolKeyMap.put(serverAddress, nettyPoolKey);
+
+        channelManager.getChannels().put(serverAddress, channel);
+        channelManager.putServerVersion(serverAddress, "2.1.0");
+
+        channelManager.destroyChannel(serverAddress, channel);
+
+        assertFalse(channelManager.getChannels().containsKey(serverAddress));
+        Assertions.assertNull(channelManager.getServerVersion(serverAddress));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDestroyChannelKeepsServerVersionWhenChannelMismatch() throws Exception {
+        String serverAddress = "127.0.0.1:8091";
+        setNettyClientKeyPool();
+        ConcurrentMap<String, NettyPoolKey> poolKeyMap =
+                (ConcurrentMap<String, NettyPoolKey>) getFieldValue("poolKeyMap", channelManager);
+        poolKeyMap.put(serverAddress, nettyPoolKey);
+
+        // Put a different channel in the map
+        channelManager.getChannels().put(serverAddress, newChannel);
+        channelManager.putServerVersion(serverAddress, "2.1.0");
+
+        // Destroy with a channel that doesn't match the cached one
+        channelManager.destroyChannel(serverAddress, channel);
+
+        // channels and serverVersionMap should remain since the channel didn't match
+        assertTrue(channelManager.getChannels().containsKey(serverAddress));
+        assertEquals("2.1.0", channelManager.getServerVersion(serverAddress));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDoReconnectCleansUpStaleAddresses() {
+        String transactionServiceGroup = "default_tx_group";
+        String staleAddress = "10.0.0.1:8091";
+        String activeAddress = "10.0.0.2:8091";
+        List<InetSocketAddress> availableServers = new ArrayList<>();
+        availableServers.add(new InetSocketAddress("10.0.0.2", 8091));
+
+        // Pre-populate maps with a stale address (no longer in available list)
+        channelManager.putServerVersion(staleAddress, "2.1.0");
+        ConcurrentMap<String, Object> channelLocks =
+                (ConcurrentMap<String, Object>) getFieldValue("channelLocks", channelManager);
+        channelLocks.put(staleAddress, new Object());
+        ConcurrentMap<String, NettyPoolKey> poolKeyMap =
+                (ConcurrentMap<String, NettyPoolKey>) getFieldValue("poolKeyMap", channelManager);
+        poolKeyMap.put(staleAddress, nettyPoolKey);
+
+        try (MockedStatic<RegistryFactory> registryFactoryMock = mockStatic(RegistryFactory.class)) {
+            registryFactoryMock.when(RegistryFactory::getInstance).thenReturn(registryService);
+            when(registryService.lookup(transactionServiceGroup)).thenReturn(availableServers);
+
+            setupPoolFactory(nettyPoolKey, channel);
+
+            channelManager.doReconnect(transactionServiceGroup, false);
+
+            // Stale address entries should be cleaned up
+            Assertions.assertNull(channelManager.getServerVersion(staleAddress));
+            assertFalse(channelLocks.containsKey(staleAddress));
+            assertFalse(poolKeyMap.containsKey(staleAddress));
+        } catch (Exception e) {
+            Assertions.fail("Should not throw exception: " + e.getMessage());
+        }
+    }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
@@ -485,36 +485,46 @@ class NettyClientChannelManagerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void testDoReconnectCleansUpStaleAddresses() {
-        String transactionServiceGroup = "default_tx_group";
-        String staleAddress = "10.0.0.1:8091";
-        String activeAddress = "10.0.0.2:8091";
-        List<InetSocketAddress> availableServers = new ArrayList<>();
-        availableServers.add(new InetSocketAddress("10.0.0.2", 8091));
+    void testCleanupDisconnectedChannelMetadata() {
+        String serverAddress = "10.0.0.1:8091";
 
-        // Pre-populate maps with a stale address (no longer in available list)
-        channelManager.putServerVersion(staleAddress, "2.1.0");
+        // Pre-populate maps with metadata for the address
+        channelManager.putServerVersion(serverAddress, "2.1.0");
         ConcurrentMap<String, Object> channelLocks =
                 (ConcurrentMap<String, Object>) getFieldValue("channelLocks", channelManager);
-        channelLocks.put(staleAddress, new Object());
+        channelLocks.put(serverAddress, new Object());
         ConcurrentMap<String, NettyPoolKey> poolKeyMap =
                 (ConcurrentMap<String, NettyPoolKey>) getFieldValue("poolKeyMap", channelManager);
-        poolKeyMap.put(staleAddress, nettyPoolKey);
+        poolKeyMap.put(serverAddress, nettyPoolKey);
 
-        try (MockedStatic<RegistryFactory> registryFactoryMock = mockStatic(RegistryFactory.class)) {
-            registryFactoryMock.when(RegistryFactory::getInstance).thenReturn(registryService);
-            when(registryService.lookup(transactionServiceGroup)).thenReturn(availableServers);
+        // No active channel for this address — cleanup should proceed
+        channelManager.cleanupDisconnectedChannelMetadata(serverAddress);
 
-            setupPoolFactory(nettyPoolKey, channel);
+        Assertions.assertNull(channelManager.getServerVersion(serverAddress));
+        assertFalse(channelLocks.containsKey(serverAddress));
+        assertFalse(poolKeyMap.containsKey(serverAddress));
+    }
 
-            channelManager.doReconnect(transactionServiceGroup, false);
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCleanupSkippedWhenActiveChannelExists() {
+        String serverAddress = "10.0.0.1:8091";
 
-            // Stale address entries should be cleaned up
-            Assertions.assertNull(channelManager.getServerVersion(staleAddress));
-            assertFalse(channelLocks.containsKey(staleAddress));
-            assertFalse(poolKeyMap.containsKey(staleAddress));
-        } catch (Exception e) {
-            Assertions.fail("Should not throw exception: " + e.getMessage());
-        }
+        // Pre-populate maps and an active channel
+        channelManager.getChannels().put(serverAddress, channel);
+        channelManager.putServerVersion(serverAddress, "2.1.0");
+        ConcurrentMap<String, Object> channelLocks =
+                (ConcurrentMap<String, Object>) getFieldValue("channelLocks", channelManager);
+        channelLocks.put(serverAddress, new Object());
+        ConcurrentMap<String, NettyPoolKey> poolKeyMap =
+                (ConcurrentMap<String, NettyPoolKey>) getFieldValue("poolKeyMap", channelManager);
+        poolKeyMap.put(serverAddress, nettyPoolKey);
+
+        // Active channel exists — cleanup should be skipped
+        channelManager.cleanupDisconnectedChannelMetadata(serverAddress);
+
+        assertEquals("2.1.0", channelManager.getServerVersion(serverAddress));
+        assertTrue(channelLocks.containsKey(serverAddress));
+        assertTrue(poolKeyMap.containsKey(serverAddress));
     }
 }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
@@ -17,6 +17,7 @@
 package org.apache.seata.core.rpc.netty;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.exception.FrameworkErrorCode;
 import org.apache.seata.common.exception.FrameworkException;
@@ -27,7 +28,6 @@ import org.apache.seata.core.protocol.HeartbeatMessage;
 import org.apache.seata.core.protocol.RegisterRMRequest;
 import org.apache.seata.core.protocol.RegisterRMResponse;
 import org.apache.seata.core.protocol.ResultCode;
-import org.apache.seata.core.protocol.UnregisterRMRequest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -364,10 +364,11 @@ class RmNettyClientTest {
     }
 
     @Test
-    public void unregisterResourceWithBlankParamsTest() {
+    public void unregisterResourceWithBlankParamsTest() throws Exception {
         RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
 
         NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+        setChannelManager(client, channelManager);
 
         client.setTransactionServiceGroup(null);
         client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
@@ -385,8 +386,11 @@ class RmNettyClientTest {
     public void unregisterResourceWithActiveChannelTest() throws Exception {
         RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
 
+        ChannelFuture channelFuture = mock(ChannelFuture.class);
         Channel channel = mock(Channel.class);
         when(channel.isActive()).thenReturn(true);
+        when(channel.isWritable()).thenReturn(true);
+        when(channel.writeAndFlush(any())).thenReturn(channelFuture);
 
         String serverAddress = "127.0.0.1:8091";
         ConcurrentHashMap<String, Channel> channels = new ConcurrentHashMap<>();
@@ -398,11 +402,9 @@ class RmNettyClientTest {
 
         when(channelManager.getServerVersion(serverAddress)).thenReturn("2.6.0");
 
-        RmNettyRemotingClient spyClient = Mockito.spy(client);
+        client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
-        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
-
-        verify(spyClient).sendAsyncRequest(eq(channel), any(UnregisterRMRequest.class));
+        verify(channel).writeAndFlush(any());
     }
 
     @Test
@@ -422,11 +424,9 @@ class RmNettyClientTest {
 
         when(channelManager.getServerVersion(serverAddress)).thenReturn("2.5.0");
 
-        RmNettyRemotingClient spyClient = Mockito.spy(client);
+        client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
-        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
-
-        verify(spyClient, never()).sendAsyncRequest(any(Channel.class), any(UnregisterRMRequest.class));
+        verify(channel, never()).writeAndFlush(any());
     }
 
     @Test
@@ -444,11 +444,9 @@ class RmNettyClientTest {
         when(channelManager.getChannels()).thenReturn(channels);
         setChannelManager(client, channelManager);
 
-        RmNettyRemotingClient spyClient = Mockito.spy(client);
+        client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
-        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
-
-        verify(spyClient, never()).sendAsyncRequest(any(Channel.class), any(UnregisterRMRequest.class));
+        verify(channel, never()).writeAndFlush(any());
     }
 
     @Test
@@ -457,6 +455,7 @@ class RmNettyClientTest {
 
         Channel channel = mock(Channel.class);
         when(channel.isActive()).thenReturn(true);
+        when(channel.isWritable()).thenReturn(false);
 
         String serverAddress = "127.0.0.1:8091";
         ConcurrentHashMap<String, Channel> channels = new ConcurrentHashMap<>();
@@ -468,12 +467,7 @@ class RmNettyClientTest {
 
         when(channelManager.getServerVersion(serverAddress)).thenReturn("2.6.0");
 
-        RmNettyRemotingClient spyClient = Mockito.spy(client);
-        doThrow(new FrameworkException("Channel is not writable", FrameworkErrorCode.ChannelIsNotWritable))
-                .when(spyClient)
-                .sendAsyncRequest(eq(channel), any(UnregisterRMRequest.class));
-
-        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
+        client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
         verify(channelManager).releaseChannel(eq(channel), eq(serverAddress));
     }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
@@ -28,7 +28,6 @@ import org.apache.seata.core.protocol.RegisterRMRequest;
 import org.apache.seata.core.protocol.RegisterRMResponse;
 import org.apache.seata.core.protocol.ResultCode;
 import org.apache.seata.core.protocol.UnregisterRMRequest;
-import org.apache.seata.core.protocol.Version;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -397,15 +396,13 @@ class RmNettyClientTest {
         when(channelManager.getChannels()).thenReturn(channels);
         setChannelManager(client, channelManager);
 
-        Version.putServerVersion(serverAddress, "2.6.0");
+        when(channelManager.getServerVersion(serverAddress)).thenReturn("2.6.0");
 
         RmNettyRemotingClient spyClient = Mockito.spy(client);
 
         spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
         verify(spyClient).sendAsyncRequest(eq(channel), any(UnregisterRMRequest.class));
-
-        Version.SERVER_VERSION_MAP.remove(serverAddress);
     }
 
     @Test
@@ -423,15 +420,13 @@ class RmNettyClientTest {
         when(channelManager.getChannels()).thenReturn(channels);
         setChannelManager(client, channelManager);
 
-        Version.putServerVersion(serverAddress, "2.5.0");
+        when(channelManager.getServerVersion(serverAddress)).thenReturn("2.5.0");
 
         RmNettyRemotingClient spyClient = Mockito.spy(client);
 
         spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
         verify(spyClient, never()).sendAsyncRequest(any(Channel.class), any(UnregisterRMRequest.class));
-
-        Version.SERVER_VERSION_MAP.remove(serverAddress);
     }
 
     @Test
@@ -471,7 +466,7 @@ class RmNettyClientTest {
         when(channelManager.getChannels()).thenReturn(channels);
         setChannelManager(client, channelManager);
 
-        Version.putServerVersion(serverAddress, "2.6.0");
+        when(channelManager.getServerVersion(serverAddress)).thenReturn("2.6.0");
 
         RmNettyRemotingClient spyClient = Mockito.spy(client);
         doThrow(new FrameworkException("Channel is not writable", FrameworkErrorCode.ChannelIsNotWritable))
@@ -481,8 +476,6 @@ class RmNettyClientTest {
         spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
 
         verify(channelManager).releaseChannel(eq(channel), eq(serverAddress));
-
-        Version.SERVER_VERSION_MAP.remove(serverAddress);
     }
 
     @Test

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/RmNettyClientTest.java
@@ -27,6 +27,8 @@ import org.apache.seata.core.protocol.HeartbeatMessage;
 import org.apache.seata.core.protocol.RegisterRMRequest;
 import org.apache.seata.core.protocol.RegisterRMResponse;
 import org.apache.seata.core.protocol.ResultCode;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.core.protocol.Version;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -360,6 +362,138 @@ class RmNettyClientTest {
 
         Object function = method.invoke(client);
         assertNotNull(function);
+    }
+
+    @Test
+    public void unregisterResourceWithBlankParamsTest() {
+        RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
+
+        NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+
+        client.setTransactionServiceGroup(null);
+        client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
+        verify(channelManager, never()).getChannels();
+
+        client.setTransactionServiceGroup("test_group");
+        client.unregisterResource("group1", "");
+        verify(channelManager, never()).getChannels();
+
+        client.unregisterResource("group1", null);
+        verify(channelManager, never()).getChannels();
+    }
+
+    @Test
+    public void unregisterResourceWithActiveChannelTest() throws Exception {
+        RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
+
+        Channel channel = mock(Channel.class);
+        when(channel.isActive()).thenReturn(true);
+
+        String serverAddress = "127.0.0.1:8091";
+        ConcurrentHashMap<String, Channel> channels = new ConcurrentHashMap<>();
+        channels.put(serverAddress, channel);
+
+        NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+        when(channelManager.getChannels()).thenReturn(channels);
+        setChannelManager(client, channelManager);
+
+        Version.putServerVersion(serverAddress, "2.6.0");
+
+        RmNettyRemotingClient spyClient = Mockito.spy(client);
+
+        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
+
+        verify(spyClient).sendAsyncRequest(eq(channel), any(UnregisterRMRequest.class));
+
+        Version.SERVER_VERSION_MAP.remove(serverAddress);
+    }
+
+    @Test
+    public void unregisterResourceSkipsOldServerVersionTest() throws Exception {
+        RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
+
+        Channel channel = mock(Channel.class);
+        when(channel.isActive()).thenReturn(true);
+
+        String serverAddress = "127.0.0.1:8091";
+        ConcurrentHashMap<String, Channel> channels = new ConcurrentHashMap<>();
+        channels.put(serverAddress, channel);
+
+        NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+        when(channelManager.getChannels()).thenReturn(channels);
+        setChannelManager(client, channelManager);
+
+        Version.putServerVersion(serverAddress, "2.5.0");
+
+        RmNettyRemotingClient spyClient = Mockito.spy(client);
+
+        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
+
+        verify(spyClient, never()).sendAsyncRequest(any(Channel.class), any(UnregisterRMRequest.class));
+
+        Version.SERVER_VERSION_MAP.remove(serverAddress);
+    }
+
+    @Test
+    public void unregisterResourceSkipsInactiveChannelTest() throws Exception {
+        RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
+
+        Channel channel = mock(Channel.class);
+        when(channel.isActive()).thenReturn(false);
+
+        String serverAddress = "127.0.0.1:8091";
+        ConcurrentHashMap<String, Channel> channels = new ConcurrentHashMap<>();
+        channels.put(serverAddress, channel);
+
+        NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+        when(channelManager.getChannels()).thenReturn(channels);
+        setChannelManager(client, channelManager);
+
+        RmNettyRemotingClient spyClient = Mockito.spy(client);
+
+        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
+
+        verify(spyClient, never()).sendAsyncRequest(any(Channel.class), any(UnregisterRMRequest.class));
+    }
+
+    @Test
+    public void unregisterResourceHandlesChannelNotWritableTest() throws Exception {
+        RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
+
+        Channel channel = mock(Channel.class);
+        when(channel.isActive()).thenReturn(true);
+
+        String serverAddress = "127.0.0.1:8091";
+        ConcurrentHashMap<String, Channel> channels = new ConcurrentHashMap<>();
+        channels.put(serverAddress, channel);
+
+        NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+        when(channelManager.getChannels()).thenReturn(channels);
+        setChannelManager(client, channelManager);
+
+        Version.putServerVersion(serverAddress, "2.6.0");
+
+        RmNettyRemotingClient spyClient = Mockito.spy(client);
+        doThrow(new FrameworkException("Channel is not writable", FrameworkErrorCode.ChannelIsNotWritable))
+                .when(spyClient)
+                .sendAsyncRequest(eq(channel), any(UnregisterRMRequest.class));
+
+        spyClient.unregisterResource("group1", "jdbc:mysql://localhost:3306/test");
+
+        verify(channelManager).releaseChannel(eq(channel), eq(serverAddress));
+
+        Version.SERVER_VERSION_MAP.remove(serverAddress);
+    }
+
+    @Test
+    public void unregisterResourceHandlesNullChannelsTest() throws Exception {
+        RmNettyRemotingClient client = RmNettyRemotingClient.getInstance("app", "test_group");
+
+        NettyClientChannelManager channelManager = mock(NettyClientChannelManager.class);
+        when(channelManager.getChannels()).thenReturn(null);
+        setChannelManager(client, channelManager);
+
+        Assertions.assertDoesNotThrow(() -> client.unregisterResource("group1", "jdbc:mysql://localhost:3306/test"));
     }
 
     private void setChannelManager(RmNettyRemotingClient client, NettyClientChannelManager channelManager)

--- a/core/src/test/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/processor/server/UnregRmProcessorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.core.rpc.processor.server;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.seata.core.protocol.RegisterRMRequest;
+import org.apache.seata.core.protocol.RpcMessage;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.core.protocol.UnregisterRMResponse;
+import org.apache.seata.core.rpc.RemotingServer;
+import org.apache.seata.core.rpc.netty.ChannelManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for UnregRmProcessor
+ */
+public class UnregRmProcessorTest {
+
+    private UnregRmProcessor processor;
+    private RemotingServer remotingServer;
+    private ChannelHandlerContext ctx;
+    private Channel channel;
+
+    @BeforeEach
+    public void setUp() {
+        remotingServer = mock(RemotingServer.class);
+        processor = new UnregRmProcessor(remotingServer);
+
+        ctx = mock(ChannelHandlerContext.class);
+        channel = mock(Channel.class);
+
+        when(ctx.channel()).thenReturn(channel);
+        when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 8080));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        try {
+            ChannelManager.releaseRpcContext(channel);
+        } catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    public void processUnregisterSuccessTest() throws Exception {
+        // First register the RM
+        RegisterRMRequest registerRequest = new RegisterRMRequest();
+        registerRequest.setApplicationId("test-app");
+        registerRequest.setTransactionServiceGroup("test-group");
+        registerRequest.setVersion("2.6.0");
+        registerRequest.setResourceIds("jdbc:mysql://localhost:3306/db1");
+        ChannelManager.registerRMChannel(registerRequest, channel);
+
+        // Unregister
+        UnregisterRMRequest unregRequest = new UnregisterRMRequest();
+        unregRequest.setApplicationId("test-app");
+        unregRequest.setTransactionServiceGroup("test-group");
+        unregRequest.setResourceIds("jdbc:mysql://localhost:3306/db1");
+
+        RpcMessage rpcMessage = new RpcMessage();
+        rpcMessage.setId(1);
+        rpcMessage.setBody(unregRequest);
+
+        processor.process(ctx, rpcMessage);
+
+        ArgumentCaptor<UnregisterRMResponse> responseCaptor = ArgumentCaptor.forClass(UnregisterRMResponse.class);
+        verify(remotingServer).sendAsyncResponse(eq(rpcMessage), eq(channel), responseCaptor.capture());
+
+        UnregisterRMResponse response = responseCaptor.getValue();
+        assertNotNull(response);
+        assertTrue(response.isIdentified());
+    }
+
+    @Test
+    public void processUnregisterUnknownChannelTest() throws Exception {
+        UnregisterRMRequest unregRequest = new UnregisterRMRequest();
+        unregRequest.setApplicationId("test-app");
+        unregRequest.setTransactionServiceGroup("test-group");
+        unregRequest.setResourceIds("jdbc:mysql://localhost:3306/db1");
+
+        RpcMessage rpcMessage = new RpcMessage();
+        rpcMessage.setId(1);
+        rpcMessage.setBody(unregRequest);
+
+        processor.process(ctx, rpcMessage);
+
+        verify(remotingServer).sendAsyncResponse(eq(rpcMessage), eq(channel), any(UnregisterRMResponse.class));
+    }
+}

--- a/serializer/seata-serializer-seata/src/main/java/org/apache/seata/serializer/seata/MessageCodecFactory.java
+++ b/serializer/seata-serializer-seata/src/main/java/org/apache/seata/serializer/seata/MessageCodecFactory.java
@@ -45,6 +45,8 @@ import org.apache.seata.serializer.seata.protocol.RegisterRMRequestCodec;
 import org.apache.seata.serializer.seata.protocol.RegisterRMResponseCodec;
 import org.apache.seata.serializer.seata.protocol.RegisterTMRequestCodec;
 import org.apache.seata.serializer.seata.protocol.RegisterTMResponseCodec;
+import org.apache.seata.serializer.seata.protocol.UnregisterRMRequestCodec;
+import org.apache.seata.serializer.seata.protocol.UnregisterRMResponseCodec;
 import org.apache.seata.serializer.seata.protocol.transaction.BranchCommitRequestCodec;
 import org.apache.seata.serializer.seata.protocol.transaction.BranchCommitResponseCodec;
 import org.apache.seata.serializer.seata.protocol.transaction.BranchRegisterRequestCodec;
@@ -119,6 +121,12 @@ public class MessageCodecFactory {
                 break;
             case MessageType.TYPE_REG_RM:
                 msgCodec = new RegisterRMRequestCodec();
+                break;
+            case MessageType.TYPE_UNREG_RM:
+                msgCodec = new UnregisterRMRequestCodec();
+                break;
+            case MessageType.TYPE_UNREG_RM_RESULT:
+                msgCodec = new UnregisterRMResponseCodec();
                 break;
             case MessageType.TYPE_REG_RM_RESULT:
                 if (version == ProtocolConstants.VERSION_2) {
@@ -230,6 +238,12 @@ public class MessageCodecFactory {
                 break;
             case MessageType.TYPE_REG_RM_RESULT:
                 abstractMessage = new RegisterRMResponse();
+                break;
+            case MessageType.TYPE_UNREG_RM:
+                abstractMessage = new UnregisterRMRequest();
+                break;
+            case MessageType.TYPE_UNREG_RM_RESULT:
+                abstractMessage = new UnregisterRMResponse();
                 break;
             case MessageType.TYPE_BRANCH_COMMIT:
                 abstractMessage = new BranchCommitRequest();

--- a/serializer/seata-serializer-seata/src/main/java/org/apache/seata/serializer/seata/protocol/UnregisterRMRequestCodec.java
+++ b/serializer/seata-serializer-seata/src/main/java/org/apache/seata/serializer/seata/protocol/UnregisterRMRequestCodec.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.seata.protocol;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+
+import java.nio.ByteBuffer;
+
+/**
+ * The type Unregister rm request codec.
+ */
+public class UnregisterRMRequestCodec extends AbstractIdentifyRequestCodec {
+
+    @Override
+    public Class<?> getMessageClassType() {
+        return UnregisterRMRequest.class;
+    }
+
+    @Override
+    protected <T> void doEncode(T t, ByteBuf out) {
+        super.doEncode(t, out);
+
+        UnregisterRMRequest unregisterRMRequest = (UnregisterRMRequest) t;
+        String resourceIds = unregisterRMRequest.getResourceIds();
+
+        if (resourceIds != null) {
+            byte[] bs = resourceIds.getBytes(UTF8);
+            out.writeInt(bs.length);
+            if (bs.length > 0) {
+                out.writeBytes(bs);
+            }
+        } else {
+            out.writeInt(0);
+        }
+    }
+
+    @Override
+    public <T> void decode(T t, ByteBuffer in) {
+        UnregisterRMRequest unregisterRMRequest = (UnregisterRMRequest) t;
+
+        if (in.remaining() < 2) {
+            return;
+        }
+        short len = in.getShort();
+        if (len > 0) {
+            if (in.remaining() < len) {
+                return;
+            }
+            byte[] bs = new byte[len];
+            in.get(bs);
+            unregisterRMRequest.setVersion(new String(bs, UTF8));
+        } else {
+            return;
+        }
+        if (in.remaining() < 2) {
+            return;
+        }
+        len = in.getShort();
+
+        if (len > 0) {
+            if (in.remaining() < len) {
+                return;
+            }
+            byte[] bs = new byte[len];
+            in.get(bs);
+            unregisterRMRequest.setApplicationId(new String(bs, UTF8));
+        }
+
+        if (in.remaining() < 2) {
+            return;
+        }
+        len = in.getShort();
+
+        if (in.remaining() < len) {
+            return;
+        }
+        byte[] bs = new byte[len];
+        in.get(bs);
+        unregisterRMRequest.setTransactionServiceGroup(new String(bs, UTF8));
+
+        if (in.remaining() < 2) {
+            return;
+        }
+        len = in.getShort();
+
+        if (len > 0) {
+            if (in.remaining() < len) {
+                return;
+            }
+            bs = new byte[len];
+            in.get(bs);
+            unregisterRMRequest.setExtraData(new String(bs, UTF8));
+        }
+
+        int iLen;
+        if (in.remaining() < 4) {
+            return;
+        }
+        iLen = in.getInt();
+
+        if (iLen > 0) {
+            if (in.remaining() < iLen) {
+                return;
+            }
+            bs = new byte[iLen];
+            in.get(bs);
+            unregisterRMRequest.setResourceIds(new String(bs, UTF8));
+        }
+    }
+}

--- a/serializer/seata-serializer-seata/src/main/java/org/apache/seata/serializer/seata/protocol/UnregisterRMResponseCodec.java
+++ b/serializer/seata-serializer-seata/src/main/java/org/apache/seata/serializer/seata/protocol/UnregisterRMResponseCodec.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.seata.protocol;
+
+import org.apache.seata.core.protocol.UnregisterRMResponse;
+
+/**
+ * The type Unregister rm response codec.
+ */
+public class UnregisterRMResponseCodec extends AbstractIdentifyResponseCodec {
+
+    @Override
+    public Class<?> getMessageClassType() {
+        return UnregisterRMResponse.class;
+    }
+}

--- a/serializer/seata-serializer-seata/src/test/java/org/apache/seata/serializer/seata/protocol/UnregisterRMRequestSerializerTest.java
+++ b/serializer/seata-serializer-seata/src/test/java/org/apache/seata/serializer/seata/protocol/UnregisterRMRequestSerializerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.seata.protocol;
+
+import org.apache.seata.core.protocol.ProtocolConstants;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.serializer.seata.SeataSerializer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The type Unregister rm request codec test.
+ */
+public class UnregisterRMRequestSerializerTest {
+
+    SeataSerializer seataSerializer = new SeataSerializer(ProtocolConstants.VERSION);
+
+    @Test
+    public void codecTest() {
+        UnregisterRMRequest unregisterRMRequest = new UnregisterRMRequest();
+        unregisterRMRequest.setResourceIds("a1,a2");
+        unregisterRMRequest.setApplicationId("abc");
+        unregisterRMRequest.setExtraData("abc124");
+        unregisterRMRequest.setTransactionServiceGroup("def");
+        unregisterRMRequest.setVersion("1");
+
+        byte[] body = seataSerializer.serialize(unregisterRMRequest);
+
+        UnregisterRMRequest deserialized = seataSerializer.deserialize(body);
+        assertThat(deserialized.getResourceIds()).isEqualTo(unregisterRMRequest.getResourceIds());
+        assertThat(deserialized.getExtraData()).isEqualTo(unregisterRMRequest.getExtraData());
+        assertThat(deserialized.getApplicationId()).isEqualTo(unregisterRMRequest.getApplicationId());
+        assertThat(deserialized.getVersion()).isEqualTo(unregisterRMRequest.getVersion());
+        assertThat(deserialized.getTransactionServiceGroup())
+                .isEqualTo(unregisterRMRequest.getTransactionServiceGroup());
+    }
+}

--- a/serializer/seata-serializer-seata/src/test/java/org/apache/seata/serializer/seata/protocol/UnregisterRMResponseSerializerTest.java
+++ b/serializer/seata-serializer-seata/src/test/java/org/apache/seata/serializer/seata/protocol/UnregisterRMResponseSerializerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.seata.protocol;
+
+import org.apache.seata.core.protocol.ProtocolConstants;
+import org.apache.seata.core.protocol.ResultCode;
+import org.apache.seata.core.protocol.UnregisterRMResponse;
+import org.apache.seata.serializer.seata.SeataSerializer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The type Unregister rm response codec test.
+ */
+public class UnregisterRMResponseSerializerTest {
+
+    SeataSerializer seataSerializer = new SeataSerializer(ProtocolConstants.VERSION);
+
+    @Test
+    public void codecTest() {
+        UnregisterRMResponse unregisterRMResponse = new UnregisterRMResponse();
+        unregisterRMResponse.setExtraData("abc123");
+        unregisterRMResponse.setIdentified(true);
+        unregisterRMResponse.setMsg("123456");
+        unregisterRMResponse.setVersion("12");
+        unregisterRMResponse.setResultCode(ResultCode.Failed);
+
+        byte[] body = seataSerializer.serialize(unregisterRMResponse);
+
+        UnregisterRMResponse deserialized = seataSerializer.deserialize(body);
+
+        assertThat(deserialized.isIdentified()).isEqualTo(unregisterRMResponse.isIdentified());
+        assertThat(deserialized.getVersion()).isEqualTo(unregisterRMResponse.getVersion());
+    }
+}


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
```mermaid
sequenceDiagram
    participant App as Application
    participant RM as RmNettyRemotingClient
    participant CM as NettyClientChannelManager
    participant TC as TC Server
    participant Proc as UnregRmProcessor
    participant ChMgr as ChannelManager

    App->>RM: destroy()
    RM->>CM: getServerVersion(serverAddress)
    CM-->>RM: serverVersion

    alt serverVersion >= 2.6.0
        RM->>TC: UnregisterRMRequest(appId, group, resourceIds)
        TC->>Proc: process(ctx, rpcMessage)
        Proc->>ChMgr: unregisterRMChannel(channel, resourceIds)
        ChMgr->>ChMgr: remove from RM_CHANNELS and IDENTIFIED_CHANNELS
        ChMgr-->>Proc: done
        Proc->>TC: UnregisterRMResponse(identified=true)
        TC-->>RM: UnregisterRMResponse
    else serverVersion < 2.6.0 or null
        Note right of RM: Skip server not supported
    end

    RM->>CM: clearServerVersions()
    RM->>App: shutdown complete
```


When RmNettyRemotingClient.destroy() is called (e.g., by ShardingSphere closing Seata Client), the server side is not notified that the client is going offline, causing background threads like TableMetaRefreshHolder to continue running and
  eventually throw NullPointerException.

  This PR implements two features to fix this:

  1. Cache server version from RegisterRMResponse (#7593): After successful RM registration, the server version is cached in `NettyClientChannelManager.serverVersionMap` so the client knows what protocol features the server supports.
  2. Add UnregisterRMRequest/Response protocol (#7594): A new message type that allows the client to notify the server to unregister its resources before destroying. This includes:
    - New protocol messages: UnregisterRMRequest (type=105) / UnregisterRMResponse (type=106)
    - Server-side: UnregRmProcessor to handle unregister requests, ChannelManager.unregisterRMChannel() to clean up RM channel entries by resource ID
    - Client-side: RmNettyRemotingClient.destroy() now sends UnregisterRMRequest to all connected servers before cleanup, with version check to ensure backward compatibility (only sends to servers >= 2.6.0)
    - Seata serializer codec support for the new message types

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #7593
fixes #7594

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

