### PR TITLE
feature: add protobuf serialization support for UnregisterRM protocol

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -28,6 +28,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7903](https://github.com/apache/incubator-seata/pull/7903)] Support HTTP/2 stream push for the Watch API in Server Raft mode
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] add Grafana dashboard JSON for NamingServer metrics
 - [[#8020](https://github.com/apache/incubator-seata/pull/8020)] add UnregisterRM protocol to notify server on client destroy
+- [[#8044](https://github.com/apache/incubator-seata/pull/8044)] add protobuf serialization support for UnregisterRM protocol
 
 ### bugfix:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -29,6 +29,7 @@
 - [[#8014](https://github.com/apache/incubator-seata/pull/8014)] 为 benchmark CLI 添加 P99.9 尾延迟百分位
 - [[#8002](https://github.com/apache/incubator-seata/pull/8002)] 为namingserver指标增加Grafana dashboard JSON
 - [[#8020](https://github.com/apache/incubator-seata/pull/8020)] 新增 UnregisterRM 协议，在客户端销毁时通知服务端
+- [[#8044](https://github.com/apache/incubator-seata/pull/8044)] 为 UnregisterRM 协议添加 protobuf 序列化支持
 
 ### bugfix:
 

--- a/serializer/seata-serializer-protobuf/src/main/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMRequestConvertor.java
+++ b/serializer/seata-serializer-protobuf/src/main/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMRequestConvertor.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.protobuf.convertor;
+
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.serializer.protobuf.generated.AbstractIdentifyRequestProto;
+import org.apache.seata.serializer.protobuf.generated.AbstractMessageProto;
+import org.apache.seata.serializer.protobuf.generated.MessageTypeProto;
+import org.apache.seata.serializer.protobuf.generated.UnregisterRMRequestProto;
+
+public class UnregisterRMRequestConvertor implements PbConvertor<UnregisterRMRequest, UnregisterRMRequestProto> {
+    @Override
+    public UnregisterRMRequestProto convert2Proto(UnregisterRMRequest unregisterRMRequest) {
+        final short typeCode = unregisterRMRequest.getTypeCode();
+
+        final AbstractMessageProto abstractMessage = AbstractMessageProto.newBuilder()
+                .setMessageType(MessageTypeProto.forNumber(typeCode))
+                .build();
+
+        final String extraData = unregisterRMRequest.getExtraData();
+        AbstractIdentifyRequestProto abstractIdentifyRequestProto = AbstractIdentifyRequestProto.newBuilder()
+                .setAbstractMessage(abstractMessage)
+                .setApplicationId(unregisterRMRequest.getApplicationId())
+                .setExtraData(extraData == null ? "" : extraData)
+                .setTransactionServiceGroup(unregisterRMRequest.getTransactionServiceGroup())
+                .setVersion(unregisterRMRequest.getVersion())
+                .build();
+        UnregisterRMRequestProto result = UnregisterRMRequestProto.newBuilder()
+                .setAbstractIdentifyRequest(abstractIdentifyRequestProto)
+                .setResourceIds(
+                        unregisterRMRequest.getResourceIds() == null ? "" : unregisterRMRequest.getResourceIds())
+                .build();
+
+        return result;
+    }
+
+    @Override
+    public UnregisterRMRequest convert2Model(UnregisterRMRequestProto unregisterRMRequestProto) {
+        UnregisterRMRequest unregisterRMRequest = new UnregisterRMRequest();
+
+        AbstractIdentifyRequestProto abstractIdentifyRequest = unregisterRMRequestProto.getAbstractIdentifyRequest();
+        unregisterRMRequest.setResourceIds(unregisterRMRequestProto.getResourceIds());
+        unregisterRMRequest.setApplicationId(abstractIdentifyRequest.getApplicationId());
+        unregisterRMRequest.setExtraData(abstractIdentifyRequest.getExtraData());
+        unregisterRMRequest.setTransactionServiceGroup(abstractIdentifyRequest.getTransactionServiceGroup());
+        unregisterRMRequest.setVersion(abstractIdentifyRequest.getVersion());
+
+        return unregisterRMRequest;
+    }
+}

--- a/serializer/seata-serializer-protobuf/src/main/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMResponseConvertor.java
+++ b/serializer/seata-serializer-protobuf/src/main/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMResponseConvertor.java
@@ -16,51 +16,50 @@
  */
 package org.apache.seata.serializer.protobuf.convertor;
 
-import org.apache.seata.core.protocol.RegisterRMResponse;
 import org.apache.seata.core.protocol.ResultCode;
+import org.apache.seata.core.protocol.UnregisterRMResponse;
 import org.apache.seata.serializer.protobuf.generated.AbstractIdentifyResponseProto;
 import org.apache.seata.serializer.protobuf.generated.AbstractMessageProto;
 import org.apache.seata.serializer.protobuf.generated.AbstractResultMessageProto;
 import org.apache.seata.serializer.protobuf.generated.MessageTypeProto;
-import org.apache.seata.serializer.protobuf.generated.RegisterRMResponseProto;
 import org.apache.seata.serializer.protobuf.generated.ResultCodeProto;
+import org.apache.seata.serializer.protobuf.generated.UnregisterRMResponseProto;
 
-public class RegisterRMResponseConvertor implements PbConvertor<RegisterRMResponse, RegisterRMResponseProto> {
+public class UnregisterRMResponseConvertor implements PbConvertor<UnregisterRMResponse, UnregisterRMResponseProto> {
     @Override
-    public RegisterRMResponseProto convert2Proto(RegisterRMResponse registerRMResponse) {
-        final short typeCode = registerRMResponse.getTypeCode();
+    public UnregisterRMResponseProto convert2Proto(UnregisterRMResponse unregisterRMResponse) {
+        final short typeCode = unregisterRMResponse.getTypeCode();
 
         final AbstractMessageProto abstractMessage = AbstractMessageProto.newBuilder()
                 .setMessageType(MessageTypeProto.forNumber(typeCode))
                 .build();
 
-        final String msg = registerRMResponse.getMsg();
+        final String msg = unregisterRMResponse.getMsg();
 
-        // for code
-        if (registerRMResponse.getResultCode() == null) {
-            if (registerRMResponse.isIdentified()) {
-                registerRMResponse.setResultCode(ResultCode.Success);
+        if (unregisterRMResponse.getResultCode() == null) {
+            if (unregisterRMResponse.isIdentified()) {
+                unregisterRMResponse.setResultCode(ResultCode.Success);
             } else {
-                registerRMResponse.setResultCode(ResultCode.Failed);
+                unregisterRMResponse.setResultCode(ResultCode.Failed);
             }
         }
 
         final AbstractResultMessageProto abstractResultMessageProto = AbstractResultMessageProto.newBuilder()
                 .setMsg(msg == null ? "" : msg)
                 .setResultCode(ResultCodeProto.valueOf(
-                        registerRMResponse.getResultCode().name()))
+                        unregisterRMResponse.getResultCode().name()))
                 .setAbstractMessage(abstractMessage)
                 .build();
 
-        final String extraData = registerRMResponse.getExtraData();
+        final String extraData = unregisterRMResponse.getExtraData();
         AbstractIdentifyResponseProto abstractIdentifyResponseProto = AbstractIdentifyResponseProto.newBuilder()
                 .setAbstractResultMessage(abstractResultMessageProto)
                 .setExtraData(extraData == null ? "" : extraData)
-                .setVersion(registerRMResponse.getVersion())
-                .setIdentified(registerRMResponse.isIdentified())
+                .setVersion(unregisterRMResponse.getVersion())
+                .setIdentified(unregisterRMResponse.isIdentified())
                 .build();
 
-        RegisterRMResponseProto result = RegisterRMResponseProto.newBuilder()
+        UnregisterRMResponseProto result = UnregisterRMResponseProto.newBuilder()
                 .setAbstractIdentifyResponse(abstractIdentifyResponseProto)
                 .build();
 
@@ -68,22 +67,22 @@ public class RegisterRMResponseConvertor implements PbConvertor<RegisterRMRespon
     }
 
     @Override
-    public RegisterRMResponse convert2Model(RegisterRMResponseProto registerRMResponseProto) {
-        RegisterRMResponse registerRMResponse = new RegisterRMResponse();
+    public UnregisterRMResponse convert2Model(UnregisterRMResponseProto unregisterRMResponseProto) {
+        UnregisterRMResponse unregisterRMResponse = new UnregisterRMResponse();
 
         AbstractIdentifyResponseProto abstractIdentifyResponseProto =
-                registerRMResponseProto.getAbstractIdentifyResponse();
-        registerRMResponse.setExtraData(abstractIdentifyResponseProto.getExtraData());
-        registerRMResponse.setVersion(abstractIdentifyResponseProto.getVersion());
-        registerRMResponse.setIdentified(abstractIdentifyResponseProto.getIdentified());
+                unregisterRMResponseProto.getAbstractIdentifyResponse();
+        unregisterRMResponse.setExtraData(abstractIdentifyResponseProto.getExtraData());
+        unregisterRMResponse.setVersion(abstractIdentifyResponseProto.getVersion());
+        unregisterRMResponse.setIdentified(abstractIdentifyResponseProto.getIdentified());
 
-        registerRMResponse.setMsg(
+        unregisterRMResponse.setMsg(
                 abstractIdentifyResponseProto.getAbstractResultMessage().getMsg());
-        registerRMResponse.setResultCode(ResultCode.valueOf(abstractIdentifyResponseProto
+        unregisterRMResponse.setResultCode(ResultCode.valueOf(abstractIdentifyResponseProto
                 .getAbstractResultMessage()
                 .getResultCode()
                 .name()));
 
-        return registerRMResponse;
+        return unregisterRMResponse;
     }
 }

--- a/serializer/seata-serializer-protobuf/src/main/java/org/apache/seata/serializer/protobuf/manager/ProtobufConvertManager.java
+++ b/serializer/seata-serializer-protobuf/src/main/java/org/apache/seata/serializer/protobuf/manager/ProtobufConvertManager.java
@@ -24,6 +24,8 @@ import org.apache.seata.core.protocol.RegisterRMRequest;
 import org.apache.seata.core.protocol.RegisterRMResponse;
 import org.apache.seata.core.protocol.RegisterTMRequest;
 import org.apache.seata.core.protocol.RegisterTMResponse;
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.core.protocol.UnregisterRMResponse;
 import org.apache.seata.core.protocol.transaction.BranchCommitRequest;
 import org.apache.seata.core.protocol.transaction.BranchCommitResponse;
 import org.apache.seata.core.protocol.transaction.BranchRegisterRequest;
@@ -75,6 +77,8 @@ import org.apache.seata.serializer.protobuf.convertor.RegisterRMResponseConverto
 import org.apache.seata.serializer.protobuf.convertor.RegisterTMRequestConvertor;
 import org.apache.seata.serializer.protobuf.convertor.RegisterTMResponseConvertor;
 import org.apache.seata.serializer.protobuf.convertor.UndoLogDeleteRequestConvertor;
+import org.apache.seata.serializer.protobuf.convertor.UnregisterRMRequestConvertor;
+import org.apache.seata.serializer.protobuf.convertor.UnregisterRMResponseConvertor;
 import org.apache.seata.serializer.protobuf.generated.BatchResultMessageProto;
 import org.apache.seata.serializer.protobuf.generated.BranchCommitRequestProto;
 import org.apache.seata.serializer.protobuf.generated.BranchCommitResponseProto;
@@ -104,6 +108,8 @@ import org.apache.seata.serializer.protobuf.generated.RegisterRMResponseProto;
 import org.apache.seata.serializer.protobuf.generated.RegisterTMRequestProto;
 import org.apache.seata.serializer.protobuf.generated.RegisterTMResponseProto;
 import org.apache.seata.serializer.protobuf.generated.UndoLogDeleteRequestProto;
+import org.apache.seata.serializer.protobuf.generated.UnregisterRMRequestProto;
+import org.apache.seata.serializer.protobuf.generated.UnregisterRMResponseProto;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -174,6 +180,10 @@ public class ProtobufConvertManager {
             protobufConvertManager.convertorMap.put(
                     RegisterRMResponse.class.getName(), new RegisterRMResponseConvertor());
             protobufConvertManager.convertorMap.put(
+                    UnregisterRMRequest.class.getName(), new UnregisterRMRequestConvertor());
+            protobufConvertManager.convertorMap.put(
+                    UnregisterRMResponse.class.getName(), new UnregisterRMResponseConvertor());
+            protobufConvertManager.convertorMap.put(
                     RegisterTMRequest.class.getName(), new RegisterTMRequestConvertor());
             protobufConvertManager.convertorMap.put(
                     RegisterTMResponse.class.getName(), new RegisterTMResponseConvertor());
@@ -234,6 +244,10 @@ public class ProtobufConvertManager {
             protobufConvertManager.protoClazzMap.put(
                     RegisterRMResponseProto.getDescriptor().getFullName(), RegisterRMResponseProto.class);
             protobufConvertManager.protoClazzMap.put(
+                    UnregisterRMRequestProto.getDescriptor().getFullName(), UnregisterRMRequestProto.class);
+            protobufConvertManager.protoClazzMap.put(
+                    UnregisterRMResponseProto.getDescriptor().getFullName(), UnregisterRMResponseProto.class);
+            protobufConvertManager.protoClazzMap.put(
                     RegisterTMRequestProto.getDescriptor().getFullName(), RegisterTMRequestProto.class);
             protobufConvertManager.protoClazzMap.put(
                     RegisterTMResponseProto.getDescriptor().getFullName(), RegisterTMResponseProto.class);
@@ -293,6 +307,10 @@ public class ProtobufConvertManager {
                     RegisterRMRequestProto.class.getName(), new RegisterRMRequestConvertor());
             protobufConvertManager.reverseConvertorMap.put(
                     RegisterRMResponseProto.class.getName(), new RegisterRMResponseConvertor());
+            protobufConvertManager.reverseConvertorMap.put(
+                    UnregisterRMRequestProto.class.getName(), new UnregisterRMRequestConvertor());
+            protobufConvertManager.reverseConvertorMap.put(
+                    UnregisterRMResponseProto.class.getName(), new UnregisterRMResponseConvertor());
             protobufConvertManager.reverseConvertorMap.put(
                     RegisterTMRequestProto.class.getName(), new RegisterTMRequestConvertor());
             protobufConvertManager.reverseConvertorMap.put(

--- a/serializer/seata-serializer-protobuf/src/main/resources/protobuf/org/apache/seata/protocol/transcation/messageType.proto
+++ b/serializer/seata-serializer-protobuf/src/main/resources/protobuf/org/apache/seata/protocol/transcation/messageType.proto
@@ -129,6 +129,14 @@ enum MessageTypeProto {
      * The constant TYPE_REG_RM_RESULT.
      */
     TYPE_REG_RM_RESULT = 104;
+    /**
+     * The constant TYPE_UNREG_RM.
+     */
+    TYPE_UNREG_RM = 105;
+    /**
+     * The constant TYPE_UNREG_RM_RESULT.
+     */
+    TYPE_UNREG_RM_RESULT = 106;
 
     /**
      * The constant TYPE_UNDO_LOG_DELETE.

--- a/serializer/seata-serializer-protobuf/src/main/resources/protobuf/org/apache/seata/protocol/transcation/unregisterRMRequest.proto
+++ b/serializer/seata-serializer-protobuf/src/main/resources/protobuf/org/apache/seata/protocol/transcation/unregisterRMRequest.proto
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+package org.apache.seata.protocol.protobuf;
+
+import "abstractIdentifyRequest.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "UnregisterRMRequest";
+option java_package = "org.apache.seata.serializer.protobuf.generated";
+
+message UnregisterRMRequestProto {
+    AbstractIdentifyRequestProto abstractIdentifyRequest = 1;
+    string resourceIds = 2;
+
+}

--- a/serializer/seata-serializer-protobuf/src/main/resources/protobuf/org/apache/seata/protocol/transcation/unregisterRMResponse.proto
+++ b/serializer/seata-serializer-protobuf/src/main/resources/protobuf/org/apache/seata/protocol/transcation/unregisterRMResponse.proto
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+package org.apache.seata.protocol.protobuf;
+
+import "abstractIdentifyResponse.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "UnregisterRMResponse";
+option java_package = "org.apache.seata.serializer.protobuf.generated";
+
+message UnregisterRMResponseProto {
+    AbstractIdentifyResponseProto abstractIdentifyResponse = 1;
+}

--- a/serializer/seata-serializer-protobuf/src/test/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMRequestConvertorTest.java
+++ b/serializer/seata-serializer-protobuf/src/test/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMRequestConvertorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.protobuf.convertor;
+
+import org.apache.seata.core.protocol.UnregisterRMRequest;
+import org.apache.seata.serializer.protobuf.generated.UnregisterRMRequestProto;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnregisterRMRequestConvertorTest {
+
+    @Test
+    public void convert2ProtoTest() {
+        UnregisterRMRequest unregisterRMRequest = new UnregisterRMRequest();
+        unregisterRMRequest.setResourceIds("res1");
+        unregisterRMRequest.setVersion("123");
+        unregisterRMRequest.setTransactionServiceGroup("group");
+        unregisterRMRequest.setExtraData("extraData");
+        unregisterRMRequest.setApplicationId("appId");
+
+        UnregisterRMRequestConvertor convertor = new UnregisterRMRequestConvertor();
+        UnregisterRMRequestProto proto = convertor.convert2Proto(unregisterRMRequest);
+        UnregisterRMRequest real = convertor.convert2Model(proto);
+
+        assertThat((real.getTypeCode())).isEqualTo(unregisterRMRequest.getTypeCode());
+        assertThat((real.getResourceIds())).isEqualTo(unregisterRMRequest.getResourceIds());
+        assertThat((real.getVersion())).isEqualTo(unregisterRMRequest.getVersion());
+        assertThat((real.getTransactionServiceGroup())).isEqualTo(unregisterRMRequest.getTransactionServiceGroup());
+        assertThat((real.getExtraData())).isEqualTo(unregisterRMRequest.getExtraData());
+        assertThat((real.getApplicationId())).isEqualTo(unregisterRMRequest.getApplicationId());
+    }
+}

--- a/serializer/seata-serializer-protobuf/src/test/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMResponseConvertorTest.java
+++ b/serializer/seata-serializer-protobuf/src/test/java/org/apache/seata/serializer/protobuf/convertor/UnregisterRMResponseConvertorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.protobuf.convertor;
+
+import org.apache.seata.core.protocol.ResultCode;
+import org.apache.seata.core.protocol.UnregisterRMResponse;
+import org.apache.seata.serializer.protobuf.generated.UnregisterRMResponseProto;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnregisterRMResponseConvertorTest {
+
+    @Test
+    public void convert2ProtoTest() {
+        UnregisterRMResponse unregisterRMResponse = new UnregisterRMResponse();
+        unregisterRMResponse.setResultCode(ResultCode.Failed);
+        unregisterRMResponse.setMsg("msg");
+        unregisterRMResponse.setIdentified(true);
+        unregisterRMResponse.setVersion("11");
+        unregisterRMResponse.setExtraData("extraData");
+
+        UnregisterRMResponseConvertor convertor = new UnregisterRMResponseConvertor();
+        UnregisterRMResponseProto proto = convertor.convert2Proto(unregisterRMResponse);
+        UnregisterRMResponse real = convertor.convert2Model(proto);
+
+        assertThat((real.getTypeCode())).isEqualTo(unregisterRMResponse.getTypeCode());
+        assertThat((real.getMsg())).isEqualTo(unregisterRMResponse.getMsg());
+        assertThat((real.getResultCode())).isEqualTo(unregisterRMResponse.getResultCode());
+        assertThat((real.isIdentified())).isEqualTo(unregisterRMResponse.isIdentified());
+        assertThat((real.getVersion())).isEqualTo(unregisterRMResponse.getVersion());
+        assertThat((real.getExtraData())).isEqualTo(unregisterRMResponse.getExtraData());
+    }
+}


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Add protobuf serialization/deserialization support for `UnregisterRMRequest` and `UnregisterRMResponse` introduced in #8020. Without this, sending these messages would fail at runtime when `serializer.type=PROTOBUF`.

Changes:
- Add `TYPE_UNREG_RM`(105) and `TYPE_UNREG_RM_RESULT`(106) to `MessageTypeProto` enum
- Add `.proto` definitions for `UnregisterRMRequestProto` and `UnregisterRMResponseProto`
- Add `UnregisterRMRequestConvertor` and `UnregisterRMResponseConvertor`
- Register new convertors in `ProtobufConvertManager`
- Fix misleading variable names in `RegisterRMResponseConvertor.convert2Model()`

### Ⅱ. Does this pull request fix one issue?

Fixes the protobuf serialization gap from #8020.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit tests are included:
- `UnregisterRMRequestConvertorTest`
- `UnregisterRMResponseConvertorTest`

### Ⅳ. Describe how to verify it

```bash
./mvnw test -pl serializer/seata-serializer-protobuf -Dtest="UnregisterRMRequestConvertorTest,UnregisterRMResponseConvertorTest"
```

### Ⅴ. Special notes for reviews

The new convertors follow the same pattern as `RegisterRMRequestConvertor` / `RegisterRMResponseConvertor`.