### PR TITLE
feature: add detailed saga result reporting to benchmark cli

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -39,6 +39,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### optimize:
 
+- [#8039](https://github.com/apache/incubator-seata/issues/8039) enhance the traditional Saga benchmark with a more realistic state-machine workload, reproducible failure modeling, richer Saga result reporting, and clearer Saga parameter semantics
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] configure PMD to output messages in English
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] pin the Spring version for namingserver and console
 - [[#7943](https://github.com/apache/incubator-seata/pull/7943)] update jib-maven-plugin version and increase parallel test execution limits

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -39,7 +39,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### optimize:
 
-- [#8039](https://github.com/apache/incubator-seata/issues/8039) enhance the traditional Saga benchmark with a more realistic state-machine workload, reproducible failure modeling, richer Saga result reporting, and clearer Saga parameter semantics
+- [[#8042](https://github.com/apache/incubator-seata/pull/8042)] enhance the traditional Saga benchmark with a more realistic state-machine workload, reproducible failure modeling, richer Saga result reporting, and clearer Saga parameter semantics
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] configure PMD to output messages in English
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] pin the Spring version for namingserver and console
 - [[#7943](https://github.com/apache/incubator-seata/pull/7943)] update jib-maven-plugin version and increase parallel test execution limits

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -41,7 +41,7 @@
 
 ### optimize:
 
-- [[#8039](https://github.com/apache/incubator-seata/issues/8039)] 增强传统 Saga benchmark，支持更真实的状态机工作负载、可复现的失败建模、更丰富的 Saga 结果报告，以及更清晰的 Saga 参数语义
+- [[#8042](https://github.com/apache/incubator-seata/pull/8042)] 增强传统 Saga benchmark，支持更真实的状态机工作负载、可复现的失败建模、更丰富的 Saga 结果报告，以及更清晰的 Saga 参数语义
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] 配置PMD输出英文消息
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] 固定namingserver和console的Spring版本
 - [[#7943](https://github.com/apache/incubator-seata/pull/7943)] 升级jib-maven-plugin版本和提高ci并行度

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -41,6 +41,7 @@
 
 ### optimize:
 
+- [[#8039](https://github.com/apache/incubator-seata/issues/8039)] 增强传统 Saga benchmark，支持更真实的状态机工作负载、可复现的失败建模、更丰富的 Saga 结果报告，以及更清晰的 Saga 参数语义
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] 配置PMD输出英文消息
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] 固定namingserver和console的Spring版本
 - [[#7943](https://github.com/apache/incubator-seata/pull/7943)] 升级jib-maven-plugin版本和提高ci并行度

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -28,6 +28,7 @@ A command-line benchmark tool for stress testing Seata transaction modes.
 - **Multi-threaded** workload generation
 - **Fault injection** with configurable rollback percentage
 - **Selectable SAGA state machine shapes** such as `simple` and `order`
+- **Selectable SAGA workload implementations** such as `mock` and `db`
 - **Step-targeted SAGA failure injection** for forward steps such as `inventory`, `payment`, and `order`
 - **Reproducible SAGA failure injection** with `--saga-random-seed`
 - **Step-targeted SAGA timeout simulation** with `--saga-timeout-step` and `--saga-timeout-ms`
@@ -109,6 +110,16 @@ java -jar seata-benchmark-cli.jar \
   --duration 60 \
   --branches 3 \
   --saga-shape order
+
+# SAGA mode with DB-backed business actions (via Testcontainers MySQL)
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 100 \
+  --duration 60 \
+  --branches 3 \
+  --saga-shape order \
+  --saga-workload db
 
 # SAGA mode with payment-step failure injection
 java -jar seata-benchmark-cli.jar \
@@ -205,6 +216,7 @@ Usage: seata-benchmark [-hV] [--application-id=<applicationId>]
                        [-d=<duration>] [--export-csv=<exportCsv>]
                        [-m=<mode>] [-s=<server>] [-t=<targetTps>]
                        [--saga-shape=<sagaShape>]
+                       [--saga-workload=<sagaWorkload>]
                        [--saga-fail-step=<sagaFailStep>]
                        [--saga-random-seed=<sagaRandomSeed>]
                        [--saga-timeout-step=<sagaTimeoutStep>]
@@ -227,6 +239,10 @@ Options:
       --saga-shape=<sagaShape>         Select SAGA state machine shape: simple or order.
                                        If omitted, the benchmark keeps the existing
                                        branches-based compatibility behavior.
+      --saga-workload=<sagaWorkload>   Select SAGA workload implementation: mock or db.
+                                       The default is mock. The db workload uses
+                                       Testcontainers MySQL for DB-backed order,
+                                       inventory, and payment actions.
       --saga-fail-step=<sagaFailStep>  Restrict SAGA failure injection to one forward step:
                                        inventory, payment, or order.
                                        The failure ratio is still controlled by
@@ -301,6 +317,7 @@ When the benchmark completes, a final report is displayed:
            Seata Benchmark Final Report
 ===================================================
 Mode:                  SAGA
+Saga Workload:         db
 Saga Shape:            order
 Total Transactions:    6,000
 Success Count:         5,780
@@ -328,6 +345,8 @@ Latency Statistics:
 
 For timeout simulation scenarios, the reported `Elapsed Time` may slightly exceed the configured `--duration` because already-started transactions are allowed to finish before the workload generator stops.
 
+For DB-backed SAGA scenarios, the final report and CSV output also include `Saga Workload`, so benchmark results from `mock` and `db` workloads can be compared explicitly.
+
 ### CSV Export
 
 Use `--export-csv` to export metrics:
@@ -346,6 +365,7 @@ Output format:
 ```csv
 Metric,Value
 Mode,SAGA
+Saga Workload,db
 Saga Shape,order
 Total Transactions,6000
 Success Count,5780
@@ -418,6 +438,35 @@ java -jar seata-benchmark-cli.jar \
   --saga-fail-step payment
 ```
 
+### Test SAGA Mode with DB-Backed Business Actions
+
+```bash
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 100 \
+  --duration 60 \
+  --branches 3 \
+  --saga-shape order \
+  --saga-workload db
+```
+
+### Test DB-Backed SAGA with Payment-Step Failure Injection
+
+```bash
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 10 \
+  --threads 1 \
+  --duration 10 \
+  --branches 3 \
+  --saga-shape order \
+  --saga-workload db \
+  --rollback-percentage 20 \
+  --saga-fail-step payment
+```
+
 ### Test TCC Mode at High Load
 
 ```bash
@@ -477,10 +526,28 @@ When `--branches` is set to a value greater than 0:
 - **SAGA Mode**:
   - Uses Seata state machine engine
   - Executes predefined state machine definitions
+  - Supports `mock` and `db` workloads
   - Supports compensation on failure
   - Available state machines:
     - `benchmarkSimpleSaga`: For 1-2 branches
     - `benchmarkOrderSaga`: For 3+ branches (order/inventory/payment)
+  - DB workload behavior:
+    - Starts MySQL via Testcontainers
+    - Creates benchmark inventory, account, and order tables
+    - Executes DB-backed inventory/payment/order actions with compensation
+
+### SAGA Workloads
+
+- `mock` workload:
+  - Keeps the lightweight benchmark-oriented implementation
+  - Uses in-memory Saga services with simulated delay, failure injection, and timeout injection
+  - Is the default workload and preserves backward compatibility
+
+- `db` workload:
+  - Starts a MySQL container via Testcontainers
+  - Initializes benchmark tables for inventory, account, and order data
+  - Executes DB-backed order, inventory, and payment actions while still supporting the same Saga shape, fail-step, random-seed, and timeout options
+  - Is intended for more realistic business-style Saga benchmarking
 
 ### Fault Injection
 

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -27,6 +27,7 @@ A command-line benchmark tool for stress testing Seata transaction modes.
 - **Configurable TPS** (Transactions Per Second) control
 - **Multi-threaded** workload generation
 - **Fault injection** with configurable rollback percentage
+- **Step-targeted SAGA failure injection** for forward steps such as `inventory`, `payment`, and `order`
 - **Window-based progress reporting** (every 10 seconds)
 - Performance metrics collection (latency percentiles, success rate, TPS)
 - **CSV export** for post-analysis
@@ -96,6 +97,16 @@ java -jar seata-benchmark-cli.jar \
   --duration 60 \
   --branches 3 \
   --rollback-percentage 5
+
+# SAGA mode with payment-step failure injection
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 100 \
+  --duration 60 \
+  --branches 3 \
+  --rollback-percentage 20 \
+  --saga-fail-step payment
 ```
 
 ### Performance Testing Modes
@@ -157,6 +168,7 @@ java -jar seata-benchmark-cli.jar \
 Usage: seata-benchmark [-hV] [--application-id=<applicationId>]
                        [-d=<duration>] [--export-csv=<exportCsv>]
                        [-m=<mode>] [-s=<server>] [-t=<targetTps>]
+                       [--saga-fail-step=<sagaFailStep>]
                        [--threads=<threads>] [--tx-service-group=<txServiceGroup>]
                        [--warmup-duration=<warmupDuration>]
                        [--rollback-percentage=<rollbackPercentage>]
@@ -172,6 +184,10 @@ Options:
                                        Warmup duration in seconds (default: 0)
       --rollback-percentage=<rollbackPercentage>
                                        Rollback percentage for fault injection (0-100, default: 2)
+      --saga-fail-step=<sagaFailStep>  Restrict SAGA failure injection to one forward step:
+                                       inventory, payment, or order.
+                                       The failure ratio is still controlled by
+                                       --rollback-percentage.
       --branches=<branches>            Number of branch transactions
                                        0 = empty mode (protocol overhead only)
                                        >=1 = real mode (actual execution)
@@ -329,6 +345,19 @@ java -jar seata-benchmark-cli.jar \
   --duration 60 \
   --branches 3 \
   --rollback-percentage 5
+```
+
+### Test SAGA Mode with Payment-Step Failure Injection
+
+```bash
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 100 \
+  --duration 60 \
+  --branches 3 \
+  --rollback-percentage 20 \
+  --saga-fail-step payment
 ```
 
 ### Test TCC Mode at High Load

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -27,6 +27,7 @@ A command-line benchmark tool for stress testing Seata transaction modes.
 - **Configurable TPS** (Transactions Per Second) control
 - **Multi-threaded** workload generation
 - **Fault injection** with configurable rollback percentage
+- **Selectable SAGA state machine shapes** such as `simple` and `order`
 - **Step-targeted SAGA failure injection** for forward steps such as `inventory`, `payment`, and `order`
 - **Window-based progress reporting** (every 10 seconds)
 - Performance metrics collection (latency percentiles, success rate, TPS)
@@ -98,6 +99,15 @@ java -jar seata-benchmark-cli.jar \
   --branches 3 \
   --rollback-percentage 5
 
+# SAGA mode with explicit order state machine shape
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 100 \
+  --duration 60 \
+  --branches 3 \
+  --saga-shape order
+
 # SAGA mode with payment-step failure injection
 java -jar seata-benchmark-cli.jar \
   --server 127.0.0.1:8091 \
@@ -168,6 +178,7 @@ java -jar seata-benchmark-cli.jar \
 Usage: seata-benchmark [-hV] [--application-id=<applicationId>]
                        [-d=<duration>] [--export-csv=<exportCsv>]
                        [-m=<mode>] [-s=<server>] [-t=<targetTps>]
+                       [--saga-shape=<sagaShape>]
                        [--saga-fail-step=<sagaFailStep>]
                        [--threads=<threads>] [--tx-service-group=<txServiceGroup>]
                        [--warmup-duration=<warmupDuration>]
@@ -184,6 +195,9 @@ Options:
                                        Warmup duration in seconds (default: 0)
       --rollback-percentage=<rollbackPercentage>
                                        Rollback percentage for fault injection (0-100, default: 2)
+      --saga-shape=<sagaShape>         Select SAGA state machine shape: simple or order.
+                                       If omitted, the benchmark keeps the existing
+                                       branches-based compatibility behavior.
       --saga-fail-step=<sagaFailStep>  Restrict SAGA failure injection to one forward step:
                                        inventory, payment, or order.
                                        The failure ratio is still controlled by
@@ -248,6 +262,8 @@ When the benchmark completes, a final report is displayed:
 ===================================================
            Seata Benchmark Final Report
 ===================================================
+Mode:                  SAGA
+Saga Shape:            order
 Total Transactions:    6,000
 Success Count:         5,940
 Failed Count:          60
@@ -289,6 +305,8 @@ Output format:
 
 ```csv
 Metric,Value
+Mode,SAGA
+Saga Shape,order
 Total Transactions,6000
 Success Count,5940
 Failed Count,60

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -236,6 +236,14 @@ Total Transactions:    6,000
 Success Count:         5,940
 Failed Count:          60
 Success Rate:          99.00%
+Committed Count:       4,860
+Compensated Count:     920
+Execution Failed Count:140
+Compensation Failed Count: 40
+Unknown Count:         0
+Committed Rate:        81.00%
+Compensated Rate:      15.33%
+End-State Success Rate: 96.33%
 Average TPS:           100.2
 Elapsed Time:          60 seconds
 
@@ -243,6 +251,7 @@ Latency Statistics:
   P50:                 12 ms
   P95:                 45 ms
   P99:                 89 ms
+  P99.9:               120 ms
   Max:                 230 ms
 ===================================================
 ```
@@ -268,11 +277,20 @@ Total Transactions,6000
 Success Count,5940
 Failed Count,60
 Success Rate (%),99.00
+Committed Count,4860
+Compensated Count,920
+Execution Failed Count,140
+Compensation Failed Count,40
+Unknown Count,0
+Committed Rate (%),81.00
+Compensated Rate (%),15.33
+End-State Success Rate (%),96.33
 Average TPS,100.2
 Elapsed Time (s),60
 Latency P50 (ms),12
 Latency P95 (ms),45
 Latency P99 (ms),89
+Latency P99.9 (ms),120
 Latency Max (ms),230
 Export Timestamp,2025-12-01 10:30:45
 ```

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -282,18 +282,18 @@ When the benchmark completes, a final report is displayed:
 Mode:                  SAGA
 Saga Shape:            order
 Total Transactions:    6,000
-Success Count:         5,940
-Failed Count:          60
-Success Rate:          99.00%
+Success Count:         4,860
+Failed Count:          1,140
+Success Rate:          81.00%
 Committed Count:       4,860
 Compensated Count:     920
-Execution Failed Count:140
+Execution Failed Count: 180
 Compensation Failed Count: 40
 Unknown Count:         0
 Committed Rate:        81.00%
 Compensated Rate:      15.33%
 End-State Success Rate: 96.33%
-Average TPS:           100.2
+Average TPS:           100.0
 Elapsed Time:          60 seconds
 
 Latency Statistics:
@@ -325,25 +325,25 @@ Metric,Value
 Mode,SAGA
 Saga Shape,order
 Total Transactions,6000
-Success Count,5940
-Failed Count,60
-Success Rate (%),99.00
+Success Count,4860
+Failed Count,1140
+Success Rate (%),81.00
 Committed Count,4860
 Compensated Count,920
-Execution Failed Count,140
+Execution Failed Count,180
 Compensation Failed Count,40
 Unknown Count,0
 Committed Rate (%),81.00
 Compensated Rate (%),15.33
 End-State Success Rate (%),96.33
-Average TPS,100.2
+Average TPS,100.0
 Elapsed Time (s),60
 Latency P50 (ms),12
 Latency P95 (ms),45
 Latency P99 (ms),89
 Latency P99.9 (ms),120
 Latency Max (ms),230
-Export Timestamp,2025-12-01 10:30:45
+Export Time,2025-12-01 10:30:45
 ```
 
 ## Examples

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -30,6 +30,7 @@ A command-line benchmark tool for stress testing Seata transaction modes.
 - **Selectable SAGA state machine shapes** such as `simple` and `order`
 - **Step-targeted SAGA failure injection** for forward steps such as `inventory`, `payment`, and `order`
 - **Reproducible SAGA failure injection** with `--saga-random-seed`
+- **Step-targeted SAGA timeout simulation** with `--saga-timeout-step` and `--saga-timeout-ms`
 - **Window-based progress reporting** (every 10 seconds)
 - Performance metrics collection (latency percentiles, success rate, TPS)
 - **CSV export** for post-analysis
@@ -130,6 +131,18 @@ java -jar seata-benchmark-cli.jar \
   --rollback-percentage 20 \
   --saga-fail-step payment \
   --saga-random-seed 123
+
+# SAGA mode with payment-step timeout simulation
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 10 \
+  --threads 1 \
+  --duration 10 \
+  --branches 3 \
+  --saga-shape order \
+  --saga-timeout-step payment \
+  --saga-timeout-ms 3000
 ```
 
 ### Performance Testing Modes
@@ -194,6 +207,8 @@ Usage: seata-benchmark [-hV] [--application-id=<applicationId>]
                        [--saga-shape=<sagaShape>]
                        [--saga-fail-step=<sagaFailStep>]
                        [--saga-random-seed=<sagaRandomSeed>]
+                       [--saga-timeout-step=<sagaTimeoutStep>]
+                       [--saga-timeout-ms=<sagaTimeoutMs>]
                        [--threads=<threads>] [--tx-service-group=<txServiceGroup>]
                        [--warmup-duration=<warmupDuration>]
                        [--rollback-percentage=<rollbackPercentage>]
@@ -219,6 +234,12 @@ Options:
       --saga-random-seed=<sagaRandomSeed>
                                        Optional random seed for reproducible SAGA
                                        failure injection behavior.
+      --saga-timeout-step=<sagaTimeoutStep>
+                                       Simulate SAGA timeout at one forward step:
+                                       inventory, payment, or order.
+      --saga-timeout-ms=<sagaTimeoutMs>
+                                       Simulated timeout delay in milliseconds for
+                                       SAGA timeout injection (default: 3000).
       --branches=<branches>            Number of branch transactions
                                        0 = empty mode (protocol overhead only)
                                        >=1 = real mode (actual execution)
@@ -282,9 +303,9 @@ When the benchmark completes, a final report is displayed:
 Mode:                  SAGA
 Saga Shape:            order
 Total Transactions:    6,000
-Success Count:         4,860
-Failed Count:          1,140
-Success Rate:          81.00%
+Success Count:         5,780
+Failed Count:          220
+Success Rate:          96.33%
 Committed Count:       4,860
 Compensated Count:     920
 Execution Failed Count: 180
@@ -304,6 +325,8 @@ Latency Statistics:
   Max:                 230 ms
 ===================================================
 ```
+
+For timeout simulation scenarios, the reported `Elapsed Time` may slightly exceed the configured `--duration` because already-started transactions are allowed to finish before the workload generator stops.
 
 ### CSV Export
 
@@ -325,9 +348,9 @@ Metric,Value
 Mode,SAGA
 Saga Shape,order
 Total Transactions,6000
-Success Count,4860
-Failed Count,1140
-Success Rate (%),81.00
+Success Count,5780
+Failed Count,220
+Success Rate (%),96.33
 Committed Count,4860
 Compensated Count,920
 Execution Failed Count,180

--- a/test-suite/seata-benchmark-cli/README.md
+++ b/test-suite/seata-benchmark-cli/README.md
@@ -29,6 +29,7 @@ A command-line benchmark tool for stress testing Seata transaction modes.
 - **Fault injection** with configurable rollback percentage
 - **Selectable SAGA state machine shapes** such as `simple` and `order`
 - **Step-targeted SAGA failure injection** for forward steps such as `inventory`, `payment`, and `order`
+- **Reproducible SAGA failure injection** with `--saga-random-seed`
 - **Window-based progress reporting** (every 10 seconds)
 - Performance metrics collection (latency percentiles, success rate, TPS)
 - **CSV export** for post-analysis
@@ -117,6 +118,18 @@ java -jar seata-benchmark-cli.jar \
   --branches 3 \
   --rollback-percentage 20 \
   --saga-fail-step payment
+
+# SAGA mode with reproducible payment-step failure injection
+java -jar seata-benchmark-cli.jar \
+  --server 127.0.0.1:8091 \
+  --mode SAGA \
+  --tps 100 \
+  --duration 60 \
+  --branches 3 \
+  --saga-shape order \
+  --rollback-percentage 20 \
+  --saga-fail-step payment \
+  --saga-random-seed 123
 ```
 
 ### Performance Testing Modes
@@ -180,6 +193,7 @@ Usage: seata-benchmark [-hV] [--application-id=<applicationId>]
                        [-m=<mode>] [-s=<server>] [-t=<targetTps>]
                        [--saga-shape=<sagaShape>]
                        [--saga-fail-step=<sagaFailStep>]
+                       [--saga-random-seed=<sagaRandomSeed>]
                        [--threads=<threads>] [--tx-service-group=<txServiceGroup>]
                        [--warmup-duration=<warmupDuration>]
                        [--rollback-percentage=<rollbackPercentage>]
@@ -202,6 +216,9 @@ Options:
                                        inventory, payment, or order.
                                        The failure ratio is still controlled by
                                        --rollback-percentage.
+      --saga-random-seed=<sagaRandomSeed>
+                                       Optional random seed for reproducible SAGA
+                                       failure injection behavior.
       --branches=<branches>            Number of branch transactions
                                        0 = empty mode (protocol overhead only)
                                        >=1 = real mode (actual execution)

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
@@ -196,7 +196,8 @@ public class BenchmarkApplication implements Callable<Integer> {
         System.out.println("  Rollback %:   " + config.getRollbackPercentage() + "%");
         System.out.println("  Branches:     " + config.getBranches()
                 + (config.getBranches() == 0 ? " (empty mode)" : " (real mode)"));
-        if (config.getMode() == BranchType.SAGA && config.getSagaWorkload() != null
+        if (config.getMode() == BranchType.SAGA
+                && config.getSagaWorkload() != null
                 && !config.getSagaWorkload().isEmpty()) {
             System.out.println("  Saga Workload:" + padValue(config.getSagaWorkload()));
         }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
@@ -94,6 +94,11 @@ public class BenchmarkApplication implements Callable<Integer> {
     private Integer branches;
 
     @Option(
+            names = {"--saga-shape"},
+            description = "Select SAGA state machine shape: simple or order")
+    private String sagaShape;
+
+    @Option(
             names = {"--saga-fail-step"},
             description = "Force SAGA forward failure at a specific step: inventory, payment, or order")
     private String sagaFailStep;
@@ -149,6 +154,7 @@ public class BenchmarkApplication implements Callable<Integer> {
                 txServiceGroup,
                 rollbackPercentage,
                 branches,
+                sagaShape,
                 sagaFailStep);
     }
 
@@ -165,6 +171,9 @@ public class BenchmarkApplication implements Callable<Integer> {
         System.out.println("  Rollback %:   " + config.getRollbackPercentage() + "%");
         System.out.println("  Branches:     " + config.getBranches()
                 + (config.getBranches() == 0 ? " (empty mode)" : " (real mode)"));
+        if (config.getSagaShape() != null && !config.getSagaShape().isEmpty()) {
+            System.out.println("  Saga Shape:   " + config.getSagaShape());
+        }
         if (config.getSagaFailStep() != null && !config.getSagaFailStep().isEmpty()) {
             System.out.println("  Saga Fail:    " + config.getSagaFailStep());
         }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
@@ -93,6 +93,11 @@ public class BenchmarkApplication implements Callable<Integer> {
             description = "Number of branch transactions (0=empty mode, >=1=real mode with actual execution)")
     private Integer branches;
 
+    @Option(
+            names = {"--saga-fail-step"},
+            description = "Force SAGA forward failure at a specific step: inventory, payment, or order")
+    private String sagaFailStep;
+
     public static void main(String[] args) {
         // Parse server address from args before any Seata class loading
         String serverAddr = BenchmarkConstants.DEFAULT_SERVER_ADDRESS;
@@ -143,7 +148,8 @@ public class BenchmarkApplication implements Callable<Integer> {
                 applicationId,
                 txServiceGroup,
                 rollbackPercentage,
-                branches);
+                branches,
+                sagaFailStep);
     }
 
     private void printConfiguration(BenchmarkConfig config) {
@@ -159,6 +165,9 @@ public class BenchmarkApplication implements Callable<Integer> {
         System.out.println("  Rollback %:   " + config.getRollbackPercentage() + "%");
         System.out.println("  Branches:     " + config.getBranches()
                 + (config.getBranches() == 0 ? " (empty mode)" : " (real mode)"));
+        if (config.getSagaFailStep() != null && !config.getSagaFailStep().isEmpty()) {
+            System.out.println("  Saga Fail:    " + config.getSagaFailStep());
+        }
         System.out.println();
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
@@ -108,6 +108,16 @@ public class BenchmarkApplication implements Callable<Integer> {
             description = "Seed for reproducible SAGA failure injection")
     private Long sagaRandomSeed;
 
+    @Option(
+            names = {"--saga-timeout-step"},
+            description = "Simulate SAGA timeout at a specific forward step: inventory, payment, or order")
+    private String sagaTimeoutStep;
+
+    @Option(
+            names = {"--saga-timeout-ms"},
+            description = "Simulated timeout delay in milliseconds for SAGA timeout injection (default: 3000)")
+    private Integer sagaTimeoutMs;
+
     public static void main(String[] args) {
         // Parse server address from args before any Seata class loading
         String serverAddr = BenchmarkConstants.DEFAULT_SERVER_ADDRESS;
@@ -161,7 +171,9 @@ public class BenchmarkApplication implements Callable<Integer> {
                 branches,
                 sagaShape,
                 sagaFailStep,
-                sagaRandomSeed);
+                sagaRandomSeed,
+                sagaTimeoutStep,
+                sagaTimeoutMs);
     }
 
     private void printConfiguration(BenchmarkConfig config) {
@@ -185,6 +197,10 @@ public class BenchmarkApplication implements Callable<Integer> {
         }
         if (config.getSagaRandomSeed() != null) {
             System.out.println("  Saga Seed:    " + config.getSagaRandomSeed());
+        }
+        if (config.getSagaTimeoutStep() != null && !config.getSagaTimeoutStep().isEmpty()) {
+            System.out.println("  Saga Timeout: " + config.getSagaTimeoutStep());
+            System.out.println("  Timeout Ms:   " + config.getSagaTimeoutMs());
         }
         System.out.println();
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
@@ -103,6 +103,11 @@ public class BenchmarkApplication implements Callable<Integer> {
             description = "Force SAGA forward failure at a specific step: inventory, payment, or order")
     private String sagaFailStep;
 
+    @Option(
+            names = {"--saga-random-seed"},
+            description = "Seed for reproducible SAGA failure injection")
+    private Long sagaRandomSeed;
+
     public static void main(String[] args) {
         // Parse server address from args before any Seata class loading
         String serverAddr = BenchmarkConstants.DEFAULT_SERVER_ADDRESS;
@@ -155,7 +160,8 @@ public class BenchmarkApplication implements Callable<Integer> {
                 rollbackPercentage,
                 branches,
                 sagaShape,
-                sagaFailStep);
+                sagaFailStep,
+                sagaRandomSeed);
     }
 
     private void printConfiguration(BenchmarkConfig config) {
@@ -176,6 +182,9 @@ public class BenchmarkApplication implements Callable<Integer> {
         }
         if (config.getSagaFailStep() != null && !config.getSagaFailStep().isEmpty()) {
             System.out.println("  Saga Fail:    " + config.getSagaFailStep());
+        }
+        if (config.getSagaRandomSeed() != null) {
+            System.out.println("  Saga Seed:    " + config.getSagaRandomSeed());
         }
         System.out.println();
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkApplication.java
@@ -19,6 +19,7 @@ package org.apache.seata.benchmark;
 import org.apache.seata.benchmark.config.BenchmarkConfig;
 import org.apache.seata.benchmark.config.BenchmarkConfigLoader;
 import org.apache.seata.benchmark.constant.BenchmarkConstants;
+import org.apache.seata.core.model.BranchType;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -99,6 +100,11 @@ public class BenchmarkApplication implements Callable<Integer> {
     private String sagaShape;
 
     @Option(
+            names = {"--saga-workload"},
+            description = "Select SAGA workload implementation: mock or db")
+    private String sagaWorkload;
+
+    @Option(
             names = {"--saga-fail-step"},
             description = "Force SAGA forward failure at a specific step: inventory, payment, or order")
     private String sagaFailStep;
@@ -170,6 +176,7 @@ public class BenchmarkApplication implements Callable<Integer> {
                 rollbackPercentage,
                 branches,
                 sagaShape,
+                sagaWorkload,
                 sagaFailStep,
                 sagaRandomSeed,
                 sagaTimeoutStep,
@@ -189,6 +196,10 @@ public class BenchmarkApplication implements Callable<Integer> {
         System.out.println("  Rollback %:   " + config.getRollbackPercentage() + "%");
         System.out.println("  Branches:     " + config.getBranches()
                 + (config.getBranches() == 0 ? " (empty mode)" : " (real mode)"));
+        if (config.getMode() == BranchType.SAGA && config.getSagaWorkload() != null
+                && !config.getSagaWorkload().isEmpty()) {
+            System.out.println("  Saga Workload:" + padValue(config.getSagaWorkload()));
+        }
         if (config.getSagaShape() != null && !config.getSagaShape().isEmpty()) {
             System.out.println("  Saga Shape:   " + config.getSagaShape());
         }
@@ -203,5 +214,9 @@ public class BenchmarkApplication implements Callable<Integer> {
             System.out.println("  Timeout Ms:   " + config.getSagaTimeoutMs());
         }
         System.out.println();
+    }
+
+    private String padValue(String value) {
+        return value == null ? "" : "   " + value;
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkRunner.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/BenchmarkRunner.java
@@ -69,7 +69,7 @@ public class BenchmarkRunner {
             executor.init();
 
             BenchmarkMetrics metrics = new BenchmarkMetrics();
-            MetricsCollector metricsCollector = new MetricsCollector(metrics);
+            MetricsCollector metricsCollector = new MetricsCollector(config, metrics);
             workloadGenerator = new WorkloadGenerator(config, executor, metrics);
 
             System.out.println("Starting benchmark...\n");

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -34,6 +34,7 @@ public class BenchmarkConfig {
     private String txServiceGroup = "default_tx_group";
     private int rollbackPercentage = 2;
     private int branches = 0;
+    private String sagaShape;
     private String sagaFailStep;
 
     public BranchType getMode() {
@@ -120,6 +121,14 @@ public class BenchmarkConfig {
         this.branches = branches;
     }
 
+    public String getSagaShape() {
+        return sagaShape;
+    }
+
+    public void setSagaShape(String sagaShape) {
+        this.sagaShape = sagaShape;
+    }
+
     public String getSagaFailStep() {
         return sagaFailStep;
     }
@@ -139,6 +148,7 @@ public class BenchmarkConfig {
         validateNonNegative(warmupDuration, "warmupDuration");
         validateNonNegative(branches, "branches");
         validateRange(rollbackPercentage, 0, 100, "rollbackPercentage");
+        validateSagaShape();
         validateSagaFailStep();
         validateTpsAndThreads();
     }
@@ -171,6 +181,18 @@ public class BenchmarkConfig {
         if (value < min || value > max) {
             throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
         }
+    }
+
+    private void validateSagaShape() {
+        if (sagaShape == null || sagaShape.trim().isEmpty()) {
+            return;
+        }
+
+        String normalized = sagaShape.trim().toLowerCase();
+        if (!"simple".equals(normalized) && !"order".equals(normalized)) {
+            throw new IllegalArgumentException("sagaShape must be one of: simple, order");
+        }
+        sagaShape = normalized;
     }
 
     private void validateSagaFailStep() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -19,6 +19,8 @@ package org.apache.seata.benchmark.config;
 import org.apache.seata.benchmark.constant.BenchmarkConstants;
 import org.apache.seata.core.model.BranchType;
 
+import java.util.Locale;
+
 /**
  * Benchmark configuration
  */
@@ -197,7 +199,7 @@ public class BenchmarkConfig {
             return;
         }
 
-        String normalized = sagaShape.trim().toLowerCase();
+        String normalized = sagaShape.trim().toLowerCase(Locale.ROOT);
         if (!"simple".equals(normalized) && !"order".equals(normalized)) {
             throw new IllegalArgumentException("sagaShape must be one of: simple, order");
         }
@@ -209,7 +211,7 @@ public class BenchmarkConfig {
             return;
         }
 
-        String normalized = sagaFailStep.trim().toLowerCase();
+        String normalized = sagaFailStep.trim().toLowerCase(Locale.ROOT);
         if (!"inventory".equals(normalized) && !"payment".equals(normalized) && !"order".equals(normalized)) {
             throw new IllegalArgumentException(
                     "sagaFailStep must be one of: inventory, payment, order");

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -34,6 +34,7 @@ public class BenchmarkConfig {
     private String txServiceGroup = "default_tx_group";
     private int rollbackPercentage = 2;
     private int branches = 0;
+    private String sagaFailStep;
 
     public BranchType getMode() {
         return mode;
@@ -119,6 +120,14 @@ public class BenchmarkConfig {
         this.branches = branches;
     }
 
+    public String getSagaFailStep() {
+        return sagaFailStep;
+    }
+
+    public void setSagaFailStep(String sagaFailStep) {
+        this.sagaFailStep = sagaFailStep;
+    }
+
     public void validate() {
         validateMode();
         validateNotEmpty(server, "server");
@@ -130,6 +139,7 @@ public class BenchmarkConfig {
         validateNonNegative(warmupDuration, "warmupDuration");
         validateNonNegative(branches, "branches");
         validateRange(rollbackPercentage, 0, 100, "rollbackPercentage");
+        validateSagaFailStep();
         validateTpsAndThreads();
     }
 
@@ -161,6 +171,19 @@ public class BenchmarkConfig {
         if (value < min || value > max) {
             throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
         }
+    }
+
+    private void validateSagaFailStep() {
+        if (sagaFailStep == null || sagaFailStep.trim().isEmpty()) {
+            return;
+        }
+
+        String normalized = sagaFailStep.trim().toLowerCase();
+        if (!"inventory".equals(normalized) && !"payment".equals(normalized) && !"order".equals(normalized)) {
+            throw new IllegalArgumentException(
+                    "sagaFailStep must be one of: inventory, payment, order");
+        }
+        sagaFailStep = normalized;
     }
 
     private void validateTpsAndThreads() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -37,6 +37,7 @@ public class BenchmarkConfig {
     private int rollbackPercentage = 2;
     private int branches = 0;
     private String sagaShape;
+    private String sagaWorkload = "mock";
     private String sagaFailStep;
     private Long sagaRandomSeed;
     private String sagaTimeoutStep;
@@ -134,6 +135,14 @@ public class BenchmarkConfig {
         this.sagaShape = sagaShape;
     }
 
+    public String getSagaWorkload() {
+        return sagaWorkload;
+    }
+
+    public void setSagaWorkload(String sagaWorkload) {
+        this.sagaWorkload = sagaWorkload;
+    }
+
     public String getSagaFailStep() {
         return sagaFailStep;
     }
@@ -178,6 +187,7 @@ public class BenchmarkConfig {
         validateNonNegative(branches, "branches");
         validateRange(rollbackPercentage, 0, 100, "rollbackPercentage");
         validateSagaShape();
+        validateSagaWorkload();
         validateSagaFailStep();
         validateSagaTimeoutStep();
         validateNonNegative(sagaTimeoutMs, "sagaTimeoutMs");
@@ -224,6 +234,19 @@ public class BenchmarkConfig {
             throw new IllegalArgumentException("sagaShape must be one of: simple, order");
         }
         sagaShape = normalized;
+    }
+
+    private void validateSagaWorkload() {
+        if (sagaWorkload == null || sagaWorkload.trim().isEmpty()) {
+            sagaWorkload = "mock";
+            return;
+        }
+
+        String normalized = sagaWorkload.trim().toLowerCase(Locale.ROOT);
+        if (!"mock".equals(normalized) && !"db".equals(normalized)) {
+            throw new IllegalArgumentException("sagaWorkload must be one of: mock, db");
+        }
+        sagaWorkload = normalized;
     }
 
     private void validateSagaFailStep() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -256,8 +256,7 @@ public class BenchmarkConfig {
 
         String normalized = sagaFailStep.trim().toLowerCase(Locale.ROOT);
         if (!"inventory".equals(normalized) && !"payment".equals(normalized) && !"order".equals(normalized)) {
-            throw new IllegalArgumentException(
-                    "sagaFailStep must be one of: inventory, payment, order");
+            throw new IllegalArgumentException("sagaFailStep must be one of: inventory, payment, order");
         }
         sagaFailStep = normalized;
     }
@@ -269,8 +268,7 @@ public class BenchmarkConfig {
 
         String normalized = sagaTimeoutStep.trim().toLowerCase(Locale.ROOT);
         if (!"inventory".equals(normalized) && !"payment".equals(normalized) && !"order".equals(normalized)) {
-            throw new IllegalArgumentException(
-                    "sagaTimeoutStep must be one of: inventory, payment, order");
+            throw new IllegalArgumentException("sagaTimeoutStep must be one of: inventory, payment, order");
         }
         sagaTimeoutStep = normalized;
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -36,6 +36,7 @@ public class BenchmarkConfig {
     private int branches = 0;
     private String sagaShape;
     private String sagaFailStep;
+    private Long sagaRandomSeed;
 
     public BranchType getMode() {
         return mode;
@@ -135,6 +136,14 @@ public class BenchmarkConfig {
 
     public void setSagaFailStep(String sagaFailStep) {
         this.sagaFailStep = sagaFailStep;
+    }
+
+    public Long getSagaRandomSeed() {
+        return sagaRandomSeed;
+    }
+
+    public void setSagaRandomSeed(Long sagaRandomSeed) {
+        this.sagaRandomSeed = sagaRandomSeed;
     }
 
     public void validate() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfig.java
@@ -39,6 +39,8 @@ public class BenchmarkConfig {
     private String sagaShape;
     private String sagaFailStep;
     private Long sagaRandomSeed;
+    private String sagaTimeoutStep;
+    private int sagaTimeoutMs = 3000;
 
     public BranchType getMode() {
         return mode;
@@ -148,6 +150,22 @@ public class BenchmarkConfig {
         this.sagaRandomSeed = sagaRandomSeed;
     }
 
+    public String getSagaTimeoutStep() {
+        return sagaTimeoutStep;
+    }
+
+    public void setSagaTimeoutStep(String sagaTimeoutStep) {
+        this.sagaTimeoutStep = sagaTimeoutStep;
+    }
+
+    public int getSagaTimeoutMs() {
+        return sagaTimeoutMs;
+    }
+
+    public void setSagaTimeoutMs(int sagaTimeoutMs) {
+        this.sagaTimeoutMs = sagaTimeoutMs;
+    }
+
     public void validate() {
         validateMode();
         validateNotEmpty(server, "server");
@@ -161,6 +179,8 @@ public class BenchmarkConfig {
         validateRange(rollbackPercentage, 0, 100, "rollbackPercentage");
         validateSagaShape();
         validateSagaFailStep();
+        validateSagaTimeoutStep();
+        validateNonNegative(sagaTimeoutMs, "sagaTimeoutMs");
         validateTpsAndThreads();
     }
 
@@ -217,6 +237,19 @@ public class BenchmarkConfig {
                     "sagaFailStep must be one of: inventory, payment, order");
         }
         sagaFailStep = normalized;
+    }
+
+    private void validateSagaTimeoutStep() {
+        if (sagaTimeoutStep == null || sagaTimeoutStep.trim().isEmpty()) {
+            return;
+        }
+
+        String normalized = sagaTimeoutStep.trim().toLowerCase(Locale.ROOT);
+        if (!"inventory".equals(normalized) && !"payment".equals(normalized) && !"order".equals(normalized)) {
+            throw new IllegalArgumentException(
+                    "sagaTimeoutStep must be one of: inventory, payment, order");
+        }
+        sagaTimeoutStep = normalized;
     }
 
     private void validateTpsAndThreads() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
@@ -99,7 +99,8 @@ public class BenchmarkConfigLoader {
             String applicationId,
             String txServiceGroup,
             Integer rollbackPercentage,
-            Integer branches) {
+            Integer branches,
+            String sagaFailStep) {
         if (StringUtils.isNotEmpty(server)) {
             config.setServer(server);
         }
@@ -129,6 +130,9 @@ public class BenchmarkConfigLoader {
         }
         if (branches != null && branches >= 0) {
             config.setBranches(branches);
+        }
+        if (StringUtils.isNotEmpty(sagaFailStep)) {
+            config.setSagaFailStep(sagaFailStep);
         }
         return config;
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
@@ -100,6 +100,7 @@ public class BenchmarkConfigLoader {
             String txServiceGroup,
             Integer rollbackPercentage,
             Integer branches,
+            String sagaShape,
             String sagaFailStep) {
         if (StringUtils.isNotEmpty(server)) {
             config.setServer(server);
@@ -130,6 +131,9 @@ public class BenchmarkConfigLoader {
         }
         if (branches != null && branches >= 0) {
             config.setBranches(branches);
+        }
+        if (StringUtils.isNotEmpty(sagaShape)) {
+            config.setSagaShape(sagaShape);
         }
         if (StringUtils.isNotEmpty(sagaFailStep)) {
             config.setSagaFailStep(sagaFailStep);

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
@@ -102,7 +102,9 @@ public class BenchmarkConfigLoader {
             Integer branches,
             String sagaShape,
             String sagaFailStep,
-            Long sagaRandomSeed) {
+            Long sagaRandomSeed,
+            String sagaTimeoutStep,
+            Integer sagaTimeoutMs) {
         if (StringUtils.isNotEmpty(server)) {
             config.setServer(server);
         }
@@ -141,6 +143,12 @@ public class BenchmarkConfigLoader {
         }
         if (sagaRandomSeed != null) {
             config.setSagaRandomSeed(sagaRandomSeed);
+        }
+        if (StringUtils.isNotEmpty(sagaTimeoutStep)) {
+            config.setSagaTimeoutStep(sagaTimeoutStep);
+        }
+        if (sagaTimeoutMs != null && sagaTimeoutMs >= 0) {
+            config.setSagaTimeoutMs(sagaTimeoutMs);
         }
         return config;
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
@@ -101,6 +101,7 @@ public class BenchmarkConfigLoader {
             Integer rollbackPercentage,
             Integer branches,
             String sagaShape,
+            String sagaWorkload,
             String sagaFailStep,
             Long sagaRandomSeed,
             String sagaTimeoutStep,
@@ -137,6 +138,9 @@ public class BenchmarkConfigLoader {
         }
         if (StringUtils.isNotEmpty(sagaShape)) {
             config.setSagaShape(sagaShape);
+        }
+        if (StringUtils.isNotEmpty(sagaWorkload)) {
+            config.setSagaWorkload(sagaWorkload);
         }
         if (StringUtils.isNotEmpty(sagaFailStep)) {
             config.setSagaFailStep(sagaFailStep);

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/config/BenchmarkConfigLoader.java
@@ -101,7 +101,8 @@ public class BenchmarkConfigLoader {
             Integer rollbackPercentage,
             Integer branches,
             String sagaShape,
-            String sagaFailStep) {
+            String sagaFailStep,
+            Long sagaRandomSeed) {
         if (StringUtils.isNotEmpty(server)) {
             config.setServer(server);
         }
@@ -137,6 +138,9 @@ public class BenchmarkConfigLoader {
         }
         if (StringUtils.isNotEmpty(sagaFailStep)) {
             config.setSagaFailStep(sagaFailStep);
+        }
+        if (sagaRandomSeed != null) {
+            config.setSagaRandomSeed(sagaRandomSeed);
         }
         return config;
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/constant/BenchmarkConstants.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/constant/BenchmarkConstants.java
@@ -41,6 +41,9 @@ public final class BenchmarkConstants {
     public static final int INITIAL_BALANCE = 10000;
     public static final int MIN_TRANSFER_AMOUNT = 1;
     public static final int MAX_TRANSFER_AMOUNT = 100;
+    public static final int SAGA_PRODUCT_COUNT = 100;
+    public static final int SAGA_INITIAL_BALANCE = 1000000;
+    public static final int SAGA_INITIAL_INVENTORY = 100000;
 
     // Thread pool configuration
     public static final int SHUTDOWN_TIMEOUT_SECONDS = 10;

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -65,6 +65,9 @@ public class SagaModeExecutor implements TransactionExecutor {
 
     private static final String SIMPLE_SAGA_NAME = "benchmarkSimpleSaga";
     private static final String ORDER_SAGA_NAME = "benchmarkOrderSaga";
+    private static final String STEP_INVENTORY = "inventory";
+    private static final String STEP_PAYMENT = "payment";
+    private static final String STEP_ORDER = "order";
 
     private final BenchmarkConfig config;
     private StateMachineEngine stateMachineEngine;
@@ -95,6 +98,7 @@ public class SagaModeExecutor implements TransactionExecutor {
             // Create and configure state machine config
             stateMachineConfig = new BenchmarkStateMachineConfig();
             stateMachineConfig.setRollbackPercentage(config.getRollbackPercentage());
+            stateMachineConfig.setSagaFailStep(config.getSagaFailStep());
             stateMachineConfig.init();
 
             // Create state machine engine
@@ -187,19 +191,15 @@ public class SagaModeExecutor implements TransactionExecutor {
             ExecutionStatus executionStatus = instance.getStatus();
             ExecutionStatus compensationStatus = instance.getCompensationStatus();
 
-            if (ExecutionStatus.SU.equals(executionStatus)) {
+            if (ExecutionStatus.SU.equals(compensationStatus)) {
+                status = STATUS_COMPENSATED;
+            } else if (ExecutionStatus.FA.equals(compensationStatus)) {
+                status = STATUS_COMPENSATION_FAILED;
+            } else if (ExecutionStatus.SU.equals(executionStatus)) {
                 status = STATUS_COMMITTED;
                 success = true;
             } else if (ExecutionStatus.FA.equals(executionStatus)) {
-                if (compensationStatus != null) {
-                    if (ExecutionStatus.SU.equals(compensationStatus)) {
-                        status = STATUS_COMPENSATED;
-                    } else {
-                        status = STATUS_COMPENSATION_FAILED;
-                    }
-                } else {
-                    status = STATUS_FAILED;
-                }
+                status = STATUS_FAILED;
             } else if (ExecutionStatus.UN.equals(executionStatus)) {
                 status = STATUS_UNKNOWN;
             } else {
@@ -262,9 +262,14 @@ public class SagaModeExecutor implements TransactionExecutor {
     private static class BenchmarkStateMachineConfig extends AbstractStateMachineConfig {
 
         private int rollbackPercentage = 0;
+        private String sagaFailStep;
 
         public void setRollbackPercentage(int rollbackPercentage) {
             this.rollbackPercentage = rollbackPercentage;
+        }
+
+        public void setSagaFailStep(String sagaFailStep) {
+            this.sagaFailStep = sagaFailStep;
         }
 
         @Override
@@ -308,9 +313,14 @@ public class SagaModeExecutor implements TransactionExecutor {
                 // Divide rollback percentage by 3 for each service so total probability is approximately correct
                 int serviceRollbackPct = rollbackPercentage > 0 ? Math.max(1, rollbackPercentage / 3) : 0;
 
-                serviceInvoker.registerService("orderService", new OrderSagaService(serviceRollbackPct, 5));
-                serviceInvoker.registerService("inventoryService", new InventorySagaService(serviceRollbackPct, 5));
-                serviceInvoker.registerService("paymentService", new PaymentSagaService(serviceRollbackPct, 5));
+                serviceInvoker.registerService(
+                        "orderService", new OrderSagaService(serviceRollbackPct, 5, STEP_ORDER.equals(sagaFailStep)));
+                serviceInvoker.registerService(
+                        "inventoryService",
+                        new InventorySagaService(serviceRollbackPct, 5, STEP_INVENTORY.equals(sagaFailStep)));
+                serviceInvoker.registerService(
+                        "paymentService",
+                        new PaymentSagaService(serviceRollbackPct, 5, STEP_PAYMENT.equals(sagaFailStep)));
 
                 // Register the service invoker for different service types
                 getServiceInvokerManager().putServiceInvoker(DomainConstants.SERVICE_TYPE_SPRING_BEAN, serviceInvoker);

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -297,6 +297,12 @@ public class SagaModeExecutor implements TransactionExecutor {
         private String sagaWorkload = "mock";
         private BenchmarkConfig benchmarkConfig;
         private SagaDbEnvironment sagaDbEnvironment;
+        private OrderSagaService orderSagaService;
+        private InventorySagaService inventorySagaService;
+        private PaymentSagaService paymentSagaService;
+        private OrderDbSagaService orderDbSagaService;
+        private InventoryDbSagaService inventoryDbSagaService;
+        private PaymentDbSagaService paymentDbSagaService;
 
         public void setRollbackPercentage(int rollbackPercentage) {
             this.rollbackPercentage = rollbackPercentage;
@@ -428,33 +434,23 @@ public class SagaModeExecutor implements TransactionExecutor {
                 boolean orderTimeoutEnabled,
                 boolean inventoryTimeoutEnabled,
                 boolean paymentTimeoutEnabled) {
+            orderSagaService = new OrderSagaService(
+                    serviceRollbackPct, 5, orderFailEnabled, createFailureRandom(11), orderTimeoutEnabled, sagaTimeoutMs);
             serviceInvoker.registerService(
-                    "orderService",
-                    new OrderSagaService(
-                            serviceRollbackPct,
-                            5,
-                            orderFailEnabled,
-                            createFailureRandom(11),
-                            orderTimeoutEnabled,
-                            sagaTimeoutMs));
+                    "orderService", orderSagaService);
+            inventorySagaService = new InventorySagaService(
+                    serviceRollbackPct,
+                    5,
+                    inventoryFailEnabled,
+                    createFailureRandom(17),
+                    inventoryTimeoutEnabled,
+                    sagaTimeoutMs);
             serviceInvoker.registerService(
-                    "inventoryService",
-                    new InventorySagaService(
-                            serviceRollbackPct,
-                            5,
-                            inventoryFailEnabled,
-                            createFailureRandom(17),
-                            inventoryTimeoutEnabled,
-                            sagaTimeoutMs));
+                    "inventoryService", inventorySagaService);
+            paymentSagaService = new PaymentSagaService(
+                    serviceRollbackPct, 5, paymentFailEnabled, createFailureRandom(23), paymentTimeoutEnabled, sagaTimeoutMs);
             serviceInvoker.registerService(
-                    "paymentService",
-                    new PaymentSagaService(
-                            serviceRollbackPct,
-                            5,
-                            paymentFailEnabled,
-                            createFailureRandom(23),
-                            paymentTimeoutEnabled,
-                            sagaTimeoutMs));
+                    "paymentService", paymentSagaService);
         }
 
         private void registerDbServices(
@@ -466,36 +462,36 @@ public class SagaModeExecutor implements TransactionExecutor {
                 boolean orderTimeoutEnabled,
                 boolean inventoryTimeoutEnabled,
                 boolean paymentTimeoutEnabled) {
+            orderDbSagaService = new OrderDbSagaService(
+                    sagaDbEnvironment.getDataSource(),
+                    serviceRollbackPct,
+                    5,
+                    orderFailEnabled,
+                    createFailureRandom(11),
+                    orderTimeoutEnabled,
+                    sagaTimeoutMs);
             serviceInvoker.registerService(
-                    "orderService",
-                    new OrderDbSagaService(
-                            sagaDbEnvironment.getDataSource(),
-                            serviceRollbackPct,
-                            5,
-                            orderFailEnabled,
-                            createFailureRandom(11),
-                            orderTimeoutEnabled,
-                            sagaTimeoutMs));
+                    "orderService", orderDbSagaService);
+            inventoryDbSagaService = new InventoryDbSagaService(
+                    sagaDbEnvironment.getDataSource(),
+                    serviceRollbackPct,
+                    5,
+                    inventoryFailEnabled,
+                    createFailureRandom(17),
+                    inventoryTimeoutEnabled,
+                    sagaTimeoutMs);
             serviceInvoker.registerService(
-                    "inventoryService",
-                    new InventoryDbSagaService(
-                            sagaDbEnvironment.getDataSource(),
-                            serviceRollbackPct,
-                            5,
-                            inventoryFailEnabled,
-                            createFailureRandom(17),
-                            inventoryTimeoutEnabled,
-                            sagaTimeoutMs));
+                    "inventoryService", inventoryDbSagaService);
+            paymentDbSagaService = new PaymentDbSagaService(
+                    sagaDbEnvironment.getDataSource(),
+                    serviceRollbackPct,
+                    5,
+                    paymentFailEnabled,
+                    createFailureRandom(23),
+                    paymentTimeoutEnabled,
+                    sagaTimeoutMs);
             serviceInvoker.registerService(
-                    "paymentService",
-                    new PaymentDbSagaService(
-                            sagaDbEnvironment.getDataSource(),
-                            serviceRollbackPct,
-                            5,
-                            paymentFailEnabled,
-                            createFailureRandom(23),
-                            paymentTimeoutEnabled,
-                            sagaTimeoutMs));
+                    "paymentService", paymentDbSagaService);
         }
 
         private void initDbEnvironment() {
@@ -507,9 +503,37 @@ public class SagaModeExecutor implements TransactionExecutor {
         }
 
         public void destroy() {
+            destroyServices();
             if (sagaDbEnvironment != null) {
                 sagaDbEnvironment.destroy();
                 sagaDbEnvironment = null;
+            }
+        }
+
+        private void destroyServices() {
+            if (orderSagaService != null) {
+                orderSagaService.destroy();
+                orderSagaService = null;
+            }
+            if (inventorySagaService != null) {
+                inventorySagaService.destroy();
+                inventorySagaService = null;
+            }
+            if (paymentSagaService != null) {
+                paymentSagaService.destroy();
+                paymentSagaService = null;
+            }
+            if (orderDbSagaService != null) {
+                orderDbSagaService.destroy();
+                orderDbSagaService = null;
+            }
+            if (inventoryDbSagaService != null) {
+                inventoryDbSagaService.destroy();
+                inventoryDbSagaService = null;
+            }
+            if (paymentDbSagaService != null) {
+                paymentDbSagaService.destroy();
+                paymentDbSagaService = null;
             }
         }
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -327,24 +327,27 @@ public class SagaModeExecutor implements TransactionExecutor {
                 // Register benchmark services with the service invoker manager
                 BenchmarkServiceInvoker serviceInvoker = new BenchmarkServiceInvoker();
 
-                // Register services with configured rollback percentage
-                // Divide rollback percentage by 3 for each service so total probability is approximately correct
-                int serviceRollbackPct = rollbackPercentage > 0 ? Math.max(1, rollbackPercentage / 3) : 0;
-                Random failureRandom =
-                        sagaRandomSeed == null ? null : new Random(sagaRandomSeed);
+                boolean restrictFailureStep = sagaFailStep != null && !sagaFailStep.trim().isEmpty();
+                int serviceRollbackPct = restrictFailureStep
+                        ? rollbackPercentage
+                        : (rollbackPercentage > 0 ? Math.max(1, rollbackPercentage / 3) : 0);
+
+                boolean orderFailEnabled = !restrictFailureStep || STEP_ORDER.equals(sagaFailStep);
+                boolean inventoryFailEnabled = !restrictFailureStep || STEP_INVENTORY.equals(sagaFailStep);
+                boolean paymentFailEnabled = !restrictFailureStep || STEP_PAYMENT.equals(sagaFailStep);
 
                 serviceInvoker.registerService(
                         "orderService",
                         new OrderSagaService(
-                                serviceRollbackPct, 5, STEP_ORDER.equals(sagaFailStep), failureRandom));
+                                serviceRollbackPct, 5, orderFailEnabled, createFailureRandom(11)));
                 serviceInvoker.registerService(
                         "inventoryService",
                         new InventorySagaService(
-                                serviceRollbackPct, 5, STEP_INVENTORY.equals(sagaFailStep), failureRandom));
+                                serviceRollbackPct, 5, inventoryFailEnabled, createFailureRandom(17)));
                 serviceInvoker.registerService(
                         "paymentService",
                         new PaymentSagaService(
-                                serviceRollbackPct, 5, STEP_PAYMENT.equals(sagaFailStep), failureRandom));
+                                serviceRollbackPct, 5, paymentFailEnabled, createFailureRandom(23)));
 
                 // Register the service invoker for different service types
                 getServiceInvokerManager().putServiceInvoker(DomainConstants.SERVICE_TYPE_SPRING_BEAN, serviceInvoker);
@@ -359,6 +362,10 @@ public class SagaModeExecutor implements TransactionExecutor {
                 buffer.write(data, 0, nRead);
             }
             return buffer.toByteArray();
+        }
+
+        private Random createFailureRandom(int salt) {
+            return sagaRandomSeed == null ? null : new Random(sagaRandomSeed + salt);
         }
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -48,7 +48,6 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -364,7 +363,8 @@ public class SagaModeExecutor implements TransactionExecutor {
                 // Register benchmark services with the service invoker manager
                 BenchmarkServiceInvoker serviceInvoker = new BenchmarkServiceInvoker();
 
-                boolean restrictFailureStep = sagaFailStep != null && !sagaFailStep.trim().isEmpty();
+                boolean restrictFailureStep =
+                        sagaFailStep != null && !sagaFailStep.trim().isEmpty();
                 int serviceRollbackPct = restrictFailureStep
                         ? rollbackPercentage
                         : (rollbackPercentage > 0 ? Math.max(1, rollbackPercentage / 3) : 0);
@@ -414,8 +414,9 @@ public class SagaModeExecutor implements TransactionExecutor {
             return buffer.toByteArray();
         }
 
-        private Random createFailureRandom(int salt) {
-            return sagaRandomSeed == null ? null : new Random(sagaRandomSeed + salt);
+        private ThreadLocal<java.util.Random> createFailureRandom(int salt) {
+            return org.apache.seata.benchmark.saga.FailureRandomProvider.create(
+                    sagaRandomSeed == null ? null : sagaRandomSeed + salt);
         }
 
         private void registerMockServices(

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -435,9 +435,13 @@ public class SagaModeExecutor implements TransactionExecutor {
                 boolean inventoryTimeoutEnabled,
                 boolean paymentTimeoutEnabled) {
             orderSagaService = new OrderSagaService(
-                    serviceRollbackPct, 5, orderFailEnabled, createFailureRandom(11), orderTimeoutEnabled, sagaTimeoutMs);
-            serviceInvoker.registerService(
-                    "orderService", orderSagaService);
+                    serviceRollbackPct,
+                    5,
+                    orderFailEnabled,
+                    createFailureRandom(11),
+                    orderTimeoutEnabled,
+                    sagaTimeoutMs);
+            serviceInvoker.registerService("orderService", orderSagaService);
             inventorySagaService = new InventorySagaService(
                     serviceRollbackPct,
                     5,
@@ -445,12 +449,15 @@ public class SagaModeExecutor implements TransactionExecutor {
                     createFailureRandom(17),
                     inventoryTimeoutEnabled,
                     sagaTimeoutMs);
-            serviceInvoker.registerService(
-                    "inventoryService", inventorySagaService);
+            serviceInvoker.registerService("inventoryService", inventorySagaService);
             paymentSagaService = new PaymentSagaService(
-                    serviceRollbackPct, 5, paymentFailEnabled, createFailureRandom(23), paymentTimeoutEnabled, sagaTimeoutMs);
-            serviceInvoker.registerService(
-                    "paymentService", paymentSagaService);
+                    serviceRollbackPct,
+                    5,
+                    paymentFailEnabled,
+                    createFailureRandom(23),
+                    paymentTimeoutEnabled,
+                    sagaTimeoutMs);
+            serviceInvoker.registerService("paymentService", paymentSagaService);
         }
 
         private void registerDbServices(
@@ -470,8 +477,7 @@ public class SagaModeExecutor implements TransactionExecutor {
                     createFailureRandom(11),
                     orderTimeoutEnabled,
                     sagaTimeoutMs);
-            serviceInvoker.registerService(
-                    "orderService", orderDbSagaService);
+            serviceInvoker.registerService("orderService", orderDbSagaService);
             inventoryDbSagaService = new InventoryDbSagaService(
                     sagaDbEnvironment.getDataSource(),
                     serviceRollbackPct,
@@ -480,8 +486,7 @@ public class SagaModeExecutor implements TransactionExecutor {
                     createFailureRandom(17),
                     inventoryTimeoutEnabled,
                     sagaTimeoutMs);
-            serviceInvoker.registerService(
-                    "inventoryService", inventoryDbSagaService);
+            serviceInvoker.registerService("inventoryService", inventoryDbSagaService);
             paymentDbSagaService = new PaymentDbSagaService(
                     sagaDbEnvironment.getDataSource(),
                     serviceRollbackPct,
@@ -490,8 +495,7 @@ public class SagaModeExecutor implements TransactionExecutor {
                     createFailureRandom(23),
                     paymentTimeoutEnabled,
                     sagaTimeoutMs);
-            serviceInvoker.registerService(
-                    "paymentService", paymentDbSagaService);
+            serviceInvoker.registerService("paymentService", paymentDbSagaService);
         }
 
         private void initDbEnvironment() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -19,9 +19,13 @@ package org.apache.seata.benchmark.executor;
 import org.apache.seata.benchmark.config.BenchmarkConfig;
 import org.apache.seata.benchmark.model.TransactionRecord;
 import org.apache.seata.benchmark.saga.BenchmarkServiceInvoker;
+import org.apache.seata.benchmark.saga.InventoryDbSagaService;
 import org.apache.seata.benchmark.saga.InventorySagaService;
+import org.apache.seata.benchmark.saga.OrderDbSagaService;
 import org.apache.seata.benchmark.saga.OrderSagaService;
+import org.apache.seata.benchmark.saga.PaymentDbSagaService;
 import org.apache.seata.benchmark.saga.PaymentSagaService;
+import org.apache.seata.benchmark.saga.SagaDbEnvironment;
 import org.apache.seata.benchmark.saga.SimpleSpelExpressionFactory;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.GlobalStatus;
@@ -71,6 +75,7 @@ public class SagaModeExecutor implements TransactionExecutor {
     private static final String STEP_ORDER = "order";
     private static final String SHAPE_SIMPLE = "simple";
     private static final String SHAPE_ORDER = "order";
+    private static final String WORKLOAD_DB = "db";
 
     private final BenchmarkConfig config;
     private StateMachineEngine stateMachineEngine;
@@ -105,6 +110,8 @@ public class SagaModeExecutor implements TransactionExecutor {
             stateMachineConfig.setSagaRandomSeed(config.getSagaRandomSeed());
             stateMachineConfig.setSagaTimeoutStep(config.getSagaTimeoutStep());
             stateMachineConfig.setSagaTimeoutMs(config.getSagaTimeoutMs());
+            stateMachineConfig.setSagaWorkload(config.getSagaWorkload());
+            stateMachineConfig.setBenchmarkConfig(config);
             stateMachineConfig.init();
 
             // Create state machine engine
@@ -116,6 +123,9 @@ public class SagaModeExecutor implements TransactionExecutor {
             LOGGER.info("Available state machines: {}, {}", SIMPLE_SAGA_NAME, ORDER_SAGA_NAME);
 
         } catch (Exception e) {
+            if (stateMachineConfig != null) {
+                stateMachineConfig.destroy();
+            }
             throw new RuntimeException("Failed to initialize Saga state machine engine", e);
         }
     }
@@ -268,7 +278,9 @@ public class SagaModeExecutor implements TransactionExecutor {
 
     private void destroyRealMode() {
         LOGGER.info("Destroying Real Saga mode resources");
-        // StateMachineEngine doesn't have a close method
+        if (stateMachineConfig != null) {
+            stateMachineConfig.destroy();
+        }
         stateMachineEngine = null;
         stateMachineConfig = null;
     }
@@ -283,6 +295,9 @@ public class SagaModeExecutor implements TransactionExecutor {
         private Long sagaRandomSeed;
         private String sagaTimeoutStep;
         private int sagaTimeoutMs = 3000;
+        private String sagaWorkload = "mock";
+        private BenchmarkConfig benchmarkConfig;
+        private SagaDbEnvironment sagaDbEnvironment;
 
         public void setRollbackPercentage(int rollbackPercentage) {
             this.rollbackPercentage = rollbackPercentage;
@@ -302,6 +317,14 @@ public class SagaModeExecutor implements TransactionExecutor {
 
         public void setSagaTimeoutMs(int sagaTimeoutMs) {
             this.sagaTimeoutMs = sagaTimeoutMs;
+        }
+
+        public void setSagaWorkload(String sagaWorkload) {
+            this.sagaWorkload = sagaWorkload;
+        }
+
+        public void setBenchmarkConfig(BenchmarkConfig benchmarkConfig) {
+            this.benchmarkConfig = benchmarkConfig;
         }
 
         @Override
@@ -353,33 +376,28 @@ public class SagaModeExecutor implements TransactionExecutor {
                 boolean inventoryTimeoutEnabled = STEP_INVENTORY.equals(sagaTimeoutStep);
                 boolean paymentTimeoutEnabled = STEP_PAYMENT.equals(sagaTimeoutStep);
 
-                serviceInvoker.registerService(
-                        "orderService",
-                        new OrderSagaService(
-                                serviceRollbackPct,
-                                5,
-                                orderFailEnabled,
-                                createFailureRandom(11),
-                                orderTimeoutEnabled,
-                                sagaTimeoutMs));
-                serviceInvoker.registerService(
-                        "inventoryService",
-                        new InventorySagaService(
-                                serviceRollbackPct,
-                                5,
-                                inventoryFailEnabled,
-                                createFailureRandom(17),
-                                inventoryTimeoutEnabled,
-                                sagaTimeoutMs));
-                serviceInvoker.registerService(
-                        "paymentService",
-                        new PaymentSagaService(
-                                serviceRollbackPct,
-                                5,
-                                paymentFailEnabled,
-                                createFailureRandom(23),
-                                paymentTimeoutEnabled,
-                                sagaTimeoutMs));
+                if (WORKLOAD_DB.equals(sagaWorkload)) {
+                    initDbEnvironment();
+                    registerDbServices(
+                            serviceInvoker,
+                            serviceRollbackPct,
+                            orderFailEnabled,
+                            inventoryFailEnabled,
+                            paymentFailEnabled,
+                            orderTimeoutEnabled,
+                            inventoryTimeoutEnabled,
+                            paymentTimeoutEnabled);
+                } else {
+                    registerMockServices(
+                            serviceInvoker,
+                            serviceRollbackPct,
+                            orderFailEnabled,
+                            inventoryFailEnabled,
+                            paymentFailEnabled,
+                            orderTimeoutEnabled,
+                            inventoryTimeoutEnabled,
+                            paymentTimeoutEnabled);
+                }
 
                 // Register the service invoker for different service types
                 getServiceInvokerManager().putServiceInvoker(DomainConstants.SERVICE_TYPE_SPRING_BEAN, serviceInvoker);
@@ -398,6 +416,100 @@ public class SagaModeExecutor implements TransactionExecutor {
 
         private Random createFailureRandom(int salt) {
             return sagaRandomSeed == null ? null : new Random(sagaRandomSeed + salt);
+        }
+
+        private void registerMockServices(
+                BenchmarkServiceInvoker serviceInvoker,
+                int serviceRollbackPct,
+                boolean orderFailEnabled,
+                boolean inventoryFailEnabled,
+                boolean paymentFailEnabled,
+                boolean orderTimeoutEnabled,
+                boolean inventoryTimeoutEnabled,
+                boolean paymentTimeoutEnabled) {
+            serviceInvoker.registerService(
+                    "orderService",
+                    new OrderSagaService(
+                            serviceRollbackPct,
+                            5,
+                            orderFailEnabled,
+                            createFailureRandom(11),
+                            orderTimeoutEnabled,
+                            sagaTimeoutMs));
+            serviceInvoker.registerService(
+                    "inventoryService",
+                    new InventorySagaService(
+                            serviceRollbackPct,
+                            5,
+                            inventoryFailEnabled,
+                            createFailureRandom(17),
+                            inventoryTimeoutEnabled,
+                            sagaTimeoutMs));
+            serviceInvoker.registerService(
+                    "paymentService",
+                    new PaymentSagaService(
+                            serviceRollbackPct,
+                            5,
+                            paymentFailEnabled,
+                            createFailureRandom(23),
+                            paymentTimeoutEnabled,
+                            sagaTimeoutMs));
+        }
+
+        private void registerDbServices(
+                BenchmarkServiceInvoker serviceInvoker,
+                int serviceRollbackPct,
+                boolean orderFailEnabled,
+                boolean inventoryFailEnabled,
+                boolean paymentFailEnabled,
+                boolean orderTimeoutEnabled,
+                boolean inventoryTimeoutEnabled,
+                boolean paymentTimeoutEnabled) {
+            serviceInvoker.registerService(
+                    "orderService",
+                    new OrderDbSagaService(
+                            sagaDbEnvironment.getDataSource(),
+                            serviceRollbackPct,
+                            5,
+                            orderFailEnabled,
+                            createFailureRandom(11),
+                            orderTimeoutEnabled,
+                            sagaTimeoutMs));
+            serviceInvoker.registerService(
+                    "inventoryService",
+                    new InventoryDbSagaService(
+                            sagaDbEnvironment.getDataSource(),
+                            serviceRollbackPct,
+                            5,
+                            inventoryFailEnabled,
+                            createFailureRandom(17),
+                            inventoryTimeoutEnabled,
+                            sagaTimeoutMs));
+            serviceInvoker.registerService(
+                    "paymentService",
+                    new PaymentDbSagaService(
+                            sagaDbEnvironment.getDataSource(),
+                            serviceRollbackPct,
+                            5,
+                            paymentFailEnabled,
+                            createFailureRandom(23),
+                            paymentTimeoutEnabled,
+                            sagaTimeoutMs));
+        }
+
+        private void initDbEnvironment() {
+            if (benchmarkConfig == null) {
+                throw new IllegalStateException("BenchmarkConfig is required for DB-backed Saga workload");
+            }
+            sagaDbEnvironment = new SagaDbEnvironment(benchmarkConfig);
+            sagaDbEnvironment.init();
+        }
+
+        public void destroy() {
+            if (sagaDbEnvironment != null) {
+                sagaDbEnvironment.destroy();
+                sagaDbEnvironment = null;
+            }
         }
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -101,6 +102,7 @@ public class SagaModeExecutor implements TransactionExecutor {
             stateMachineConfig = new BenchmarkStateMachineConfig();
             stateMachineConfig.setRollbackPercentage(config.getRollbackPercentage());
             stateMachineConfig.setSagaFailStep(config.getSagaFailStep());
+            stateMachineConfig.setSagaRandomSeed(config.getSagaRandomSeed());
             stateMachineConfig.init();
 
             // Create state machine engine
@@ -274,6 +276,7 @@ public class SagaModeExecutor implements TransactionExecutor {
 
         private int rollbackPercentage = 0;
         private String sagaFailStep;
+        private Long sagaRandomSeed;
 
         public void setRollbackPercentage(int rollbackPercentage) {
             this.rollbackPercentage = rollbackPercentage;
@@ -281,6 +284,10 @@ public class SagaModeExecutor implements TransactionExecutor {
 
         public void setSagaFailStep(String sagaFailStep) {
             this.sagaFailStep = sagaFailStep;
+        }
+
+        public void setSagaRandomSeed(Long sagaRandomSeed) {
+            this.sagaRandomSeed = sagaRandomSeed;
         }
 
         @Override
@@ -323,15 +330,21 @@ public class SagaModeExecutor implements TransactionExecutor {
                 // Register services with configured rollback percentage
                 // Divide rollback percentage by 3 for each service so total probability is approximately correct
                 int serviceRollbackPct = rollbackPercentage > 0 ? Math.max(1, rollbackPercentage / 3) : 0;
+                Random failureRandom =
+                        sagaRandomSeed == null ? null : new Random(sagaRandomSeed);
 
                 serviceInvoker.registerService(
-                        "orderService", new OrderSagaService(serviceRollbackPct, 5, STEP_ORDER.equals(sagaFailStep)));
+                        "orderService",
+                        new OrderSagaService(
+                                serviceRollbackPct, 5, STEP_ORDER.equals(sagaFailStep), failureRandom));
                 serviceInvoker.registerService(
                         "inventoryService",
-                        new InventorySagaService(serviceRollbackPct, 5, STEP_INVENTORY.equals(sagaFailStep)));
+                        new InventorySagaService(
+                                serviceRollbackPct, 5, STEP_INVENTORY.equals(sagaFailStep), failureRandom));
                 serviceInvoker.registerService(
                         "paymentService",
-                        new PaymentSagaService(serviceRollbackPct, 5, STEP_PAYMENT.equals(sagaFailStep)));
+                        new PaymentSagaService(
+                                serviceRollbackPct, 5, STEP_PAYMENT.equals(sagaFailStep), failureRandom));
 
                 // Register the service invoker for different service types
                 getServiceInvokerManager().putServiceInvoker(DomainConstants.SERVICE_TYPE_SPRING_BEAN, serviceInvoker);

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -103,6 +103,8 @@ public class SagaModeExecutor implements TransactionExecutor {
             stateMachineConfig.setRollbackPercentage(config.getRollbackPercentage());
             stateMachineConfig.setSagaFailStep(config.getSagaFailStep());
             stateMachineConfig.setSagaRandomSeed(config.getSagaRandomSeed());
+            stateMachineConfig.setSagaTimeoutStep(config.getSagaTimeoutStep());
+            stateMachineConfig.setSagaTimeoutMs(config.getSagaTimeoutMs());
             stateMachineConfig.init();
 
             // Create state machine engine
@@ -198,6 +200,8 @@ public class SagaModeExecutor implements TransactionExecutor {
                 status = STATUS_COMPENSATED;
             } else if (ExecutionStatus.FA.equals(compensationStatus)) {
                 status = STATUS_COMPENSATION_FAILED;
+            } else if (ExecutionStatus.UN.equals(compensationStatus)) {
+                status = STATUS_UNKNOWN;
             } else if (ExecutionStatus.SU.equals(executionStatus)) {
                 status = STATUS_COMMITTED;
                 success = true;
@@ -277,6 +281,8 @@ public class SagaModeExecutor implements TransactionExecutor {
         private int rollbackPercentage = 0;
         private String sagaFailStep;
         private Long sagaRandomSeed;
+        private String sagaTimeoutStep;
+        private int sagaTimeoutMs = 3000;
 
         public void setRollbackPercentage(int rollbackPercentage) {
             this.rollbackPercentage = rollbackPercentage;
@@ -288,6 +294,14 @@ public class SagaModeExecutor implements TransactionExecutor {
 
         public void setSagaRandomSeed(Long sagaRandomSeed) {
             this.sagaRandomSeed = sagaRandomSeed;
+        }
+
+        public void setSagaTimeoutStep(String sagaTimeoutStep) {
+            this.sagaTimeoutStep = sagaTimeoutStep;
+        }
+
+        public void setSagaTimeoutMs(int sagaTimeoutMs) {
+            this.sagaTimeoutMs = sagaTimeoutMs;
         }
 
         @Override
@@ -335,19 +349,37 @@ public class SagaModeExecutor implements TransactionExecutor {
                 boolean orderFailEnabled = !restrictFailureStep || STEP_ORDER.equals(sagaFailStep);
                 boolean inventoryFailEnabled = !restrictFailureStep || STEP_INVENTORY.equals(sagaFailStep);
                 boolean paymentFailEnabled = !restrictFailureStep || STEP_PAYMENT.equals(sagaFailStep);
+                boolean orderTimeoutEnabled = STEP_ORDER.equals(sagaTimeoutStep);
+                boolean inventoryTimeoutEnabled = STEP_INVENTORY.equals(sagaTimeoutStep);
+                boolean paymentTimeoutEnabled = STEP_PAYMENT.equals(sagaTimeoutStep);
 
                 serviceInvoker.registerService(
                         "orderService",
                         new OrderSagaService(
-                                serviceRollbackPct, 5, orderFailEnabled, createFailureRandom(11)));
+                                serviceRollbackPct,
+                                5,
+                                orderFailEnabled,
+                                createFailureRandom(11),
+                                orderTimeoutEnabled,
+                                sagaTimeoutMs));
                 serviceInvoker.registerService(
                         "inventoryService",
                         new InventorySagaService(
-                                serviceRollbackPct, 5, inventoryFailEnabled, createFailureRandom(17)));
+                                serviceRollbackPct,
+                                5,
+                                inventoryFailEnabled,
+                                createFailureRandom(17),
+                                inventoryTimeoutEnabled,
+                                sagaTimeoutMs));
                 serviceInvoker.registerService(
                         "paymentService",
                         new PaymentSagaService(
-                                serviceRollbackPct, 5, paymentFailEnabled, createFailureRandom(23)));
+                                serviceRollbackPct,
+                                5,
+                                paymentFailEnabled,
+                                createFailureRandom(23),
+                                paymentTimeoutEnabled,
+                                sagaTimeoutMs));
 
                 // Register the service invoker for different service types
                 getServiceInvokerManager().putServiceInvoker(DomainConstants.SERVICE_TYPE_SPRING_BEAN, serviceInvoker);

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/SagaModeExecutor.java
@@ -68,6 +68,8 @@ public class SagaModeExecutor implements TransactionExecutor {
     private static final String STEP_INVENTORY = "inventory";
     private static final String STEP_PAYMENT = "payment";
     private static final String STEP_ORDER = "order";
+    private static final String SHAPE_SIMPLE = "simple";
+    private static final String SHAPE_ORDER = "order";
 
     private final BenchmarkConfig config;
     private StateMachineEngine stateMachineEngine;
@@ -177,8 +179,7 @@ public class SagaModeExecutor implements TransactionExecutor {
         boolean success = false;
 
         try {
-            // Choose state machine based on branch count
-            String stateMachineName = branchCount >= 3 ? ORDER_SAGA_NAME : SIMPLE_SAGA_NAME;
+            String stateMachineName = resolveStateMachineName(branchCount);
 
             // Prepare start parameters
             Map<String, Object> startParams = createStartParams();
@@ -213,6 +214,16 @@ public class SagaModeExecutor implements TransactionExecutor {
 
         long duration = System.currentTimeMillis() - startTime;
         return new TransactionRecord(businessKey, status, duration, branchCount, success);
+    }
+
+    private String resolveStateMachineName(int branchCount) {
+        if (SHAPE_ORDER.equals(config.getSagaShape())) {
+            return ORDER_SAGA_NAME;
+        }
+        if (SHAPE_SIMPLE.equals(config.getSagaShape())) {
+            return SIMPLE_SAGA_NAME;
+        }
+        return branchCount >= 3 ? ORDER_SAGA_NAME : SIMPLE_SAGA_NAME;
     }
 
     private Map<String, Object> createStartParams() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/WorkloadGenerator.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/WorkloadGenerator.java
@@ -34,6 +34,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.seata.benchmark.constant.BenchmarkConstants.STATUS_FAILED;
+
 /**
  * Workload generator with TPS rate limiting
  */
@@ -100,6 +102,7 @@ public class WorkloadGenerator {
     }
 
     private void executeTransaction() {
+        long startTime = System.currentTimeMillis();
         try {
             TransactionRecord record = executor.execute();
             metrics.recordTransaction(record.getStatus(), record.getDuration());
@@ -108,7 +111,8 @@ public class WorkloadGenerator {
 
         } catch (Exception e) {
             LOGGER.error("Transaction execution error", e);
-            metrics.recordFailure(0);
+            long duration = System.currentTimeMillis() - startTime;
+            metrics.recordTransaction(STATUS_FAILED, duration);
         }
     }
 

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/WorkloadGenerator.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/executor/WorkloadGenerator.java
@@ -102,12 +102,7 @@ public class WorkloadGenerator {
     private void executeTransaction() {
         try {
             TransactionRecord record = executor.execute();
-
-            if (record.isSuccess()) {
-                metrics.recordSuccess(record.getDuration());
-            } else {
-                metrics.recordFailure(record.getDuration());
-            }
+            metrics.recordTransaction(record.getStatus(), record.getDuration());
 
             addRecentRecord(record);
 

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
@@ -39,7 +39,7 @@ public class BenchmarkMetrics {
     private final List<Long> latencies =
             Collections.synchronizedList(new ArrayList<>(BenchmarkConstants.MAX_LATENCY_SAMPLES));
     private final AtomicLong totalSamples = new AtomicLong(0);
-    private final long startTime = System.currentTimeMillis();
+    private volatile long startTime = System.currentTimeMillis();
 
     private volatile long lastCountSnapshot = 0;
     private volatile long lastSnapshotTime = System.currentTimeMillis();
@@ -220,6 +220,7 @@ public class BenchmarkMetrics {
     }
 
     public void reset() {
+        startTime = System.currentTimeMillis();
         totalCount.set(0);
         successCount.set(0);
         failedCount.set(0);

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
@@ -32,6 +32,10 @@ public class BenchmarkMetrics {
     private final AtomicLong totalCount = new AtomicLong(0);
     private final AtomicLong successCount = new AtomicLong(0);
     private final AtomicLong failedCount = new AtomicLong(0);
+    private final AtomicLong committedCount = new AtomicLong(0);
+    private final AtomicLong compensatedCount = new AtomicLong(0);
+    private final AtomicLong compensationFailedCount = new AtomicLong(0);
+    private final AtomicLong unknownCount = new AtomicLong(0);
     private final List<Long> latencies =
             Collections.synchronizedList(new ArrayList<>(BenchmarkConstants.MAX_LATENCY_SAMPLES));
     private final AtomicLong totalSamples = new AtomicLong(0);
@@ -52,6 +56,29 @@ public class BenchmarkMetrics {
     public void recordFailure(long latencyMs) {
         totalCount.incrementAndGet();
         failedCount.incrementAndGet();
+        addLatencySample(latencyMs);
+    }
+
+    public void recordTransaction(String status, long latencyMs) {
+        totalCount.incrementAndGet();
+
+        if (BenchmarkConstants.STATUS_COMMITTED.equals(status)) {
+            successCount.incrementAndGet();
+            committedCount.incrementAndGet();
+        } else if (BenchmarkConstants.STATUS_COMPENSATED.equals(status)) {
+            compensatedCount.incrementAndGet();
+            failedCount.incrementAndGet();
+        } else if (BenchmarkConstants.STATUS_COMPENSATION_FAILED.equals(status)) {
+            compensationFailedCount.incrementAndGet();
+            failedCount.incrementAndGet();
+        } else if (BenchmarkConstants.STATUS_FAILED.equals(status)
+                || BenchmarkConstants.STATUS_ROLLBACKED.equals(status)) {
+            failedCount.incrementAndGet();
+        } else {
+            unknownCount.incrementAndGet();
+            failedCount.incrementAndGet();
+        }
+
         addLatencySample(latencyMs);
     }
 
@@ -80,12 +107,56 @@ public class BenchmarkMetrics {
         return failedCount.get();
     }
 
+    public long getCommittedCount() {
+        return committedCount.get();
+    }
+
+    public long getCompensatedCount() {
+        return compensatedCount.get();
+    }
+
+    public long getExecutionFailedCount() {
+        return failedCount.get() - compensatedCount.get() - compensationFailedCount.get() - unknownCount.get();
+    }
+
+    public long getCompensationFailedCount() {
+        return compensationFailedCount.get();
+    }
+
+    public long getUnknownCount() {
+        return unknownCount.get();
+    }
+
     public double getSuccessRate() {
         long total = totalCount.get();
         if (total == 0) {
             return 0.0;
         }
         return (double) successCount.get() / total * 100;
+    }
+
+    public double getCommittedRate() {
+        long total = totalCount.get();
+        if (total == 0) {
+            return 0.0;
+        }
+        return (double) committedCount.get() / total * 100;
+    }
+
+    public double getCompensatedRate() {
+        long total = totalCount.get();
+        if (total == 0) {
+            return 0.0;
+        }
+        return (double) compensatedCount.get() / total * 100;
+    }
+
+    public double getEndStateSuccessRate() {
+        long total = totalCount.get();
+        if (total == 0) {
+            return 0.0;
+        }
+        return (double) (committedCount.get() + compensatedCount.get()) / total * 100;
     }
 
     public double getAverageTps() {
@@ -152,9 +223,16 @@ public class BenchmarkMetrics {
         totalCount.set(0);
         successCount.set(0);
         failedCount.set(0);
+        committedCount.set(0);
+        compensatedCount.set(0);
+        compensationFailedCount.set(0);
+        unknownCount.set(0);
+        totalSamples.set(0);
         latencies.clear();
         lastCountSnapshot = 0;
         lastSnapshotTime = System.currentTimeMillis();
+        cachedStats = null;
+        lastStatsUpdateTime = 0;
     }
 
     public static class LatencyStats {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
@@ -116,7 +116,7 @@ public class BenchmarkMetrics {
     }
 
     public long getExecutionFailedCount() {
-        return failedCount.get() - compensatedCount.get() - compensationFailedCount.get() - unknownCount.get();
+        return failedCount.get() - compensationFailedCount.get() - unknownCount.get();
     }
 
     public long getCompensationFailedCount() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/model/BenchmarkMetrics.java
@@ -67,7 +67,7 @@ public class BenchmarkMetrics {
             committedCount.incrementAndGet();
         } else if (BenchmarkConstants.STATUS_COMPENSATED.equals(status)) {
             compensatedCount.incrementAndGet();
-            failedCount.incrementAndGet();
+            successCount.incrementAndGet();
         } else if (BenchmarkConstants.STATUS_COMPENSATION_FAILED.equals(status)) {
             compensationFailedCount.incrementAndGet();
             failedCount.incrementAndGet();

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
@@ -47,7 +47,8 @@ public class MetricsCollector {
         try (PrintWriter writer = new PrintWriter(new FileWriter(filename))) {
             writer.println("Metric,Value");
             writer.println("Mode," + config.getMode());
-            if (config.getMode() == BranchType.SAGA && config.getSagaWorkload() != null
+            if (config.getMode() == BranchType.SAGA
+                    && config.getSagaWorkload() != null
                     && !config.getSagaWorkload().isEmpty()) {
                 writer.println("Saga Workload," + config.getSagaWorkload());
             }
@@ -92,7 +93,8 @@ public class MetricsCollector {
         report.append("           Seata Benchmark Final Report\n");
         report.append("===================================================\n");
         report.append(String.format("Mode:                  %s\n", config.getMode()));
-        if (config.getMode() == BranchType.SAGA && config.getSagaWorkload() != null
+        if (config.getMode() == BranchType.SAGA
+                && config.getSagaWorkload() != null
                 && !config.getSagaWorkload().isEmpty()) {
             report.append(String.format("Saga Workload:         %s\n", config.getSagaWorkload()));
         }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
@@ -18,6 +18,7 @@ package org.apache.seata.benchmark.monitor;
 
 import org.apache.seata.benchmark.config.BenchmarkConfig;
 import org.apache.seata.benchmark.model.BenchmarkMetrics;
+import org.apache.seata.core.model.BranchType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,10 @@ public class MetricsCollector {
         try (PrintWriter writer = new PrintWriter(new FileWriter(filename))) {
             writer.println("Metric,Value");
             writer.println("Mode," + config.getMode());
+            if (config.getMode() == BranchType.SAGA && config.getSagaWorkload() != null
+                    && !config.getSagaWorkload().isEmpty()) {
+                writer.println("Saga Workload," + config.getSagaWorkload());
+            }
             if (config.getSagaShape() != null && !config.getSagaShape().isEmpty()) {
                 writer.println("Saga Shape," + config.getSagaShape());
             }
@@ -87,6 +92,10 @@ public class MetricsCollector {
         report.append("           Seata Benchmark Final Report\n");
         report.append("===================================================\n");
         report.append(String.format("Mode:                  %s\n", config.getMode()));
+        if (config.getMode() == BranchType.SAGA && config.getSagaWorkload() != null
+                && !config.getSagaWorkload().isEmpty()) {
+            report.append(String.format("Saga Workload:         %s\n", config.getSagaWorkload()));
+        }
         if (config.getSagaShape() != null && !config.getSagaShape().isEmpty()) {
             report.append(String.format("Saga Shape:            %s\n", config.getSagaShape()));
         }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
@@ -96,7 +96,7 @@ public class MetricsCollector {
         report.append(String.format("Success Rate:          %.2f%%\n", metrics.getSuccessRate()));
         report.append(String.format("Committed Count:       %,d\n", metrics.getCommittedCount()));
         report.append(String.format("Compensated Count:     %,d\n", metrics.getCompensatedCount()));
-        report.append(String.format("Execution Failed Count:%,d\n", metrics.getExecutionFailedCount()));
+        report.append(String.format("Execution Failed Count: %,d\n", metrics.getExecutionFailedCount()));
         report.append(String.format("Compensation Failed Count: %,d\n", metrics.getCompensationFailedCount()));
         report.append(String.format("Unknown Count:         %,d\n", metrics.getUnknownCount()));
         report.append(String.format("Committed Rate:        %.2f%%\n", metrics.getCommittedRate()));

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.seata.benchmark.monitor;
 
+import org.apache.seata.benchmark.config.BenchmarkConfig;
 import org.apache.seata.benchmark.model.BenchmarkMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,15 +34,21 @@ public class MetricsCollector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetricsCollector.class);
 
+    private final BenchmarkConfig config;
     private final BenchmarkMetrics metrics;
 
-    public MetricsCollector(BenchmarkMetrics metrics) {
+    public MetricsCollector(BenchmarkConfig config, BenchmarkMetrics metrics) {
+        this.config = config;
         this.metrics = metrics;
     }
 
     public void exportToCsv(String filename) {
         try (PrintWriter writer = new PrintWriter(new FileWriter(filename))) {
             writer.println("Metric,Value");
+            writer.println("Mode," + config.getMode());
+            if (config.getSagaShape() != null && !config.getSagaShape().isEmpty()) {
+                writer.println("Saga Shape," + config.getSagaShape());
+            }
             writer.println("Total Transactions," + metrics.getTotalCount());
             writer.println("Success Count," + metrics.getSuccessCount());
             writer.println("Failed Count," + metrics.getFailedCount());
@@ -79,6 +86,10 @@ public class MetricsCollector {
         report.append("===================================================\n");
         report.append("           Seata Benchmark Final Report\n");
         report.append("===================================================\n");
+        report.append(String.format("Mode:                  %s\n", config.getMode()));
+        if (config.getSagaShape() != null && !config.getSagaShape().isEmpty()) {
+            report.append(String.format("Saga Shape:            %s\n", config.getSagaShape()));
+        }
         report.append(String.format("Total Transactions:    %,d\n", metrics.getTotalCount()));
         report.append(String.format("Success Count:         %,d\n", metrics.getSuccessCount()));
         report.append(String.format("Failed Count:          %,d\n", metrics.getFailedCount()));

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/monitor/MetricsCollector.java
@@ -45,7 +45,15 @@ public class MetricsCollector {
             writer.println("Total Transactions," + metrics.getTotalCount());
             writer.println("Success Count," + metrics.getSuccessCount());
             writer.println("Failed Count," + metrics.getFailedCount());
+            writer.println("Committed Count," + metrics.getCommittedCount());
+            writer.println("Compensated Count," + metrics.getCompensatedCount());
+            writer.println("Execution Failed Count," + metrics.getExecutionFailedCount());
+            writer.println("Compensation Failed Count," + metrics.getCompensationFailedCount());
+            writer.println("Unknown Count," + metrics.getUnknownCount());
             writer.println("Success Rate (%)," + String.format("%.2f", metrics.getSuccessRate()));
+            writer.println("Committed Rate (%)," + String.format("%.2f", metrics.getCommittedRate()));
+            writer.println("Compensated Rate (%)," + String.format("%.2f", metrics.getCompensatedRate()));
+            writer.println("End-State Success Rate (%)," + String.format("%.2f", metrics.getEndStateSuccessRate()));
             writer.println("Average TPS," + String.format("%.2f", metrics.getAverageTps()));
             writer.println("Elapsed Time (s)," + metrics.getElapsedTimeSeconds());
 
@@ -75,6 +83,14 @@ public class MetricsCollector {
         report.append(String.format("Success Count:         %,d\n", metrics.getSuccessCount()));
         report.append(String.format("Failed Count:          %,d\n", metrics.getFailedCount()));
         report.append(String.format("Success Rate:          %.2f%%\n", metrics.getSuccessRate()));
+        report.append(String.format("Committed Count:       %,d\n", metrics.getCommittedCount()));
+        report.append(String.format("Compensated Count:     %,d\n", metrics.getCompensatedCount()));
+        report.append(String.format("Execution Failed Count:%,d\n", metrics.getExecutionFailedCount()));
+        report.append(String.format("Compensation Failed Count: %,d\n", metrics.getCompensationFailedCount()));
+        report.append(String.format("Unknown Count:         %,d\n", metrics.getUnknownCount()));
+        report.append(String.format("Committed Rate:        %.2f%%\n", metrics.getCommittedRate()));
+        report.append(String.format("Compensated Rate:      %.2f%%\n", metrics.getCompensatedRate()));
+        report.append(String.format("End-State Success Rate: %.2f%%\n", metrics.getEndStateSuccessRate()));
         report.append(String.format("Average TPS:           %.2f\n", metrics.getAverageTps()));
         report.append(String.format("Elapsed Time:          %d seconds\n", metrics.getElapsedTimeSeconds()));
         report.append("\n");

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/FailureRandomProvider.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/FailureRandomProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.benchmark.saga;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Thread-local failure random provider to avoid cross-thread contention while keeping seeded behavior reproducible.
+ */
+public final class FailureRandomProvider {
+
+    private FailureRandomProvider() {}
+
+    public static ThreadLocal<Random> create(Long seed) {
+        if (seed == null) {
+            return null;
+        }
+        return ThreadLocal.withInitial(
+                () -> new Random(mixSeed(seed, Thread.currentThread().getName())));
+    }
+
+    public static int nextPercent(ThreadLocal<Random> failureRandom) {
+        if (failureRandom != null) {
+            return failureRandom.get().nextInt(100);
+        }
+        return ThreadLocalRandom.current().nextInt(100);
+    }
+
+    private static long mixSeed(long seed, String threadName) {
+        long mixed = seed ^ threadName.hashCode();
+        mixed ^= (mixed << 21);
+        mixed ^= (mixed >>> 35);
+        mixed ^= (mixed << 4);
+        return mixed;
+    }
+}

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventoryDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventoryDbSagaService.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,7 +40,7 @@ public class InventoryDbSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
-    private final Random failureRandom;
+    private final ThreadLocal<Random> failureRandom;
     private final boolean timeoutInjectionEnabled;
     private final int timeoutMs;
 
@@ -50,7 +49,7 @@ public class InventoryDbSagaService {
             int rollbackPercentage,
             int simulatedDelayMs,
             boolean failInjectionEnabled,
-            Random failureRandom,
+            ThreadLocal<Random> failureRandom,
             boolean timeoutInjectionEnabled,
             int timeoutMs) {
         this.dataSource = dataSource;
@@ -75,21 +74,27 @@ public class InventoryDbSagaService {
         }
 
         try (Connection conn = dataSource.getConnection()) {
+            boolean originalAutoCommit = conn.getAutoCommit();
             conn.setAutoCommit(false);
-            int available = queryAvailableQuantity(conn, productId);
-            if (available < quantity) {
-                throw new RuntimeException("Insufficient inventory for product " + productId);
+            try {
+                try (PreparedStatement pstmt = conn.prepareStatement("UPDATE benchmark_inventory "
+                        + "SET available_qty = available_qty - ?, reserved_qty = reserved_qty + ? "
+                        + "WHERE product_id = ? AND available_qty >= ?")) {
+                    pstmt.setInt(1, quantity);
+                    pstmt.setInt(2, quantity);
+                    pstmt.setString(3, productId);
+                    pstmt.setInt(4, quantity);
+                    if (pstmt.executeUpdate() == 0) {
+                        throw new RuntimeException("Insufficient inventory for product " + productId);
+                    }
+                }
+                conn.commit();
+            } catch (Exception e) {
+                rollbackQuietly(conn, e);
+                throw e;
+            } finally {
+                restoreAutoCommit(conn, originalAutoCommit);
             }
-            try (PreparedStatement pstmt = conn.prepareStatement(
-                    "UPDATE benchmark_inventory "
-                            + "SET available_qty = available_qty - ?, reserved_qty = reserved_qty + ? "
-                            + "WHERE product_id = ?")) {
-                pstmt.setInt(1, quantity);
-                pstmt.setInt(2, quantity);
-                pstmt.setString(3, productId);
-                pstmt.executeUpdate();
-            }
-            conn.commit();
         } catch (SQLException e) {
             throw new RuntimeException("Failed to reserve inventory", e);
         }
@@ -109,10 +114,9 @@ public class InventoryDbSagaService {
         simulateDelay();
 
         try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = conn.prepareStatement(
-                        "UPDATE benchmark_inventory "
-                                + "SET available_qty = available_qty + ?, reserved_qty = GREATEST(reserved_qty - ?, 0) "
-                                + "WHERE product_id = ?")) {
+                PreparedStatement pstmt = conn.prepareStatement("UPDATE benchmark_inventory "
+                        + "SET available_qty = available_qty + ?, reserved_qty = GREATEST(reserved_qty - ?, 0) "
+                        + "WHERE product_id = ?")) {
             pstmt.setInt(1, quantity);
             pstmt.setInt(2, quantity);
             pstmt.setString(3, productId);
@@ -128,20 +132,20 @@ public class InventoryDbSagaService {
         return result;
     }
 
-    private int queryAvailableQuantity(Connection conn, String productId) throws SQLException {
-        try (PreparedStatement pstmt =
-                        conn.prepareStatement("SELECT available_qty FROM benchmark_inventory WHERE product_id = ?");
-                ResultSet rs = executeQuery(pstmt, productId)) {
-            if (!rs.next()) {
-                throw new RuntimeException("Product not found: " + productId);
-            }
-            return rs.getInt(1);
+    private void rollbackQuietly(Connection conn, Exception original) {
+        try {
+            conn.rollback();
+        } catch (SQLException rollbackException) {
+            original.addSuppressed(rollbackException);
         }
     }
 
-    private ResultSet executeQuery(PreparedStatement pstmt, String productId) throws SQLException {
-        pstmt.setString(1, productId);
-        return pstmt.executeQuery();
+    private void restoreAutoCommit(Connection conn, boolean originalAutoCommit) {
+        try {
+            conn.setAutoCommit(originalAutoCommit);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to restore auto-commit for inventory connection", e);
+        }
     }
 
     private void simulateDelay() {
@@ -168,11 +172,6 @@ public class InventoryDbSagaService {
     }
 
     private int nextFailurePercent() {
-        if (failureRandom != null) {
-            synchronized (failureRandom) {
-                return failureRandom.nextInt(100);
-            }
-        }
-        return ThreadLocalRandom.current().nextInt(100);
+        return FailureRandomProvider.nextPercent(failureRandom);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventoryDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventoryDbSagaService.java
@@ -132,6 +132,12 @@ public class InventoryDbSagaService {
         return result;
     }
 
+    public void destroy() {
+        if (failureRandom != null) {
+            failureRandom.remove();
+        }
+    }
+
     private void rollbackQuietly(Connection conn, Exception original) {
         try {
             conn.rollback();

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventoryDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventoryDbSagaService.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.benchmark.saga;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Database-backed inventory service for Saga benchmark.
+ * @author zihenzzz
+ */
+public class InventoryDbSagaService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InventoryDbSagaService.class);
+
+    private final DataSource dataSource;
+    private final int rollbackPercentage;
+    private final int simulatedDelayMs;
+    private final boolean failInjectionEnabled;
+    private final Random failureRandom;
+    private final boolean timeoutInjectionEnabled;
+    private final int timeoutMs;
+
+    public InventoryDbSagaService(
+            DataSource dataSource,
+            int rollbackPercentage,
+            int simulatedDelayMs,
+            boolean failInjectionEnabled,
+            Random failureRandom,
+            boolean timeoutInjectionEnabled,
+            int timeoutMs) {
+        this.dataSource = dataSource;
+        this.rollbackPercentage = rollbackPercentage;
+        this.simulatedDelayMs = simulatedDelayMs;
+        this.failInjectionEnabled = failInjectionEnabled;
+        this.failureRandom = failureRandom;
+        this.timeoutInjectionEnabled = timeoutInjectionEnabled;
+        this.timeoutMs = timeoutMs;
+    }
+
+    public Map<String, Object> reserveInventory(Map<String, Object> params) {
+        String productId = (String) params.get("productId");
+        Integer quantity = (Integer) params.get("quantity");
+
+        simulateDelay();
+        if (timeoutInjectionEnabled) {
+            simulateTimeout("inventory reservation");
+        }
+        if (shouldFail()) {
+            throw new RuntimeException("Simulated inventory reservation failure");
+        }
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(false);
+            int available = queryAvailableQuantity(conn, productId);
+            if (available < quantity) {
+                throw new RuntimeException("Insufficient inventory for product " + productId);
+            }
+            try (PreparedStatement pstmt = conn.prepareStatement(
+                    "UPDATE benchmark_inventory "
+                            + "SET available_qty = available_qty - ?, reserved_qty = reserved_qty + ? "
+                            + "WHERE product_id = ?")) {
+                pstmt.setInt(1, quantity);
+                pstmt.setInt(2, quantity);
+                pstmt.setString(3, productId);
+                pstmt.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to reserve inventory", e);
+        }
+
+        LOGGER.debug("Reserved inventory in DB: productId={}, quantity={}", productId, quantity);
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "S");
+        result.put("productId", productId);
+        result.put("quantity", quantity);
+        return result;
+    }
+
+    public Map<String, Object> releaseInventory(Map<String, Object> params) {
+        String productId = (String) params.get("productId");
+        Integer quantity = (Integer) params.get("quantity");
+
+        simulateDelay();
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(
+                        "UPDATE benchmark_inventory "
+                                + "SET available_qty = available_qty + ?, reserved_qty = GREATEST(reserved_qty - ?, 0) "
+                                + "WHERE product_id = ?")) {
+            pstmt.setInt(1, quantity);
+            pstmt.setInt(2, quantity);
+            pstmt.setString(3, productId);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to release inventory", e);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "S");
+        result.put("productId", productId);
+        result.put("quantity", quantity);
+        return result;
+    }
+
+    private int queryAvailableQuantity(Connection conn, String productId) throws SQLException {
+        try (PreparedStatement pstmt =
+                        conn.prepareStatement("SELECT available_qty FROM benchmark_inventory WHERE product_id = ?");
+                ResultSet rs = executeQuery(pstmt, productId)) {
+            if (!rs.next()) {
+                throw new RuntimeException("Product not found: " + productId);
+            }
+            return rs.getInt(1);
+        }
+    }
+
+    private ResultSet executeQuery(PreparedStatement pstmt, String productId) throws SQLException {
+        pstmt.setString(1, productId);
+        return pstmt.executeQuery();
+    }
+
+    private void simulateDelay() {
+        if (simulatedDelayMs > 0) {
+            try {
+                Thread.sleep(ThreadLocalRandom.current().nextInt(simulatedDelayMs));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean shouldFail() {
+        return failInjectionEnabled && nextFailurePercent() < rollbackPercentage;
+    }
+
+    private void simulateTimeout(String operation) {
+        try {
+            Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new RuntimeException("Simulated " + operation + " timeout");
+    }
+
+    private int nextFailurePercent() {
+        if (failureRandom != null) {
+            synchronized (failureRandom) {
+                return failureRandom.nextInt(100);
+            }
+        }
+        return ThreadLocalRandom.current().nextInt(100);
+    }
+}

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
@@ -110,6 +110,12 @@ public class InventorySagaService {
         return result;
     }
 
+    public void destroy() {
+        if (failureRandom != null) {
+            failureRandom.remove();
+        }
+    }
+
     private void simulateDelay() {
         if (simulatedDelayMs > 0) {
             try {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
@@ -33,10 +33,12 @@ public class InventorySagaService {
 
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
+    private final boolean failInjectionEnabled;
 
-    public InventorySagaService(int rollbackPercentage, int simulatedDelayMs) {
+    public InventorySagaService(int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
+        this.failInjectionEnabled = failInjectionEnabled;
     }
 
     /**
@@ -54,7 +56,7 @@ public class InventorySagaService {
         // Simulate processing time
         simulateDelay();
 
-        // Simulate random failure based on rollback percentage
+        // Simulate failure injection on the selected step.
         if (shouldFail()) {
             LOGGER.debug("Inventory reservation failed (simulated): productId={}", productId);
             throw new RuntimeException("Simulated inventory reservation failure");
@@ -102,6 +104,6 @@ public class InventorySagaService {
     }
 
     private boolean shouldFail() {
-        return ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
+        return failInjectionEnabled && ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -34,11 +35,14 @@ public class InventorySagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
+    private final Random failureRandom;
 
-    public InventorySagaService(int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled) {
+    public InventorySagaService(
+            int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled, Random failureRandom) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
         this.failInjectionEnabled = failInjectionEnabled;
+        this.failureRandom = failureRandom;
     }
 
     /**
@@ -104,6 +108,18 @@ public class InventorySagaService {
     }
 
     private boolean shouldFail() {
-        return failInjectionEnabled && ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
+        if (!failInjectionEnabled) {
+            return false;
+        }
+        return nextFailurePercent() < rollbackPercentage;
+    }
+
+    private int nextFailurePercent() {
+        if (failureRandom != null) {
+            synchronized (failureRandom) {
+                return failureRandom.nextInt(100);
+            }
+        }
+        return ThreadLocalRandom.current().nextInt(100);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
@@ -35,7 +35,7 @@ public class InventorySagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
-    private final Random failureRandom;
+    private final ThreadLocal<Random> failureRandom;
     private final boolean timeoutInjectionEnabled;
     private final int timeoutMs;
 
@@ -43,7 +43,7 @@ public class InventorySagaService {
             int rollbackPercentage,
             int simulatedDelayMs,
             boolean failInjectionEnabled,
-            Random failureRandom,
+            ThreadLocal<Random> failureRandom,
             boolean timeoutInjectionEnabled,
             int timeoutMs) {
         this.rollbackPercentage = rollbackPercentage;
@@ -138,11 +138,6 @@ public class InventorySagaService {
     }
 
     private int nextFailurePercent() {
-        if (failureRandom != null) {
-            synchronized (failureRandom) {
-                return failureRandom.nextInt(100);
-            }
-        }
-        return ThreadLocalRandom.current().nextInt(100);
+        return FailureRandomProvider.nextPercent(failureRandom);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/InventorySagaService.java
@@ -36,13 +36,22 @@ public class InventorySagaService {
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
     private final Random failureRandom;
+    private final boolean timeoutInjectionEnabled;
+    private final int timeoutMs;
 
     public InventorySagaService(
-            int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled, Random failureRandom) {
+            int rollbackPercentage,
+            int simulatedDelayMs,
+            boolean failInjectionEnabled,
+            Random failureRandom,
+            boolean timeoutInjectionEnabled,
+            int timeoutMs) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
         this.failInjectionEnabled = failInjectionEnabled;
         this.failureRandom = failureRandom;
+        this.timeoutInjectionEnabled = timeoutInjectionEnabled;
+        this.timeoutMs = timeoutMs;
     }
 
     /**
@@ -59,6 +68,10 @@ public class InventorySagaService {
 
         // Simulate processing time
         simulateDelay();
+
+        if (timeoutInjectionEnabled) {
+            simulateTimeout("inventory reservation");
+        }
 
         // Simulate failure injection on the selected step.
         if (shouldFail()) {
@@ -112,6 +125,16 @@ public class InventorySagaService {
             return false;
         }
         return nextFailurePercent() < rollbackPercentage;
+    }
+
+    private void simulateTimeout(String operation) {
+        LOGGER.debug("Simulating {} timeout: {} ms", operation, timeoutMs);
+        try {
+            Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new RuntimeException("Simulated " + operation + " timeout");
     }
 
     private int nextFailurePercent() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderDbSagaService.java
@@ -119,6 +119,12 @@ public class OrderDbSagaService {
         return result;
     }
 
+    public void destroy() {
+        if (failureRandom != null) {
+            failureRandom.remove();
+        }
+    }
+
     private BigDecimal toBigDecimal(Object amountObj) {
         return amountObj instanceof BigDecimal ? (BigDecimal) amountObj : new BigDecimal(amountObj.toString());
     }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderDbSagaService.java
@@ -37,7 +37,7 @@ public class OrderDbSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
-    private final Random failureRandom;
+    private final ThreadLocal<Random> failureRandom;
     private final boolean timeoutInjectionEnabled;
     private final int timeoutMs;
 
@@ -46,7 +46,7 @@ public class OrderDbSagaService {
             int rollbackPercentage,
             int simulatedDelayMs,
             boolean failInjectionEnabled,
-            Random failureRandom,
+            ThreadLocal<Random> failureRandom,
             boolean timeoutInjectionEnabled,
             int timeoutMs) {
         this.dataSource = dataSource;
@@ -74,10 +74,9 @@ public class OrderDbSagaService {
         }
 
         try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = conn.prepareStatement(
-                        "INSERT INTO benchmark_order "
-                                + "(order_id, user_id, product_id, quantity, amount, status) "
-                                + "VALUES (?, ?, ?, ?, ?, ?)")) {
+                PreparedStatement pstmt = conn.prepareStatement("INSERT INTO benchmark_order "
+                        + "(order_id, user_id, product_id, quantity, amount, status) "
+                        + "VALUES (?, ?, ?, ?, ?, ?)")) {
             pstmt.setString(1, orderId);
             pstmt.setString(2, userId);
             pstmt.setString(3, productId);
@@ -104,8 +103,8 @@ public class OrderDbSagaService {
         simulateDelay();
 
         try (Connection conn = dataSource.getConnection();
-                PreparedStatement pstmt = conn.prepareStatement(
-                        "UPDATE benchmark_order SET status = ? WHERE order_id = ?")) {
+                PreparedStatement pstmt =
+                        conn.prepareStatement("UPDATE benchmark_order SET status = ? WHERE order_id = ?")) {
             pstmt.setString(1, "CANCELLED");
             pstmt.setString(2, orderId);
             pstmt.executeUpdate();
@@ -148,11 +147,6 @@ public class OrderDbSagaService {
     }
 
     private int nextFailurePercent() {
-        if (failureRandom != null) {
-            synchronized (failureRandom) {
-                return failureRandom.nextInt(100);
-            }
-        }
-        return ThreadLocalRandom.current().nextInt(100);
+        return FailureRandomProvider.nextPercent(failureRandom);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderDbSagaService.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.benchmark.saga;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Database-backed order service for Saga benchmark.
+ * @author zihenzzz
+ */
+public class OrderDbSagaService {
+
+    private final DataSource dataSource;
+    private final int rollbackPercentage;
+    private final int simulatedDelayMs;
+    private final boolean failInjectionEnabled;
+    private final Random failureRandom;
+    private final boolean timeoutInjectionEnabled;
+    private final int timeoutMs;
+
+    public OrderDbSagaService(
+            DataSource dataSource,
+            int rollbackPercentage,
+            int simulatedDelayMs,
+            boolean failInjectionEnabled,
+            Random failureRandom,
+            boolean timeoutInjectionEnabled,
+            int timeoutMs) {
+        this.dataSource = dataSource;
+        this.rollbackPercentage = rollbackPercentage;
+        this.simulatedDelayMs = simulatedDelayMs;
+        this.failInjectionEnabled = failInjectionEnabled;
+        this.failureRandom = failureRandom;
+        this.timeoutInjectionEnabled = timeoutInjectionEnabled;
+        this.timeoutMs = timeoutMs;
+    }
+
+    public Map<String, Object> createOrder(Map<String, Object> params) {
+        String orderId = UUID.randomUUID().toString().substring(0, 8);
+        String userId = (String) params.get("userId");
+        String productId = (String) params.get("productId");
+        Integer quantity = (Integer) params.get("quantity");
+        BigDecimal amount = toBigDecimal(params.get("amount"));
+
+        simulateDelay();
+        if (timeoutInjectionEnabled) {
+            simulateTimeout("order creation");
+        }
+        if (shouldFail()) {
+            throw new RuntimeException("Simulated order creation failure");
+        }
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(
+                        "INSERT INTO benchmark_order "
+                                + "(order_id, user_id, product_id, quantity, amount, status) "
+                                + "VALUES (?, ?, ?, ?, ?, ?)")) {
+            pstmt.setString(1, orderId);
+            pstmt.setString(2, userId);
+            pstmt.setString(3, productId);
+            pstmt.setInt(4, quantity);
+            pstmt.setBigDecimal(5, amount);
+            pstmt.setString(6, "CREATED");
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create order", e);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "S");
+        result.put("orderId", orderId);
+        result.put("userId", userId);
+        result.put("productId", productId);
+        return result;
+    }
+
+    public Map<String, Object> cancelOrder(Map<String, Object> params) {
+        String orderId = (String) params.get("orderId");
+        String userId = (String) params.get("userId");
+
+        simulateDelay();
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(
+                        "UPDATE benchmark_order SET status = ? WHERE order_id = ?")) {
+            pstmt.setString(1, "CANCELLED");
+            pstmt.setString(2, orderId);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to cancel order", e);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "S");
+        result.put("orderId", orderId != null ? orderId : "unknown");
+        result.put("userId", userId);
+        return result;
+    }
+
+    private BigDecimal toBigDecimal(Object amountObj) {
+        return amountObj instanceof BigDecimal ? (BigDecimal) amountObj : new BigDecimal(amountObj.toString());
+    }
+
+    private void simulateDelay() {
+        if (simulatedDelayMs > 0) {
+            try {
+                Thread.sleep(ThreadLocalRandom.current().nextInt(simulatedDelayMs));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean shouldFail() {
+        return failInjectionEnabled && nextFailurePercent() < rollbackPercentage;
+    }
+
+    private void simulateTimeout(String operation) {
+        try {
+            Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new RuntimeException("Simulated " + operation + " timeout");
+    }
+
+    private int nextFailurePercent() {
+        if (failureRandom != null) {
+            synchronized (failureRandom) {
+                return failureRandom.nextInt(100);
+            }
+        }
+        return ThreadLocalRandom.current().nextInt(100);
+    }
+}

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
@@ -36,7 +36,7 @@ public class OrderSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
-    private final Random failureRandom;
+    private final ThreadLocal<Random> failureRandom;
     private final boolean timeoutInjectionEnabled;
     private final int timeoutMs;
 
@@ -44,7 +44,7 @@ public class OrderSagaService {
             int rollbackPercentage,
             int simulatedDelayMs,
             boolean failInjectionEnabled,
-            Random failureRandom,
+            ThreadLocal<Random> failureRandom,
             boolean timeoutInjectionEnabled,
             int timeoutMs) {
         this.rollbackPercentage = rollbackPercentage;
@@ -142,11 +142,6 @@ public class OrderSagaService {
     }
 
     private int nextFailurePercent() {
-        if (failureRandom != null) {
-            synchronized (failureRandom) {
-                return failureRandom.nextInt(100);
-            }
-        }
-        return ThreadLocalRandom.current().nextInt(100);
+        return FailureRandomProvider.nextPercent(failureRandom);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
@@ -114,6 +114,12 @@ public class OrderSagaService {
         return result;
     }
 
+    public void destroy() {
+        if (failureRandom != null) {
+            failureRandom.remove();
+        }
+    }
+
     private void simulateDelay() {
         if (simulatedDelayMs > 0) {
             try {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -35,11 +36,14 @@ public class OrderSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
+    private final Random failureRandom;
 
-    public OrderSagaService(int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled) {
+    public OrderSagaService(
+            int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled, Random failureRandom) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
         this.failInjectionEnabled = failInjectionEnabled;
+        this.failureRandom = failureRandom;
     }
 
     /**
@@ -108,6 +112,18 @@ public class OrderSagaService {
     }
 
     private boolean shouldFail() {
-        return failInjectionEnabled && ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
+        if (!failInjectionEnabled) {
+            return false;
+        }
+        return nextFailurePercent() < rollbackPercentage;
+    }
+
+    private int nextFailurePercent() {
+        if (failureRandom != null) {
+            synchronized (failureRandom) {
+                return failureRandom.nextInt(100);
+            }
+        }
+        return ThreadLocalRandom.current().nextInt(100);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
@@ -37,13 +37,22 @@ public class OrderSagaService {
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
     private final Random failureRandom;
+    private final boolean timeoutInjectionEnabled;
+    private final int timeoutMs;
 
     public OrderSagaService(
-            int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled, Random failureRandom) {
+            int rollbackPercentage,
+            int simulatedDelayMs,
+            boolean failInjectionEnabled,
+            Random failureRandom,
+            boolean timeoutInjectionEnabled,
+            int timeoutMs) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
         this.failInjectionEnabled = failInjectionEnabled;
         this.failureRandom = failureRandom;
+        this.timeoutInjectionEnabled = timeoutInjectionEnabled;
+        this.timeoutMs = timeoutMs;
     }
 
     /**
@@ -63,6 +72,10 @@ public class OrderSagaService {
 
         // Simulate processing time
         simulateDelay();
+
+        if (timeoutInjectionEnabled) {
+            simulateTimeout("order creation");
+        }
 
         // Simulate failure injection on the selected step.
         if (shouldFail()) {
@@ -116,6 +129,16 @@ public class OrderSagaService {
             return false;
         }
         return nextFailurePercent() < rollbackPercentage;
+    }
+
+    private void simulateTimeout(String operation) {
+        LOGGER.debug("Simulating {} timeout: {} ms", operation, timeoutMs);
+        try {
+            Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new RuntimeException("Simulated " + operation + " timeout");
     }
 
     private int nextFailurePercent() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/OrderSagaService.java
@@ -34,10 +34,12 @@ public class OrderSagaService {
 
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
+    private final boolean failInjectionEnabled;
 
-    public OrderSagaService(int rollbackPercentage, int simulatedDelayMs) {
+    public OrderSagaService(int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
+        this.failInjectionEnabled = failInjectionEnabled;
     }
 
     /**
@@ -58,7 +60,7 @@ public class OrderSagaService {
         // Simulate processing time
         simulateDelay();
 
-        // Simulate random failure based on rollback percentage
+        // Simulate failure injection on the selected step.
         if (shouldFail()) {
             LOGGER.debug("Order creation failed (simulated): userId={}", userId);
             throw new RuntimeException("Simulated order creation failure");
@@ -106,6 +108,6 @@ public class OrderSagaService {
     }
 
     private boolean shouldFail() {
-        return ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
+        return failInjectionEnabled && ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentDbSagaService.java
@@ -124,6 +124,12 @@ public class PaymentDbSagaService {
         return result;
     }
 
+    public void destroy() {
+        if (failureRandom != null) {
+            failureRandom.remove();
+        }
+    }
+
     private void rollbackQuietly(Connection conn, Exception original) {
         try {
             conn.rollback();

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentDbSagaService.java
@@ -20,7 +20,6 @@ import javax.sql.DataSource;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +36,7 @@ public class PaymentDbSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
-    private final Random failureRandom;
+    private final ThreadLocal<Random> failureRandom;
     private final boolean timeoutInjectionEnabled;
     private final int timeoutMs;
 
@@ -46,7 +45,7 @@ public class PaymentDbSagaService {
             int rollbackPercentage,
             int simulatedDelayMs,
             boolean failInjectionEnabled,
-            Random failureRandom,
+            ThreadLocal<Random> failureRandom,
             boolean timeoutInjectionEnabled,
             int timeoutMs) {
         this.dataSource = dataSource;
@@ -71,18 +70,26 @@ public class PaymentDbSagaService {
         }
 
         try (Connection conn = dataSource.getConnection()) {
+            boolean originalAutoCommit = conn.getAutoCommit();
             conn.setAutoCommit(false);
-            BigDecimal balance = queryBalance(conn, accountId);
-            if (balance.compareTo(amount) < 0) {
-                throw new RuntimeException("Insufficient balance for account " + accountId);
+            try {
+                try (PreparedStatement pstmt =
+                        conn.prepareStatement("UPDATE benchmark_account SET balance = balance - ? "
+                                + "WHERE account_id = ? AND balance >= ?")) {
+                    pstmt.setBigDecimal(1, amount);
+                    pstmt.setString(2, accountId);
+                    pstmt.setBigDecimal(3, amount);
+                    if (pstmt.executeUpdate() == 0) {
+                        throw new RuntimeException("Insufficient balance for account " + accountId);
+                    }
+                }
+                conn.commit();
+            } catch (Exception e) {
+                rollbackQuietly(conn, e);
+                throw e;
+            } finally {
+                restoreAutoCommit(conn, originalAutoCommit);
             }
-            try (PreparedStatement pstmt = conn.prepareStatement(
-                    "UPDATE benchmark_account SET balance = balance - ? WHERE account_id = ?")) {
-                pstmt.setBigDecimal(1, amount);
-                pstmt.setString(2, accountId);
-                pstmt.executeUpdate();
-            }
-            conn.commit();
         } catch (SQLException e) {
             throw new RuntimeException("Failed to debit payment", e);
         }
@@ -117,20 +124,20 @@ public class PaymentDbSagaService {
         return result;
     }
 
-    private BigDecimal queryBalance(Connection conn, String accountId) throws SQLException {
-        try (PreparedStatement pstmt =
-                        conn.prepareStatement("SELECT balance FROM benchmark_account WHERE account_id = ?");
-                ResultSet rs = executeQuery(pstmt, accountId)) {
-            if (!rs.next()) {
-                throw new RuntimeException("Account not found: " + accountId);
-            }
-            return rs.getBigDecimal(1);
+    private void rollbackQuietly(Connection conn, Exception original) {
+        try {
+            conn.rollback();
+        } catch (SQLException rollbackException) {
+            original.addSuppressed(rollbackException);
         }
     }
 
-    private ResultSet executeQuery(PreparedStatement pstmt, String accountId) throws SQLException {
-        pstmt.setString(1, accountId);
-        return pstmt.executeQuery();
+    private void restoreAutoCommit(Connection conn, boolean originalAutoCommit) {
+        try {
+            conn.setAutoCommit(originalAutoCommit);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to restore auto-commit for payment connection", e);
+        }
     }
 
     private BigDecimal toBigDecimal(Object amountObj) {
@@ -161,11 +168,6 @@ public class PaymentDbSagaService {
     }
 
     private int nextFailurePercent() {
-        if (failureRandom != null) {
-            synchronized (failureRandom) {
-                return failureRandom.nextInt(100);
-            }
-        }
-        return ThreadLocalRandom.current().nextInt(100);
+        return FailureRandomProvider.nextPercent(failureRandom);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentDbSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentDbSagaService.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.benchmark.saga;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Database-backed payment service for Saga benchmark.
+ * @author zihenzzz
+ */
+public class PaymentDbSagaService {
+
+    private final DataSource dataSource;
+    private final int rollbackPercentage;
+    private final int simulatedDelayMs;
+    private final boolean failInjectionEnabled;
+    private final Random failureRandom;
+    private final boolean timeoutInjectionEnabled;
+    private final int timeoutMs;
+
+    public PaymentDbSagaService(
+            DataSource dataSource,
+            int rollbackPercentage,
+            int simulatedDelayMs,
+            boolean failInjectionEnabled,
+            Random failureRandom,
+            boolean timeoutInjectionEnabled,
+            int timeoutMs) {
+        this.dataSource = dataSource;
+        this.rollbackPercentage = rollbackPercentage;
+        this.simulatedDelayMs = simulatedDelayMs;
+        this.failInjectionEnabled = failInjectionEnabled;
+        this.failureRandom = failureRandom;
+        this.timeoutInjectionEnabled = timeoutInjectionEnabled;
+        this.timeoutMs = timeoutMs;
+    }
+
+    public Map<String, Object> debitPayment(Map<String, Object> params) {
+        String accountId = (String) params.get("accountId");
+        BigDecimal amount = toBigDecimal(params.get("amount"));
+
+        simulateDelay();
+        if (timeoutInjectionEnabled) {
+            simulateTimeout("payment debit");
+        }
+        if (shouldFail()) {
+            throw new RuntimeException("Simulated payment debit failure");
+        }
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(false);
+            BigDecimal balance = queryBalance(conn, accountId);
+            if (balance.compareTo(amount) < 0) {
+                throw new RuntimeException("Insufficient balance for account " + accountId);
+            }
+            try (PreparedStatement pstmt = conn.prepareStatement(
+                    "UPDATE benchmark_account SET balance = balance - ? WHERE account_id = ?")) {
+                pstmt.setBigDecimal(1, amount);
+                pstmt.setString(2, accountId);
+                pstmt.executeUpdate();
+            }
+            conn.commit();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to debit payment", e);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "S");
+        result.put("accountId", accountId);
+        result.put("amount", amount.toPlainString());
+        return result;
+    }
+
+    public Map<String, Object> refundPayment(Map<String, Object> params) {
+        String accountId = (String) params.get("accountId");
+        BigDecimal amount = toBigDecimal(params.get("amount"));
+
+        simulateDelay();
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement pstmt = conn.prepareStatement(
+                        "UPDATE benchmark_account SET balance = balance + ? WHERE account_id = ?")) {
+            pstmt.setBigDecimal(1, amount);
+            pstmt.setString(2, accountId);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to refund payment", e);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("code", "S");
+        result.put("accountId", accountId);
+        result.put("amount", amount.toPlainString());
+        return result;
+    }
+
+    private BigDecimal queryBalance(Connection conn, String accountId) throws SQLException {
+        try (PreparedStatement pstmt =
+                        conn.prepareStatement("SELECT balance FROM benchmark_account WHERE account_id = ?");
+                ResultSet rs = executeQuery(pstmt, accountId)) {
+            if (!rs.next()) {
+                throw new RuntimeException("Account not found: " + accountId);
+            }
+            return rs.getBigDecimal(1);
+        }
+    }
+
+    private ResultSet executeQuery(PreparedStatement pstmt, String accountId) throws SQLException {
+        pstmt.setString(1, accountId);
+        return pstmt.executeQuery();
+    }
+
+    private BigDecimal toBigDecimal(Object amountObj) {
+        return amountObj instanceof BigDecimal ? (BigDecimal) amountObj : new BigDecimal(amountObj.toString());
+    }
+
+    private void simulateDelay() {
+        if (simulatedDelayMs > 0) {
+            try {
+                Thread.sleep(ThreadLocalRandom.current().nextInt(simulatedDelayMs));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private boolean shouldFail() {
+        return failInjectionEnabled && nextFailurePercent() < rollbackPercentage;
+    }
+
+    private void simulateTimeout(String operation) {
+        try {
+            Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new RuntimeException("Simulated " + operation + " timeout");
+    }
+
+    private int nextFailurePercent() {
+        if (failureRandom != null) {
+            synchronized (failureRandom) {
+                return failureRandom.nextInt(100);
+            }
+        }
+        return ThreadLocalRandom.current().nextInt(100);
+    }
+}

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
@@ -36,7 +36,7 @@ public class PaymentSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
-    private final Random failureRandom;
+    private final ThreadLocal<Random> failureRandom;
     private final boolean timeoutInjectionEnabled;
     private final int timeoutMs;
 
@@ -44,7 +44,7 @@ public class PaymentSagaService {
             int rollbackPercentage,
             int simulatedDelayMs,
             boolean failInjectionEnabled,
-            Random failureRandom,
+            ThreadLocal<Random> failureRandom,
             boolean timeoutInjectionEnabled,
             int timeoutMs) {
         this.rollbackPercentage = rollbackPercentage;
@@ -143,11 +143,6 @@ public class PaymentSagaService {
     }
 
     private int nextFailurePercent() {
-        if (failureRandom != null) {
-            synchronized (failureRandom) {
-                return failureRandom.nextInt(100);
-            }
-        }
-        return ThreadLocalRandom.current().nextInt(100);
+        return FailureRandomProvider.nextPercent(failureRandom);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -35,11 +36,14 @@ public class PaymentSagaService {
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
+    private final Random failureRandom;
 
-    public PaymentSagaService(int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled) {
+    public PaymentSagaService(
+            int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled, Random failureRandom) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
         this.failInjectionEnabled = failInjectionEnabled;
+        this.failureRandom = failureRandom;
     }
 
     /**
@@ -109,6 +113,18 @@ public class PaymentSagaService {
     }
 
     private boolean shouldFail() {
-        return failInjectionEnabled && ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
+        if (!failInjectionEnabled) {
+            return false;
+        }
+        return nextFailurePercent() < rollbackPercentage;
+    }
+
+    private int nextFailurePercent() {
+        if (failureRandom != null) {
+            synchronized (failureRandom) {
+                return failureRandom.nextInt(100);
+            }
+        }
+        return ThreadLocalRandom.current().nextInt(100);
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
@@ -115,6 +115,12 @@ public class PaymentSagaService {
         return result;
     }
 
+    public void destroy() {
+        if (failureRandom != null) {
+            failureRandom.remove();
+        }
+    }
+
     private void simulateDelay() {
         if (simulatedDelayMs > 0) {
             try {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
@@ -34,10 +34,12 @@ public class PaymentSagaService {
 
     private final int rollbackPercentage;
     private final int simulatedDelayMs;
+    private final boolean failInjectionEnabled;
 
-    public PaymentSagaService(int rollbackPercentage, int simulatedDelayMs) {
+    public PaymentSagaService(int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
+        this.failInjectionEnabled = failInjectionEnabled;
     }
 
     /**
@@ -57,7 +59,7 @@ public class PaymentSagaService {
         // Simulate processing time
         simulateDelay();
 
-        // Simulate random failure based on rollback percentage
+        // Simulate failure injection on the selected step.
         if (shouldFail()) {
             LOGGER.debug("Payment debit failed (simulated): accountId={}", accountId);
             throw new RuntimeException("Simulated payment debit failure");
@@ -107,6 +109,6 @@ public class PaymentSagaService {
     }
 
     private boolean shouldFail() {
-        return ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
+        return failInjectionEnabled && ThreadLocalRandom.current().nextInt(100) < rollbackPercentage;
     }
 }

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/PaymentSagaService.java
@@ -37,13 +37,22 @@ public class PaymentSagaService {
     private final int simulatedDelayMs;
     private final boolean failInjectionEnabled;
     private final Random failureRandom;
+    private final boolean timeoutInjectionEnabled;
+    private final int timeoutMs;
 
     public PaymentSagaService(
-            int rollbackPercentage, int simulatedDelayMs, boolean failInjectionEnabled, Random failureRandom) {
+            int rollbackPercentage,
+            int simulatedDelayMs,
+            boolean failInjectionEnabled,
+            Random failureRandom,
+            boolean timeoutInjectionEnabled,
+            int timeoutMs) {
         this.rollbackPercentage = rollbackPercentage;
         this.simulatedDelayMs = simulatedDelayMs;
         this.failInjectionEnabled = failInjectionEnabled;
         this.failureRandom = failureRandom;
+        this.timeoutInjectionEnabled = timeoutInjectionEnabled;
+        this.timeoutMs = timeoutMs;
     }
 
     /**
@@ -62,6 +71,10 @@ public class PaymentSagaService {
 
         // Simulate processing time
         simulateDelay();
+
+        if (timeoutInjectionEnabled) {
+            simulateTimeout("payment debit");
+        }
 
         // Simulate failure injection on the selected step.
         if (shouldFail()) {
@@ -117,6 +130,16 @@ public class PaymentSagaService {
             return false;
         }
         return nextFailurePercent() < rollbackPercentage;
+    }
+
+    private void simulateTimeout(String operation) {
+        LOGGER.debug("Simulating {} timeout: {} ms", operation, timeoutMs);
+        try {
+            Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        throw new RuntimeException("Simulated " + operation + " timeout");
     }
 
     private int nextFailurePercent() {

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/SagaDbEnvironment.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/SagaDbEnvironment.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.benchmark.saga;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.seata.benchmark.config.BenchmarkConfig;
+import org.apache.seata.benchmark.constant.BenchmarkConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Database-backed environment for Saga benchmark business actions.
+ * @author zihenzzz
+ */
+public class SagaDbEnvironment {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SagaDbEnvironment.class);
+
+    private final BenchmarkConfig config;
+    private MySQLContainer<?> mysqlContainer;
+    private HikariDataSource dataSource;
+
+    public SagaDbEnvironment(BenchmarkConfig config) {
+        this.config = config;
+    }
+
+    public void init() {
+        try {
+            startMySQLContainer();
+            createDataSource();
+            initDatabase();
+            LOGGER.info(
+                    "Saga DB workload initialized with {} accounts and {} products",
+                    BenchmarkConstants.ACCOUNT_COUNT,
+                    BenchmarkConstants.SAGA_PRODUCT_COUNT);
+        } catch (Exception e) {
+            destroy();
+            throw e instanceof RuntimeException
+                    ? (RuntimeException) e
+                    : new RuntimeException("Failed to initialize Saga DB workload", e);
+        }
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    public void destroy() {
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+            LOGGER.info("Saga DB DataSource closed");
+        }
+        if (mysqlContainer != null && mysqlContainer.isRunning()) {
+            mysqlContainer.stop();
+            LOGGER.info("Saga DB MySQL container stopped");
+        }
+    }
+
+    private void startMySQLContainer() {
+        LOGGER.info("Starting MySQL container for Saga DB workload...");
+        mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                .withDatabaseName("benchmark_saga")
+                .withUsername("test")
+                .withPassword("test")
+                .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
+        mysqlContainer.start();
+        LOGGER.info("Saga DB MySQL container started: {}", mysqlContainer.getJdbcUrl());
+    }
+
+    private void createDataSource() {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(mysqlContainer.getJdbcUrl());
+        hikariConfig.setUsername(mysqlContainer.getUsername());
+        hikariConfig.setPassword(mysqlContainer.getPassword());
+        hikariConfig.setDriverClassName("com.mysql.cj.jdbc.Driver");
+        hikariConfig.setMaximumPoolSize(config.getThreads() * 2);
+        hikariConfig.setMinimumIdle(Math.max(1, config.getThreads()));
+        hikariConfig.setConnectionTimeout(30000);
+        hikariConfig.setIdleTimeout(600000);
+        hikariConfig.setMaxLifetime(1800000);
+        dataSource = new HikariDataSource(hikariConfig);
+    }
+
+    private void initDatabase() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS benchmark_inventory ("
+                    + "product_id VARCHAR(64) PRIMARY KEY, "
+                    + "available_qty INT NOT NULL, "
+                    + "reserved_qty INT NOT NULL DEFAULT 0, "
+                    + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            stmt.execute("CREATE TABLE IF NOT EXISTS benchmark_account ("
+                    + "account_id VARCHAR(64) PRIMARY KEY, "
+                    + "balance DECIMAL(18,2) NOT NULL, "
+                    + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            stmt.execute("CREATE TABLE IF NOT EXISTS benchmark_order ("
+                    + "order_id VARCHAR(64) PRIMARY KEY, "
+                    + "user_id VARCHAR(64) NOT NULL, "
+                    + "product_id VARCHAR(64) NOT NULL, "
+                    + "quantity INT NOT NULL, "
+                    + "amount DECIMAL(18,2) NOT NULL, "
+                    + "status VARCHAR(32) NOT NULL, "
+                    + "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                    + "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+            stmt.execute("TRUNCATE TABLE benchmark_order");
+            stmt.execute("TRUNCATE TABLE benchmark_inventory");
+            stmt.execute("TRUNCATE TABLE benchmark_account");
+
+            seedInventory(conn);
+            seedAccounts(conn);
+        }
+    }
+
+    private void seedInventory(Connection conn) throws SQLException {
+        try (PreparedStatement pstmt = conn.prepareStatement(
+                "INSERT INTO benchmark_inventory (product_id, available_qty, reserved_qty) VALUES (?, ?, 0)")) {
+            for (int i = 0; i < BenchmarkConstants.SAGA_PRODUCT_COUNT; i++) {
+                pstmt.setString(1, "product-" + i);
+                pstmt.setInt(2, BenchmarkConstants.SAGA_INITIAL_INVENTORY);
+                pstmt.addBatch();
+                if ((i + 1) % 100 == 0) {
+                    pstmt.executeBatch();
+                }
+            }
+            pstmt.executeBatch();
+        }
+    }
+
+    private void seedAccounts(Connection conn) throws SQLException {
+        try (PreparedStatement pstmt = conn.prepareStatement(
+                "INSERT INTO benchmark_account (account_id, balance) VALUES (?, ?)")) {
+            for (int i = 0; i < BenchmarkConstants.ACCOUNT_COUNT; i++) {
+                pstmt.setString(1, "account-" + i);
+                pstmt.setBigDecimal(2, BigDecimal.valueOf(BenchmarkConstants.SAGA_INITIAL_BALANCE));
+                pstmt.addBatch();
+                if ((i + 1) % 100 == 0) {
+                    pstmt.executeBatch();
+                }
+            }
+            pstmt.executeBatch();
+        }
+    }
+}

--- a/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/SagaDbEnvironment.java
+++ b/test-suite/seata-benchmark-cli/src/main/java/org/apache/seata/benchmark/saga/SagaDbEnvironment.java
@@ -155,8 +155,8 @@ public class SagaDbEnvironment {
     }
 
     private void seedAccounts(Connection conn) throws SQLException {
-        try (PreparedStatement pstmt = conn.prepareStatement(
-                "INSERT INTO benchmark_account (account_id, balance) VALUES (?, ?)")) {
+        try (PreparedStatement pstmt =
+                conn.prepareStatement("INSERT INTO benchmark_account (account_id, balance) VALUES (?, ?)")) {
             for (int i = 0; i < BenchmarkConstants.ACCOUNT_COUNT; i++) {
                 pstmt.setString(1, "account-" + i);
                 pstmt.setBigDecimal(2, BigDecimal.valueOf(BenchmarkConstants.SAGA_INITIAL_BALANCE));


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR enhances the traditional `--mode SAGA` benchmark path in `seata-benchmark-cli` without introducing a new Saga mode.

The current changes focus on two areas:

1. Improve Saga benchmark observability by exposing richer Saga-specific result categories in benchmark metrics, final report output, and CSV export.  
   The benchmark now reports detailed Saga end states such as `committed`, `compensated`, `execution failed`, `compensation failed`, and `unknown`, instead of only showing a coarse success/failed summary.

2. Add step-targeted Saga failure injection for the real state-machine-based SAGA benchmark path.  
   A new CLI parameter `--saga-fail-step` is added to restrict failure injection to a selected forward step (`inventory`, `payment`, or `order`), while the actual failure ratio is still controlled by `--rollback-percentage`.

3. Allow explicit selection of predefined Saga state machine shapes while preserving backward compatibility.  
   A new CLI parameter `--saga-shape` is added to select the Saga state machine shape explicitly (such as `simple` or `order`). If it is not specified, the benchmark keeps the existing branches-based compatibility behavior. The selected Saga shape is also included in the final report and CSV export output.

4. Add reproducible Saga failure injection support.  
   A new CLI parameter `--saga-random-seed` is added so that Saga failure injection can be reproduced more consistently under the same benchmark configuration.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix https://github.com/apache/incubator-seata/issues/8039

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
```bash
java -jar test-suite/seata-benchmark-cli/target/seata-benchmark-cli.jar \
  --server 127.0.0.1:8091 \
  --mode SAGA \
  --tps 10 \
  --threads 1 \
  --duration 10 \
  --branches 3 \
  --rollback-percentage 20 \
  --saga-fail-step payment
```
```bash
java -jar test-suite/seata-benchmark-cli/target/seata-benchmark-cli.jar \
  --server 127.0.0.1:8091 \
  --mode SAGA \
  --tps 10 \
  --threads 1 \
  --duration 10 \
  --branches 3 \
  --rollback-percentage 20 \
  --saga-fail-step payment
```
```bash
java -jar test-suite/seata-benchmark-cli/target/seata-benchmark-cli.jar \
  --server 127.0.0.1:8091 \
  --mode SAGA \
  --tps 10 \
  --threads 1 \
  --duration 10 \
  --branches 3 \
  --saga-shape order \
  --rollback-percentage 20 \
  --saga-fail-step payment \
  --saga-random-seed 123
```
### Ⅴ. Special notes for reviews

