### PR TITLE
optimize: add checkstyle rules to enforce ThreadPoolExecutorFactory usage

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -68,6 +68,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8069](https://github.com/apache/incubator-seata/pull/8069)] bump org.assertj:assertj-core from 3.12.2 to 3.27.7
 - [[#8075](https://github.com/apache/incubator-seata/pull/8075)] bump at.yawk.lz4:lz4-java from 1.9.0 to 1.10.1
 - [[#8077](https://github.com/apache/incubator-seata/pull/8077)] removed the OkHttp3 dependency from the NamingServer
+- [[#8092](https://github.com/apache/incubator-seata/pull/8092)] add checkstyle rules to enforce ThreadPoolExecutorFactory usage
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -70,6 +70,7 @@
 - [[#8075](https://github.com/apache/incubator-seata/pull/8075)] 将 at.yawk.lz4:lz4-java 从 1.9.0 版本升级到 1.10.1
 - [[#8077](https://github.com/apache/incubator-seata/pull/8077)] namingserver 移除 okhttp3 依赖
 - [[#8086](https://github.com/apache/incubator-seata/pull/8086)] 修改consoleRemotingFilter优先级
+- [[#8092](https://github.com/apache/incubator-seata/pull/8092)] 添加 checkstyle 规则以强制使用 ThreadPoolExecutorFactory
 
 ### security:
 

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -61,6 +61,25 @@
         <property name="files" value="^(?!.*[\\/]test[\\/].*).*$"/>
     </module>
 
+    <module name="SuppressionSingleFilter">
+        <!-- new Thread() -->
+        <property name="id" value="DirectThreadCreation"/>
+        <property name="files"
+                  value=".*[\\/]test[\\/].*|.*[\\/]org/apache/seata/config[\\/].*|.*[\\/]io/seata/config[\\/].*"/>
+    </module>
+    <module name="SuppressionSingleFilter">
+        <!-- Executors.new -->
+        <property name="id" value="ExecutorsUsage"/>
+        <property name="files"
+                  value=".*[\\/]test[\\/].*|.*[\\/]org/apache/seata/config[\\/].*|.*[\\/]io/seata/config[\\/].*"/>
+    </module>
+    <module name="SuppressionSingleFilter">
+        <!-- new ThreadPoolExecutor -->
+        <property name="id" value="DirectThreadPoolExecutorCreation"/>
+        <property name="files"
+                  value=".*[\\/]test[\\/].*|.*[\\/]org/apache/seata/config[\\/].*|.*[\\/]io/seata/config[\\/].*"/>
+    </module>
+
     <!-- Allow using @SuppressWarnings("checkstyle:...") in code -->
     <module name="SuppressWarningsFilter"/>
 
@@ -99,5 +118,27 @@
 
         <!-- Constant -->
         <module name="UpperEll"/>
+
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="DirectThreadCreation"/>
+            <property name="format" value="new\s+Thread\s*\("/>
+            <property name="ignoreComments" value="true"/>
+            <property name="message"
+                      value="Direct thread creation is not allowed. Use ThreadPoolExecutorFactory instead."/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="ExecutorsUsage"/>
+            <property name="format" value="Executors\s*\.\s*new"/>
+            <property name="ignoreComments" value="true"/>
+            <property name="message"
+                      value="Using Executors factory methods is not allowed. Use ThreadPoolExecutorFactory instead."/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="DirectThreadPoolExecutorCreation"/>
+            <property name="format" value="new\s+ThreadPoolExecutor\s*\("/>
+            <property name="ignoreComments" value="true"/>
+            <property name="message"
+                      value="Direct ThreadPoolExecutor creation is not allowed. Use ThreadPoolExecutorFactory instead."/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

- Add RegexpSinglelineJava checks to prevent direct thread creation (new Thread)
- Add RegexpSinglelineJava checks to prevent Executors factory methods usage
- Add RegexpSinglelineJava checks to prevent direct ThreadPoolExecutor creation
- Add SuppressionSingleFilter to allow these patterns in `test` and `config` packages
- All rules require using `ThreadPoolExecutorFactory` instead for better thread management

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/apache/incubator-seata/issues/8091

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

