### PR TITLE
test: remove external network dependency from HttpClientUtilTest

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -76,6 +76,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### test:
 
+- [[#8099](https://github.com/apache/incubator-seata/pull/8099)] remove external network dependency from HttpClientUtilTest
 - [[#7962](https://github.com/apache/incubator-seata/pull/7962)] add unit tests for NacosRegistryProvider and NacosRegistryServiceImpl
 - [[#8003](https://github.com/apache/incubator-seata/pull/8003)] Enhance NacosRegistryServiceImplTest with additional mocks for service name group and cluster
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] add unit tests for saga-engine low coverage components

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -80,6 +80,7 @@
 
 ### test:
 
+- [[#8099](https://github.com/apache/incubator-seata/pull/8099)] 移除 HttpClientUtilTest 对外部网络的依赖
 - [[#7962](https://github.com/apache/incubator-seata/pull/7962)] 为 NacosRegistryProvider 和 NacosRegistryServiceImpl 添加单元测试用例
 - [[#8003](https://github.com/apache/incubator-seata/pull/8003)] 为 NacosRegistryServiceImplTest 增加服务名称、分组和集群的额外模拟
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] 为 saga-engine 添加单元测试用例

--- a/common/src/test/java/org/apache/seata/common/util/HttpClientUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/HttpClientUtilTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.seata.common.util;
 
+import com.sun.net.httpserver.HttpServer;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -27,9 +28,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -592,14 +596,37 @@ public class HttpClientUtilTest {
 
     @Test
     void testHttpSendRes() throws IOException {
-        Response response = HttpClientUtil.doGet("http:www.baidu.com", null, null, 3000);
-        Response postResponse = HttpClientUtil.doPost("http:www.baidu.com", new HashMap<>(), new HashMap<>(), 3000);
-        Response postResponse2 = HttpClientUtil.doPost("http:www.baidu.com", "", new HashMap<>(), 3000);
-        Response nonjsonResponse = HttpClientUtil.doPostJson("http:www.baidu.com", "nonjson", new HashMap<>(), 3000);
-        assertNotNull(response);
-        assertNotNull(postResponse);
-        assertNotNull(postResponse2);
-        assertNotNull(nonjsonResponse);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/test", exchange -> {
+            byte[] responseBody = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, responseBody.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(responseBody);
+            }
+        });
+        server.start();
+
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/test";
+
+        try {
+            try (Response response = HttpClientUtil.doGet(url, null, null, 3000);
+                    Response postResponse = HttpClientUtil.doPost(url, new HashMap<>(), new HashMap<>(), 3000);
+                    Response postResponse2 = HttpClientUtil.doPost(url, "", new HashMap<>(), 3000);
+                    Response nonjsonResponse = HttpClientUtil.doPostJson(url, "nonjson", new HashMap<>(), 3000)) {
+
+                assertNotNull(response);
+                assertNotNull(postResponse);
+                assertNotNull(postResponse2);
+                assertNotNull(nonjsonResponse);
+
+                assertEquals(200, response.code());
+                assertEquals(200, postResponse.code());
+                assertEquals(200, postResponse2.code());
+                assertEquals(200, nonjsonResponse.code());
+            }
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test


### PR DESCRIPTION
### What changed

Replaced the external HTTP calls in `HttpClientUtilTest#testHttpSendRes` with a local in-process HTTP server bound to `127.0.0.1` on a random port.

### Why

The previous test depended on an external network endpoint, which could make the unit test flaky in local or CI environments when DNS, proxy, firewall, or network connectivity is unavailable or slow.

Using a local HTTP server keeps the test deterministic while still exercising the existing `HttpClientUtil` GET and POST request paths.

### Validation

```bash
./mvnw -pl common clean test -Dtest=HttpClientUtilTest#testHttpSendRes

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS