### PR TITLE
optimize: fix export JSON consistency and iframe download restrictions

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -47,7 +47,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8035](https://github.com/apache/incubator-seata/pull/8035)] fix IllegalArgumentException when GET request has request body
 - [[#8078](https://github.com/apache/incubator-seata/pull/8078)] fix mysql undolog NotSerializableException
 - [[#8106](https://github.com/apache/incubator-seata/pull/8106)] Avoid null advice during AOT proxy creation
-
+- [[#8113](https://github.com/apache/incubator-seata/pull/8113)] Resolve export JSON consistency and iframe download restrictions
 
 ### optimize:
 

--- a/console/src/main/resources/static/console-fe/src/components/Iframe/Iframe.tsx
+++ b/console/src/main/resources/static/console-fe/src/components/Iframe/Iframe.tsx
@@ -51,7 +51,7 @@ class Iframe extends React.PureComponent<PropsType, StateType> {
           height: '98%',
           overflow: 'auto',
         }}
-        sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+        sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-downloads"
       />
     );
   }

--- a/namingserver/src/main/resources/application.yml
+++ b/namingserver/src/main/resources/application.yml
@@ -56,10 +56,10 @@ seata:
       enabled: true
   security:
     secretKey: SeataSecretKey0c382ef121d778043159209298fd40bf3850a017
-    tokenValidityInMilliseconds: 1800000
+    tokenValidityInMilliseconds: 14400000
     csrf-ignore-urls: /naming/v1/**,/api/v1/naming/**
     ignore:
-      urls: /,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/*.svg,/**/*.png,/**/*.jpeg,/**/*.ico,/api/v1/auth/login,/version.json,/naming/v1/health,/error
+      urls: /,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/*.svg,/**/*.png,/**/*.jpeg,/**/*.ico,/**/*.woff,/**/*.woff2,/**/*.ttf,/api/v1/auth/login,/version.json,/naming/v1/health,/error,/saga-statemachine-designer/**
 management:
   endpoints:
     web:

--- a/namingserver/src/test/java/org/apache/seata/namingserver/WebSecurityConfigTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/WebSecurityConfigTest.java
@@ -1,3 +1,20 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.seata.namingserver;
 
 import org.junit.jupiter.api.Test;

--- a/namingserver/src/test/java/org/apache/seata/namingserver/WebSecurityConfigTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/WebSecurityConfigTest.java
@@ -1,0 +1,39 @@
+package org.apache.seata.namingserver;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WebSecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldAllowStaticJsonResourcesWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/version.json")).andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldAllowSagaDesignerResourcesWithoutAuthentication() throws Exception {
+        mockMvc.perform(get("/saga-statemachine-designer/index.html")).andExpect(result -> {
+            int statusCode = result.getResponse().getStatus();
+            assertTrue(
+                    statusCode == 200 || statusCode == 404,
+                    "Bypassed resources should return 200 or 404, but got: " + statusCode);
+        });
+    }
+
+    @Test
+    void shouldSecureProtectedApiEndpoints() throws Exception {
+        mockMvc.perform(get("/api/v1/console/users")).andExpect(status().isUnauthorized());
+    }
+}

--- a/saga/seata-saga-statemachine-designer/src/modeling/SagaExporter.js
+++ b/saga/seata-saga-statemachine-designer/src/modeling/SagaExporter.js
@@ -42,7 +42,19 @@ SagaExporter.prototype.parseState = function (definitions, node) {
 SagaExporter.prototype.parseEdge = function (definitions, edge) {
   const { businessObject } = edge;
   const elementJson = businessObject.exportJson();
-  const { source, target } = elementJson.style;
+
+  let { source } = elementJson.style;
+  let { target } = elementJson.style;
+
+  if (edge.source && edge.source.businessObject && edge.source.businessObject.Name) {
+    source = edge.source.businessObject.Name;
+    elementJson.style.source = source;
+  }
+  if (edge.target && edge.target.businessObject && edge.target.businessObject.Name) {
+    target = edge.target.businessObject.Name;
+    elementJson.style.target = target;
+  }
+
   if (!source) {
     if (definitions.StartState) {
       throw new Error(`Two or more start states, ${target} and ${definitions.StartState}`);
@@ -55,6 +67,11 @@ SagaExporter.prototype.parseEdge = function (definitions, edge) {
     }
   } else {
     const stateRef = definitions.States[source];
+
+    if (!stateRef) {
+      throw new Error(`Export failed: Unable to resolve source state '${source}' for edge targeting '${target}'.`);
+    }
+
     switch (businessObject.Type) {
       case 'ChoiceEntry':
         if (!stateRef.Choices) {
@@ -70,6 +87,9 @@ SagaExporter.prototype.parseEdge = function (definitions, edge) {
         stateRef.edge = assign(stateRef.edge || {}, { [target]: elementJson });
         break;
       case 'ExceptionMatch':
+        if (!stateRef.Catch) {
+          stateRef.Catch = [];
+        }
         stateRef.Catch.push({
           Exceptions: businessObject.Exceptions,
           Next: target,


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

- Added allow-downloads to the sandboxed iframe so export/download operations are no longer blocked by the browser.
- Fixed stale edge source/target references during export after renaming tasks with Catch transitions.
- Added defensive handling for missing Catch collections during export.
- Updated security ignore rules for Saga designer static resources and frontend assets to avoid authentication-related loading failures after token expiration.

### Ⅱ. Does this pull request fix one issue?

Fixes #7274

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

Added integration tests for security/static-resource behavior in WebSecurityConfigTest.

### Ⅳ. Describe how to verify it

1. Start the naming server and open the Saga StateMachine Designer.
2. Verify the designer loads successfully without static resource authentication failures.
3. Create a simple state machine and export/download JSON or SVG.
4. Confirm downloads succeed and the browser console no longer shows:
5. Download is disallowed
6. Create tasks with a Catch transition, rename the source task, and export again.
7. Verify the exported JSON uses the renamed task consistently without stale references.
8. Reduce JWT expiration time, wait for token expiry, refresh the page, and verify static JS/CSS/font resources still load correctly and protected APIs still return 401 Unauthorized.

### Ⅴ. Special notes for reviews

N/A