### PR TITLE
bugfix : upgrade vulnerable MySQL Connector/J references from distribution

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -82,6 +82,8 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### security:
 
+- [[#8101](https://github.com/apache/incubator-seata/issues/8101)] remove vulnerable MySQL Connector/J references from optional image packaging and test dependencies
+
 ### test:
 
 - [[#8099](https://github.com/apache/incubator-seata/pull/8099)] remove external network dependency from HttpClientUtilTest

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -89,7 +89,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### security:
 
-- [[#8101](https://github.com/apache/incubator-seata/issues/8101)] remove vulnerable MySQL Connector/J references from optional image packaging and test dependencies
+- [[#8119](https://github.com/apache/incubator-seata/pull/8119)] remove vulnerable MySQL Connector/J references from optional image packaging and test dependencies
 
 ### test:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -83,6 +83,7 @@
 
 ### security:
 
+- [[#8101](https://github.com/apache/incubator-seata/issues/8101)] 移除可选镜像打包和测试依赖中的高风险 MySQL Connector/J 引用
 
 
 ### test:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -92,7 +92,7 @@
 
 ### security:
 
-- [[#8101](https://github.com/apache/incubator-seata/issues/8101)] 移除可选镜像打包和测试依赖中的高风险 MySQL Connector/J 引用
+- [[#8119](https://github.com/apache/incubator-seata/pull/8119)] 移除可选镜像打包和测试依赖中的高风险 MySQL Connector/J 引用
 
 
 ### test:

--- a/compatible/pom.xml
+++ b/compatible/pom.xml
@@ -127,8 +127,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/compatible/src/test/java/io/seata/rm/datasource/xa/DataSourceProxyXATest.java
+++ b/compatible/src/test/java/io/seata/rm/datasource/xa/DataSourceProxyXATest.java
@@ -17,8 +17,7 @@
 package io.seata.rm.datasource.xa;
 
 import com.alibaba.druid.pool.DruidDataSource;
-import com.mysql.jdbc.JDBC4MySQLConnection;
-import com.mysql.jdbc.jdbc2.optional.JDBC4ConnectionWrapper;
+import com.mysql.cj.jdbc.JdbcConnection;
 import io.seata.core.context.RootContext;
 import io.seata.rm.datasource.mock.MockDataSource;
 import org.apache.seata.rm.datasource.xa.ConnectionProxyXA;
@@ -57,7 +56,7 @@ public class DataSourceProxyXATest {
     public void testGetConnection() throws SQLException {
         // Mock
         Driver driver = Mockito.mock(Driver.class);
-        JDBC4MySQLConnection connection = Mockito.mock(JDBC4MySQLConnection.class);
+        JdbcConnection connection = Mockito.mock(JdbcConnection.class);
         Mockito.when(connection.getAutoCommit()).thenReturn(true);
         DatabaseMetaData metaData = Mockito.mock(DatabaseMetaData.class);
         Mockito.when(metaData.getURL()).thenReturn("jdbc:mysql:xxx");
@@ -84,7 +83,7 @@ public class DataSourceProxyXATest {
 
         XAConnection xaConnection = connectionProxyXA.getWrappedXAConnection();
         Connection connectionInXA = xaConnection.getConnection();
-        Assertions.assertTrue(connectionInXA instanceof JDBC4ConnectionWrapper);
+        Assertions.assertTrue(connectionInXA instanceof JdbcConnection);
         tearDown();
     }
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -107,7 +107,7 @@
 
         <!-- # for database -->
         <!-- db -->
-        <mysql.version>5.1.42</mysql.version>
+        <mysql.version>8.2.0</mysql.version>
         <ojdbc.version>19.3.0.0</ojdbc.version>
         <dm.version>8.1.2.192</dm.version>
         <postgresql.version>42.3.10</postgresql.version>
@@ -122,9 +122,6 @@
         <caffeine.version>2.9.3</caffeine.version>
         <!-- sql parser -->
         <antlr4.version>4.8</antlr4.version>
-        <!-- for jdbc driver when package -->
-        <mysql5.version>${mysql.version}</mysql5.version>
-        <mysql8.version>8.0.27</mysql8.version>
         <!-- rocketmq -->
         <rocketmq-version>5.0.0</rocketmq-version>
 
@@ -299,8 +296,8 @@
                 <version>${h2.version}</version>
             </dependency>
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
                 <version>${mysql.version}</version>
             </dependency>
             <dependency>

--- a/distribution/NOTICE.md
+++ b/distribution/NOTICE.md
@@ -15,7 +15,7 @@
     limitations under the License.
 -->
 Due to license compatibility issues, we cannot include jar dependencies such as mysql, mariadb, oracle, etc., in the distribution package.
-Please copy database driver dependencies, such as `mysql-connector-java.jar`, to this directory. The following is an example of a directory structure:
+Please copy database driver dependencies, such as `mysql-connector-j.jar`, to this directory. The following is an example of a directory structure:
 
 ```aidl
 .
@@ -1173,7 +1173,7 @@ Please copy database driver dependencies, such as `mysql-connector-java.jar`, to
 ---
 
 由于license兼容性问题，我们不能将mysql、mariadb、oracle等jar依赖包含在发布包中。
-请将数据库driver相关依赖例如：`mysql-connector-java.jar`，拷贝到此目录下。目录结构示例如下：
+请将数据库driver相关依赖例如：`mysql-connector-j.jar`，拷贝到此目录下。目录结构示例如下：
 ```aidl
 .
 ├── DISCLAIMER

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,8 @@
             <properties>
                 <image.publish.skip>false</image.publish.skip>
                 <dependencies.copy.skip>false</dependencies.copy.skip>
+                <mysql.copy.skip>false</mysql.copy.skip>
+                <mysql.jdbc.version>8.2.0</mysql.jdbc.version>
                 <maven.git-commit-id.skip>false</maven.git-commit-id.skip>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -191,9 +191,6 @@
             <properties>
                 <image.publish.skip>false</image.publish.skip>
                 <dependencies.copy.skip>false</dependencies.copy.skip>
-                <mysql.copy.skip>false</mysql.copy.skip>
-                <mysql.jdbc.version>5.1.42</mysql.jdbc.version>
-                <mysql8.jdbc.version>8.0.27</mysql8.jdbc.version>
                 <maven.git-commit-id.skip>false</maven.git-commit-id.skip>
             </properties>
         </profile>

--- a/rm-datasource/pom.xml
+++ b/rm-datasource/pom.xml
@@ -124,8 +124,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/DataSourceProxyXATest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/xa/DataSourceProxyXATest.java
@@ -18,9 +18,8 @@ package org.apache.seata.rm.datasource.xa;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.kingbase8.xa.KBXAConnection;
-import com.mysql.jdbc.JDBC4MySQLConnection;
-import com.mysql.jdbc.jdbc2.optional.JDBC4ConnectionWrapper;
-import com.mysql.jdbc.jdbc2.optional.MysqlXAConnection;
+import com.mysql.cj.jdbc.JdbcConnection;
+import com.mysql.cj.jdbc.MysqlXAConnection;
 import com.oscar.xa.Jdbc3XAConnection;
 import org.apache.seata.core.constants.DBType;
 import org.apache.seata.core.context.RootContext;
@@ -73,9 +72,9 @@ public class DataSourceProxyXATest {
     @Test
     public void testGetConnection() throws SQLException, ClassNotFoundException {
         XAConnection xaConnection =
-                testGetXaConnection(MysqlXAConnection.class, "jdbc:mysql:xxx", JDBC4MySQLConnection.class.getName());
+                testGetXaConnection(MysqlXAConnection.class, "jdbc:mysql:xxx", JdbcConnection.class.getName());
         Connection connectionInXA = xaConnection.getConnection();
-        Assertions.assertTrue(connectionInXA instanceof JDBC4ConnectionWrapper);
+        Assertions.assertTrue(connectionInXA instanceof JdbcConnection);
         tearDown();
     }
 
@@ -166,7 +165,7 @@ public class DataSourceProxyXATest {
                     .when(() -> CombineConnectionHolder.get(any(DataSource.class)))
                     .thenReturn(combineConn);
             Driver driver = mock(Driver.class);
-            JDBC4MySQLConnection connection = mock(JDBC4MySQLConnection.class);
+            JdbcConnection connection = mock(JdbcConnection.class);
             Mockito.when(connection.getAutoCommit()).thenReturn(true);
             DatabaseMetaData metaData = mock(DatabaseMetaData.class);
             Mockito.when(metaData.getURL()).thenReturn("jdbc:mysql:xxx");

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -194,10 +194,9 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
-       <!--  if you run seata-server in IDE and use mysql8 as session store, please rewrite version to ${mysql8.jdbc.version}-->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
 <!--        <dependency>
@@ -335,31 +334,6 @@
                             <skip>${dependencies.copy.skip}</skip>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>copy-mysql</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>mysql</groupId>
-                                    <artifactId>mysql-connector-java</artifactId>
-                                    <version>${mysql.jdbc.version}</version>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>mysql</groupId>
-                                    <artifactId>mysql-connector-java</artifactId>
-                                    <version>${mysql8.jdbc.version}</version>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>
-                                ${project.build.directory}/lib/jdbc
-                            </outputDirectory>
-                            <skip>${mysql.copy.skip}</skip>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -419,10 +393,6 @@
                     </container>
                     <extraDirectories>
                         <paths>
-                            <path>
-                                <from>target/lib/jdbc</from>
-                                <into>/seata-server/libs/jdbc</into>
-                            </path>
                             <path>
                                 <from>src/main/resources/docker</from>
                                 <includes>seata-server-entrypoint.sh</includes>
@@ -494,8 +464,6 @@
         <profile>
             <id>release-seata</id>
             <properties>
-                <mysql.jdbc.version>5.1.42</mysql.jdbc.version>
-                <mysql8.jdbc.version>8.0.27</mysql8.jdbc.version>
                 <dependencies.copy.skip>false</dependencies.copy.skip>
             </properties>
             <build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -334,6 +334,26 @@
                             <skip>${dependencies.copy.skip}</skip>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-mysql</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.mysql</groupId>
+                                    <artifactId>mysql-connector-j</artifactId>
+                                    <version>${mysql.jdbc.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>
+                                ${project.build.directory}/lib/jdbc
+                            </outputDirectory>
+                            <skip>${mysql.copy.skip}</skip>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -393,6 +413,10 @@
                     </container>
                     <extraDirectories>
                         <paths>
+                            <path>
+                                <from>target/lib/jdbc</from>
+                                <into>/seata-server/libs/jdbc</into>
+                            </path>
                             <path>
                                 <from>src/main/resources/docker</from>
                                 <includes>seata-server-entrypoint.sh</includes>

--- a/test-suite/seata-benchmark-cli/pom.xml
+++ b/test-suite/seata-benchmark-cli/pom.xml
@@ -171,7 +171,6 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.2.0</version>
         </dependency>
 
         <!-- Commons IO, Compress and Codec (required by Testcontainers) -->

--- a/test-suite/test-new-version/pom.xml
+++ b/test-suite/test-new-version/pom.xml
@@ -147,8 +147,8 @@
             <artifactId>spring-context-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test-suite/test-new-version/src/test/java/org/apache/seata/xa/XAModeTest2.java
+++ b/test-suite/test-new-version/src/test/java/org/apache/seata/xa/XAModeTest2.java
@@ -19,7 +19,7 @@ package org.apache.seata.xa;
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.pool.xa.DruidXADataSource;
 import com.alibaba.druid.util.JdbcUtils;
-import com.mysql.jdbc.jdbc2.optional.MysqlXADataSource;
+import com.mysql.cj.jdbc.MysqlXADataSource;
 import org.apache.seata.core.context.RootContext;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchStatus;

--- a/test-suite/test-new-version/src/test/java/org/apache/seata/xa/XAModeTest2.java
+++ b/test-suite/test-new-version/src/test/java/org/apache/seata/xa/XAModeTest2.java
@@ -55,39 +55,39 @@ import java.sql.Statement;
 
 public class XAModeTest2 {
 
-    private static final int testRecordId = 888;
-    private static final String testRecordName = "xxx";
-    private static final long testTid = 1582688600006L;
-    private static final String mockXid = "127.0.0.1:8091:" + testTid;
-    private static final long mockBranchId = testTid + 1;
+    private static final int TEST_RECORD_ID = 888;
+    private static final String TEST_RECORD_NAME = "xxx";
+    private static final long TEST_TID = 1582688600006L;
+    private static final String MOCK_XID = "127.0.0.1:8091:" + TEST_TID;
+    private static final long MOCK_BRANCH_ID = TEST_TID + 1;
 
-    private static final String pg_jdbcUrl = "jdbc:postgresql://127.0.0.1:5432/postgres";
-    private static final String pg_username = "postgres";
-    private static final String pg_password = "postgres";
-    private static final String pg_driverClassName = JdbcUtils.POSTGRESQL_DRIVER;
+    private static final String PG_JDBC_URL = "jdbc:postgresql://127.0.0.1:5432/postgres";
+    private static final String PG_USERNAME = "postgres";
+    private static final String PG_PASSWORD = "postgres";
+    private static final String PG_DRIVER_CLASS_NAME = JdbcUtils.POSTGRESQL_DRIVER;
 
-    private static final String mysql_jdbcUrl = "jdbc:mysql://127.0.0.1:3306/demo";
-    private static final String mysql_username = "demo";
-    private static final String mysql_password = "demo";
-    private static final String mysql_driverClassName = JdbcUtils.MYSQL_DRIVER;
+    private static final String MYSQL_JDBC_URL = "jdbc:mysql://127.0.0.1:3306/demo";
+    private static final String MYSQL_USERNAME = "demo";
+    private static final String MYSQL_PASSWORD = "demo";
+    private static final String MYSQL_DRIVER_CLASS_NAME = JdbcUtils.MYSQL_DRIVER;
 
-    private static final String mysql8_jdbcUrl =
+    private static final String MYSQL8_JDBC_URL =
             "jdbc:mysql://0.0.0.0:3306/demo?useUnicode=true&characterEncoding=utf-8&useSSL=false";
-    private static final String mysql8_username = "demo";
-    private static final String mysql8_password = "demo";
-    private static final String mysql8_driverClassName = JdbcUtils.MYSQL_DRIVER_6;
+    private static final String MYSQL8_USERNAME = "demo";
+    private static final String MYSQL8_PASSWORD = "demo";
+    private static final String MYSQL8_DRIVER_CLASS_NAME = JdbcUtils.MYSQL_DRIVER_6;
 
-    private static final String oracle_jdbcUrl = "jdbc:oracle:thin:@localhost:1521:xe";
-    private static final String oracle_username = "demo";
-    private static final String oracle_password = "demo";
-    private static final String oracle_driverClassName = JdbcUtils.ORACLE_DRIVER;
+    private static final String ORACLE_JDBC_URL = "jdbc:oracle:thin:@localhost:1521:xe";
+    private static final String ORACLE_USERNAME = "demo";
+    private static final String ORACLE_PASSWORD = "demo";
+    private static final String ORACLE_DRIVER_CLASS_NAME = JdbcUtils.ORACLE_DRIVER;
 
     // Test on different DB, including: MySQL(5.7, 8.0), PostgreSQL(11), Oracle(11)
-    private static final String dbType = JdbcConstants.MYSQL;
+    private static final String DB_TYPE = JdbcConstants.MYSQL;
 
-    private static final boolean nativeXA = false;
+    private static final boolean NATIVE_XA = false;
 
-    private static final boolean mySQL8 = false;
+    private static final boolean MYSQL8 = false;
 
     private DruidDataSource createNewDruidDataSource() throws Throwable {
         DruidDataSource druidDataSource = new DruidDataSource();
@@ -102,32 +102,32 @@ public class XAModeTest2 {
     }
 
     private XADataSource createNewNativeXADataSource() throws Throwable {
-        if (dbType.equalsIgnoreCase(JdbcConstants.POSTGRESQL)) {
+        if (DB_TYPE.equalsIgnoreCase(JdbcConstants.POSTGRESQL)) {
             PGXADataSource pgxaDataSource = new PGXADataSource();
-            pgxaDataSource.setUrl(pg_jdbcUrl);
-            pgxaDataSource.setUser(pg_username);
-            pgxaDataSource.setPassword(pg_password);
+            pgxaDataSource.setUrl(PG_JDBC_URL);
+            pgxaDataSource.setUser(PG_USERNAME);
+            pgxaDataSource.setPassword(PG_PASSWORD);
             return pgxaDataSource;
 
-        } else if (dbType.equalsIgnoreCase(JdbcConstants.MYSQL)) {
+        } else if (DB_TYPE.equalsIgnoreCase(JdbcConstants.MYSQL)) {
             MysqlXADataSource mysqlXADataSource = new MysqlXADataSource();
-            if (mySQL8) {
-                mysqlXADataSource.setURL(mysql8_jdbcUrl);
-                mysqlXADataSource.setUser(mysql8_username);
-                mysqlXADataSource.setPassword(mysql8_username);
+            if (MYSQL8) {
+                mysqlXADataSource.setURL(MYSQL8_JDBC_URL);
+                mysqlXADataSource.setUser(MYSQL8_USERNAME);
+                mysqlXADataSource.setPassword(MYSQL8_USERNAME);
 
             } else {
-                mysqlXADataSource.setURL(mysql_jdbcUrl);
-                mysqlXADataSource.setUser(mysql_username);
-                mysqlXADataSource.setPassword(mysql_username);
+                mysqlXADataSource.setURL(MYSQL_JDBC_URL);
+                mysqlXADataSource.setUser(MYSQL_USERNAME);
+                mysqlXADataSource.setPassword(MYSQL_USERNAME);
             }
             return mysqlXADataSource;
 
-        } else if (dbType.equalsIgnoreCase(JdbcConstants.ORACLE)) {
+        } else if (DB_TYPE.equalsIgnoreCase(JdbcConstants.ORACLE)) {
             return createOracleXADataSource();
 
         } else {
-            throw new IllegalAccessError("Unknown dbType: " + dbType);
+            throw new IllegalAccessError("Unknown DB_TYPE: " + DB_TYPE);
         }
     }
 
@@ -137,16 +137,16 @@ public class XAModeTest2 {
             XADataSource xaDataSource = (XADataSource) oracleXADataSourceClass.newInstance();
 
             Method setURLMethod = oracleXADataSourceClass.getMethod("setURL", String.class);
-            setURLMethod.invoke(xaDataSource, oracle_jdbcUrl);
+            setURLMethod.invoke(xaDataSource, ORACLE_JDBC_URL);
 
             Method setUserMethod = oracleXADataSourceClass.getMethod("setUser", String.class);
-            setUserMethod.invoke(xaDataSource, oracle_username);
+            setUserMethod.invoke(xaDataSource, ORACLE_USERNAME);
 
             Method setPasswordMethod = oracleXADataSourceClass.getMethod("setPassword", String.class);
-            setPasswordMethod.invoke(xaDataSource, oracle_password);
+            setPasswordMethod.invoke(xaDataSource, ORACLE_PASSWORD);
 
             Method setDriverTypeMethod = oracleXADataSourceClass.getMethod("setDriverType", String.class);
-            setDriverTypeMethod.invoke(xaDataSource, oracle_driverClassName);
+            setDriverTypeMethod.invoke(xaDataSource, ORACLE_DRIVER_CLASS_NAME);
 
             return xaDataSource;
 
@@ -157,35 +157,35 @@ public class XAModeTest2 {
     }
 
     private void initDruidDataSource(DruidDataSource druidDataSource) throws Throwable {
-        druidDataSource.setDbType(dbType);
-        if (dbType.equalsIgnoreCase(JdbcConstants.POSTGRESQL)) {
-            druidDataSource.setUrl(pg_jdbcUrl);
-            druidDataSource.setUsername(pg_username);
-            druidDataSource.setPassword(pg_password);
-            druidDataSource.setDriverClassName(pg_driverClassName);
+        druidDataSource.setDbType(DB_TYPE);
+        if (DB_TYPE.equalsIgnoreCase(JdbcConstants.POSTGRESQL)) {
+            druidDataSource.setUrl(PG_JDBC_URL);
+            druidDataSource.setUsername(PG_USERNAME);
+            druidDataSource.setPassword(PG_PASSWORD);
+            druidDataSource.setDriverClassName(PG_DRIVER_CLASS_NAME);
 
-        } else if (dbType.equalsIgnoreCase(JdbcConstants.MYSQL)) {
-            if (mySQL8) {
-                druidDataSource.setUrl(mysql8_jdbcUrl);
-                druidDataSource.setUsername(mysql8_username);
-                druidDataSource.setPassword(mysql8_password);
-                druidDataSource.setDriverClassName(mysql8_driverClassName);
+        } else if (DB_TYPE.equalsIgnoreCase(JdbcConstants.MYSQL)) {
+            if (MYSQL8) {
+                druidDataSource.setUrl(MYSQL8_JDBC_URL);
+                druidDataSource.setUsername(MYSQL8_USERNAME);
+                druidDataSource.setPassword(MYSQL8_PASSWORD);
+                druidDataSource.setDriverClassName(MYSQL8_DRIVER_CLASS_NAME);
 
             } else {
-                druidDataSource.setUrl(mysql_jdbcUrl);
-                druidDataSource.setUsername(mysql_username);
-                druidDataSource.setPassword(mysql_password);
-                druidDataSource.setDriverClassName(mysql_driverClassName);
+                druidDataSource.setUrl(MYSQL_JDBC_URL);
+                druidDataSource.setUsername(MYSQL_USERNAME);
+                druidDataSource.setPassword(MYSQL_PASSWORD);
+                druidDataSource.setDriverClassName(MYSQL_DRIVER_CLASS_NAME);
             }
 
-        } else if (dbType.equalsIgnoreCase(JdbcConstants.ORACLE)) {
-            druidDataSource.setUrl(oracle_jdbcUrl);
-            druidDataSource.setUsername(oracle_username);
-            druidDataSource.setPassword(oracle_password);
-            druidDataSource.setDriverClassName(oracle_driverClassName);
+        } else if (DB_TYPE.equalsIgnoreCase(JdbcConstants.ORACLE)) {
+            druidDataSource.setUrl(ORACLE_JDBC_URL);
+            druidDataSource.setUsername(ORACLE_USERNAME);
+            druidDataSource.setPassword(ORACLE_PASSWORD);
+            druidDataSource.setDriverClassName(ORACLE_DRIVER_CLASS_NAME);
 
         } else {
-            throw new IllegalAccessError("Unknown dbType: " + dbType);
+            throw new IllegalAccessError("Unknown DB_TYPE: " + DB_TYPE);
         }
         druidDataSource.init();
     }
@@ -209,7 +209,7 @@ public class XAModeTest2 {
                     String applicationData,
                     String lockKeys)
                     throws TransactionException {
-                return mockBranchId;
+                return MOCK_BRANCH_ID;
             }
 
             @Override
@@ -224,7 +224,7 @@ public class XAModeTest2 {
     public void testAllInOne() throws Throwable {
         testCleanXARecover();
         doTestXAModeNormalPrepareData();
-        doTestXAModeNormalCaseAllInOne(mockXid, mockBranchId);
+        doTestXAModeNormalCaseAllInOne(MOCK_XID, MOCK_BRANCH_ID);
     }
 
     @Test
@@ -232,9 +232,9 @@ public class XAModeTest2 {
     public void testGlobalCommitOnDifferentDataSource() throws Throwable {
         testCleanXARecover();
         doTestXAModeNormalPrepareData();
-        doTestXAModeNormalCasePhase1(mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase1(MOCK_XID, MOCK_BRANCH_ID);
         // Use new DataSource in phase 2
-        doTestXAModeNormalCasePhase2(true, mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase2(true, MOCK_XID, MOCK_BRANCH_ID);
     }
 
     @Test
@@ -242,9 +242,9 @@ public class XAModeTest2 {
     public void testGlobalRollbackOnDifferentDataSource() throws Throwable {
         testCleanXARecover();
         doTestXAModeNormalPrepareData();
-        doTestXAModeNormalCasePhase1(mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase1(MOCK_XID, MOCK_BRANCH_ID);
         // Use new DataSource in phase 2
-        doTestXAModeNormalCasePhase2(false, mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase2(false, MOCK_XID, MOCK_BRANCH_ID);
     }
 
     @Test
@@ -252,19 +252,19 @@ public class XAModeTest2 {
     public void testOnlyPhase1() throws Throwable {
         testCleanXARecover();
         doTestXAModeNormalPrepareData();
-        doTestXAModeNormalCasePhase1(mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase1(MOCK_XID, MOCK_BRANCH_ID);
     }
 
     @Test
     @Disabled
     public void testOnlyPhase2Commit() throws Throwable {
-        doTestXAModeNormalCasePhase2(true, mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase2(true, MOCK_XID, MOCK_BRANCH_ID);
     }
 
     @Test
     @Disabled
     public void testOnlyPhase2Rollback() throws Throwable {
-        doTestXAModeNormalCasePhase2(false, mockXid, mockBranchId);
+        doTestXAModeNormalCasePhase2(false, MOCK_XID, MOCK_BRANCH_ID);
     }
 
     private void doTestXAModeNormalPrepareData() throws Throwable {
@@ -275,7 +275,7 @@ public class XAModeTest2 {
         Connection helperConn = helperDS.getConnection();
         Statement helperStat = helperConn.createStatement();
         ResultSet helperRes = null;
-        helperStat.execute("delete from test where id = " + testRecordId);
+        helperStat.execute("delete from test where id = " + TEST_RECORD_ID);
         helperStat.close();
         helperConn.close();
     }
@@ -293,7 +293,7 @@ public class XAModeTest2 {
         initRM();
 
         AbstractDataSourceProxyXA dataSourceProxyXA = null;
-        if (nativeXA) {
+        if (NATIVE_XA) {
             // init XADataSource runnerXA
             XADataSource runnerXADS = createNewNativeXADataSource();
             dataSourceProxyXA = new DataSourceProxyXANative(runnerXADS);
@@ -316,11 +316,11 @@ public class XAModeTest2 {
             // have a check
             helperConn = helperDS.getConnection();
             helperStat = helperConn.createStatement();
-            helperRes = helperStat.executeQuery("select * from test where id = " + testRecordId);
+            helperRes = helperStat.executeQuery("select * from test where id = " + TEST_RECORD_ID);
             // should see the test record now
             Assertions.assertTrue(helperRes.next());
-            Assertions.assertEquals(helperRes.getInt(1), testRecordId);
-            Assertions.assertEquals(helperRes.getString(2), testRecordName);
+            Assertions.assertEquals(helperRes.getInt(1), TEST_RECORD_ID);
+            Assertions.assertEquals(helperRes.getString(2), TEST_RECORD_NAME);
             helperRes.close();
             helperStat.close();
             helperConn.close();
@@ -337,7 +337,7 @@ public class XAModeTest2 {
             // have a check
             helperConn = helperDS.getConnection();
             helperStat = helperConn.createStatement();
-            helperRes = helperStat.executeQuery("select * from test where id = " + testRecordId);
+            helperRes = helperStat.executeQuery("select * from test where id = " + TEST_RECORD_ID);
             // should NOT see the test record now
             Assertions.assertFalse(helperRes.next());
             helperRes.close();
@@ -359,7 +359,7 @@ public class XAModeTest2 {
         initRM();
 
         AbstractDataSourceProxyXA dataSourceProxyXA = null;
-        if (nativeXA) {
+        if (NATIVE_XA) {
             // init XADataSource runnerXA
             XADataSource runnerXADS = createNewNativeXADataSource();
             dataSourceProxyXA = new DataSourceProxyXANative(runnerXADS);
@@ -374,7 +374,7 @@ public class XAModeTest2 {
         Connection testConn = dataSourceProxyXA.getConnection();
         Statement testStat = testConn.createStatement();
         // >>> insert the test record with XA mode
-        testStat.execute("insert into test(id, name) values(" + testRecordId + ", '" + testRecordName + "')");
+        testStat.execute("insert into test(id, name) values(" + TEST_RECORD_ID + ", '" + TEST_RECORD_NAME + "')");
         // >>> close the statement and connection
         testStat.close();
         testConn.close();
@@ -383,14 +383,14 @@ public class XAModeTest2 {
         // have a check
         helperConn = helperDS.getConnection();
         helperStat = helperConn.createStatement();
-        helperRes = helperStat.executeQuery("select * from test where id = " + testRecordId);
+        helperRes = helperStat.executeQuery("select * from test where id = " + TEST_RECORD_ID);
         // should NOT see the record(id=888) now
         Assertions.assertFalse(helperRes.next());
         helperRes.close();
         helperStat.close();
         helperConn.close();
 
-        if (JdbcConstants.MYSQL.equalsIgnoreCase(dbType)) {
+        if (JdbcConstants.MYSQL.equalsIgnoreCase(DB_TYPE)) {
             XAXid xaXid = XAXidBuilder.build(mockXid, mockBranchId);
             dataSourceProxyXA.forceClosePhysicalConnection(xaXid);
         }
@@ -410,7 +410,7 @@ public class XAModeTest2 {
         initRM();
 
         AbstractDataSourceProxyXA dataSourceProxyXA = null;
-        if (nativeXA) {
+        if (NATIVE_XA) {
             // init XADataSource runnerXA
             XADataSource runnerXADS = createNewNativeXADataSource();
             dataSourceProxyXA = new DataSourceProxyXANative(runnerXADS);
@@ -425,7 +425,7 @@ public class XAModeTest2 {
         Connection testConn = dataSourceProxyXA.getConnection();
         Statement testStat = testConn.createStatement();
         // >>> insert the test record with XA mode
-        testStat.execute("insert into test(id, name) values(" + testRecordId + ", '" + testRecordName + "')");
+        testStat.execute("insert into test(id, name) values(" + TEST_RECORD_ID + ", '" + TEST_RECORD_NAME + "')");
         // >>> close the statement and connection
         testStat.close();
         testConn.close();
@@ -434,7 +434,7 @@ public class XAModeTest2 {
         // have a check
         helperConn = helperDS.getConnection();
         helperStat = helperConn.createStatement();
-        helperRes = helperStat.executeQuery("select * from test where id = " + testRecordId);
+        helperRes = helperStat.executeQuery("select * from test where id = " + TEST_RECORD_ID);
         // should NOT see the record(id=888) now
         Assertions.assertFalse(helperRes.next());
         helperRes.close();
@@ -453,11 +453,11 @@ public class XAModeTest2 {
         // have a check
         helperConn = helperDS.getConnection();
         helperStat = helperConn.createStatement();
-        helperRes = helperStat.executeQuery("select * from test where id = " + testRecordId);
+        helperRes = helperStat.executeQuery("select * from test where id = " + TEST_RECORD_ID);
         // should see the test record now
         Assertions.assertTrue(helperRes.next());
-        Assertions.assertEquals(helperRes.getInt(1), testRecordId);
-        Assertions.assertEquals(helperRes.getString(2), testRecordName);
+        Assertions.assertEquals(helperRes.getInt(1), TEST_RECORD_ID);
+        Assertions.assertEquals(helperRes.getString(2), TEST_RECORD_NAME);
         helperRes.close();
         helperStat.close();
         helperConn.close();
@@ -468,14 +468,14 @@ public class XAModeTest2 {
     @Test
     @Disabled
     public void testXid() throws Throwable {
-        XAXid xaXid = XAXidBuilder.build(mockXid, mockBranchId);
+        XAXid xaXid = XAXidBuilder.build(MOCK_XID, MOCK_BRANCH_ID);
 
         XAXid retrievedXAXid = XAXidBuilder.build(xaXid.getGlobalTransactionId(), xaXid.getBranchQualifier());
         String retrievedXid = retrievedXAXid.getGlobalXid();
         long retrievedBranchId = retrievedXAXid.getBranchId();
 
-        Assertions.assertEquals(mockXid, retrievedXid);
-        Assertions.assertEquals(mockBranchId, retrievedBranchId);
+        Assertions.assertEquals(MOCK_XID, retrievedXid);
+        Assertions.assertEquals(MOCK_BRANCH_ID, retrievedBranchId);
     }
 
     @Test
@@ -512,10 +512,10 @@ public class XAModeTest2 {
     @Disabled
     public void testXADataSourceNormal() throws Throwable {
         DruidXADataSource druidDataSource = new DruidXADataSource();
-        druidDataSource.setUrl(oracle_jdbcUrl);
-        druidDataSource.setUsername(oracle_username);
-        druidDataSource.setPassword(oracle_password);
-        druidDataSource.setDriverClassName(oracle_driverClassName);
+        druidDataSource.setUrl(ORACLE_JDBC_URL);
+        druidDataSource.setUsername(ORACLE_USERNAME);
+        druidDataSource.setPassword(ORACLE_PASSWORD);
+        druidDataSource.setDriverClassName(ORACLE_DRIVER_CLASS_NAME);
 
         XAConnection xaConnection = druidDataSource.getXAConnection();
         XAResource xaResource = xaConnection.getXAResource();
@@ -606,7 +606,7 @@ public class XAModeTest2 {
         Connection testConn = ds.getConnection();
         Statement testStat = testConn.createStatement();
         // >>> insert the test record with XA mode
-        testStat.execute("insert into test(id, name) values(" + testRecordId + ", '" + testRecordName + "')");
+        testStat.execute("insert into test(id, name) values(" + TEST_RECORD_ID + ", '" + TEST_RECORD_NAME + "')");
         // >>> close the statement and connection
         testStat.close();
         testConn.close();


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR upgrade the vulnerable MySQL Connector/J references from Seata's dependency and distribution packaging configuration.

Main changes:
- Replace the managed MySQL Connector/J dependency from `mysql:mysql-connector-java` to `com.mysql:mysql-connector-j`.
- Remove the release/image packaging logic that copied MySQL driver jars into the Seata server distribution.
- Remove obsolete MySQL driver version properties used only by the removed copy strategy.
- Update test-scoped MySQL Connector/J usages to the new coordinates.
- Update affected test imports from legacy MySQL 5 internal classes to MySQL Connector/J 8 classes.
- Update NOTICE and changelog entries.

This keeps the change scoped to the GHSA/CVE cleanup and aligns with the point that the distributed binary package should not have a hard dependency on the MySQL driver.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #8101

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

No new unit or integration test is added because this PR mainly removes packaging-time dependency copying and updates dependency coordinates. The behavioral code path is unchanged.

Existing test compilation was updated where the MySQL Connector/J upgrade exposed references to legacy MySQL 5 internal classes.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

The remaining mysql-connector-java matches are only historical changelog entries. Existing com.mysql.jdbc.Driver string defaults are kept for compatibility and are not bundled driver dependencies.