### PR TITLE
test: Isolate compatibility tests from transport protocol leakage

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -64,6 +64,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7962](https://github.com/apache/incubator-seata/pull/7962)] add unit tests for NacosRegistryProvider and NacosRegistryServiceImpl
 - [[#8003](https://github.com/apache/incubator-seata/pull/8003)] Enhance NacosRegistryServiceImplTest with additional mocks for service name group and cluster
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] add unit tests for saga-engine low coverage components
+- [[#8051](https://github.com/apache/incubator-seata/pull/8051)] isolate compatibility tests from transport protocol leakage
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -68,6 +68,7 @@
 - [[#7962](https://github.com/apache/incubator-seata/pull/7962)] 为 NacosRegistryProvider 和 NacosRegistryServiceImpl 添加单元测试用例
 - [[#8003](https://github.com/apache/incubator-seata/pull/8003)] 为 NacosRegistryServiceImplTest 增加服务名称、分组和集群的额外模拟
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] 为 saga-engine 添加单元测试用例
+- [[#8051](https://github.com/apache/incubator-seata/pull/8051)] 将兼容性测试与传输协议泄漏隔离
 
 
 ### refactor:

--- a/test-suite/test-new-version/src/test/java/org/apache/seata/core/rpc/netty/multiversion/MultiVersionCompatibilityTest.java
+++ b/test-suite/test-new-version/src/test/java/org/apache/seata/core/rpc/netty/multiversion/MultiVersionCompatibilityTest.java
@@ -34,6 +34,8 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.timeout.IdleStateHandler;
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.common.ConfigurationTestHelper;
 import org.apache.seata.common.XID;
 import org.apache.seata.common.metadata.Instance;
 import org.apache.seata.common.metadata.Node;
@@ -41,7 +43,9 @@ import org.apache.seata.common.thread.NamedThreadFactory;
 import org.apache.seata.common.util.NetUtil;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.common.util.UUIDGenerator;
+import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.core.protocol.HeartbeatMessage;
+import org.apache.seata.core.protocol.Protocol;
 import org.apache.seata.core.protocol.ProtocolConstants;
 import org.apache.seata.core.protocol.RegisterTMRequest;
 import org.apache.seata.core.protocol.RegisterTMResponse;
@@ -125,12 +129,15 @@ public abstract class MultiVersionCompatibilityTest {
     protected final AtomicReference<Object> requestRef = new AtomicReference<>();
     protected final AtomicReference<Object> responseRef = new AtomicReference<>();
     protected CountDownLatch responseLatch;
+    private String originalTransportProtocol;
 
     // Helper for creating MultiProtocolDecoder with specific version (for V1 tests)
     private final MultiProtocolDecoderTest decoderTestHelper = new MultiProtocolDecoderTest();
 
     @BeforeEach
     public void setUp() {
+        originalTransportProtocol = ConfigurationFactory.getInstance().getConfig(ConfigurationKeys.TRANSPORT_PROTOCOL);
+        ConfigurationTestHelper.putConfig(ConfigurationKeys.TRANSPORT_PROTOCOL, Protocol.SEATA.value);
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
         clientGroup = new NioEventLoopGroup();
@@ -165,6 +172,11 @@ public abstract class MultiVersionCompatibilityTest {
         bossGroup.shutdownGracefully().sync();
         workerGroup.shutdownGracefully().sync();
         clientGroup.shutdownGracefully().sync();
+        if (StringUtils.isBlank(originalTransportProtocol)) {
+            ConfigurationTestHelper.removeConfig(ConfigurationKeys.TRANSPORT_PROTOCOL);
+        } else {
+            ConfigurationTestHelper.putConfig(ConfigurationKeys.TRANSPORT_PROTOCOL, originalTransportProtocol);
+        }
     }
 
     // ==================== V1 Server Methods (manual, for legacy simulation) ====================


### PR DESCRIPTION
`ServerV1ToClientV2Test` could time out waiting for responses when earlier tests left `transport.protocol=grpc` in shared configuration state. In that condition, the V2 client in the compatibility suite could initialize with the wrong transport and never receive the expected V1 server response.

- **Problem**
  - The multi-version compatibility tests assume the Seata transport, but they were reading process-wide configuration that could be mutated by earlier gRPC-oriented tests.
  - This made `doSendRegister()` fail intermittently with `Should receive response within timeout`.

- **Change**
  - Force `transport.protocol` to `seata` in `MultiVersionCompatibilityTest` setup before creating the V2 client/server test fixtures.
  - Capture the pre-existing `transport.protocol` value and restore it in teardown so the test does not leak configuration changes into other suites.

- **Effect**
  - `ServerV1ToClientV2Test` now runs against the intended transport regardless of prior test ordering.
  - The compatibility suite becomes self-contained instead of depending on global configuration state left behind by other tests.

- **Implementation sketch**
  ```java
  @BeforeEach
  public void setUp() {
      originalTransportProtocol =
              ConfigurationFactory.getInstance().getConfig(ConfigurationKeys.TRANSPORT_PROTOCOL);
      ConfigurationTestHelper.putConfig(ConfigurationKeys.TRANSPORT_PROTOCOL, Protocol.SEATA.value);
      // initialize test fixtures...
  }

  @AfterEach
  public void tearDown() throws InterruptedException {
      // shutdown fixtures...
      if (StringUtils.isBlank(originalTransportProtocol)) {
          ConfigurationTestHelper.removeConfig(ConfigurationKeys.TRANSPORT_PROTOCOL);
      } else {
          ConfigurationTestHelper.putConfig(ConfigurationKeys.TRANSPORT_PROTOCOL, originalTransportProtocol);
      }
  }
  ```