### PR TITLE
optimize: limit allowlist cache growth

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -86,6 +86,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8109](https://github.com/apache/incubator-seata/pull/8109)] reduce npmjs dependencies in saga module
 - [[#8112](https://github.com/apache/incubator-seata/pull/8112)] optimize seata-server test performance
 - [[#8116](https://github.com/apache/incubator-seata/pull/8116)] fix incompatible dependencies
+- [[#8120](https://github.com/apache/incubator-seata/pull/8120)] limit allowlist cache growth
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -89,6 +89,7 @@
 - [[#8109](https://github.com/apache/incubator-seata/pull/8109)] 精简 saga 模块 npmjs 依赖
 - [[#8112](https://github.com/apache/incubator-seata/pull/8112)] 优化 seata-server 测试性能
 - [[#8116](https://github.com/apache/incubator-seata/pull/8116)] 修复不兼容的依赖
+- [[#8120](https://github.com/apache/incubator-seata/pull/8120)] 限制了json-common白名单缓存
 
 ### security:
 

--- a/json-common/json-common-core/src/main/java/org/apache/seata/common/json/JsonAllowlistManager.java
+++ b/json-common/json-common-core/src/main/java/org/apache/seata/common/json/JsonAllowlistManager.java
@@ -31,6 +31,9 @@ public class JsonAllowlistManager {
 
     private static final int MAX_REPORTED_CLASS_NAME_LENGTH = 256;
 
+    /**
+     * Caps memory used by positive allowlist checks. Once full, new allowed classes are still accepted but not cached.
+     */
     private static final int MAX_CACHE_SIZE = 4096;
 
     /**

--- a/json-common/json-common-core/src/main/java/org/apache/seata/common/json/JsonAllowlistManager.java
+++ b/json-common/json-common-core/src/main/java/org/apache/seata/common/json/JsonAllowlistManager.java
@@ -27,6 +27,10 @@ public class JsonAllowlistManager {
 
     private static final JsonAllowlistManager INSTANCE = new JsonAllowlistManager();
 
+    private static final int MAX_CLASS_NAME_LENGTH = 1024;
+
+    private static final int MAX_CACHE_SIZE = 4096;
+
     /**
      * Built-in exact match allowlist
      */
@@ -107,10 +111,18 @@ public class JsonAllowlistManager {
      * Check if a class is allowed for deserialization
      */
     public boolean isAllowed(String className) {
-        if (className == null) {
+        if (className == null || className.length() > MAX_CLASS_NAME_LENGTH) {
             return false;
         }
-        return cache.computeIfAbsent(className, this::doCheck);
+        if (cache.get(className) != null) {
+            return true;
+        }
+
+        boolean allowed = doCheck(className);
+        if (allowed) {
+            cacheAllowedClass(className);
+        }
+        return allowed;
     }
 
     /**
@@ -141,6 +153,14 @@ public class JsonAllowlistManager {
         }
         String componentClassName = extractArrayComponentClassName(className);
         return componentClassName != null && isExactOrPrefixAllowed(componentClassName);
+    }
+
+    private void cacheAllowedClass(String className) {
+        synchronized (cache) {
+            if (cache.size() < MAX_CACHE_SIZE) {
+                cache.put(className, Boolean.TRUE);
+            }
+        }
     }
 
     /**

--- a/json-common/json-common-core/src/main/java/org/apache/seata/common/json/JsonAllowlistManager.java
+++ b/json-common/json-common-core/src/main/java/org/apache/seata/common/json/JsonAllowlistManager.java
@@ -29,6 +29,8 @@ public class JsonAllowlistManager {
 
     private static final int MAX_CLASS_NAME_LENGTH = 1024;
 
+    private static final int MAX_REPORTED_CLASS_NAME_LENGTH = 256;
+
     private static final int MAX_CACHE_SIZE = 4096;
 
     /**
@@ -130,8 +132,8 @@ public class JsonAllowlistManager {
      */
     public void checkClass(String className) {
         if (!isAllowed(className)) {
-            throw new SecurityException("Class not in JSON deserialization allowlist: " + className
-                    + ". Please add it to seata.json.allowlist configuration.");
+            throw new SecurityException("Class not in JSON deserialization allowlist: "
+                    + formatClassNameForMessage(className) + ". Please add it to seata.json.allowlist configuration.");
         }
     }
 
@@ -161,6 +163,16 @@ public class JsonAllowlistManager {
                 cache.put(className, Boolean.TRUE);
             }
         }
+    }
+
+    private String formatClassNameForMessage(String className) {
+        if (className == null || className.length() <= MAX_REPORTED_CLASS_NAME_LENGTH) {
+            return String.valueOf(className);
+        }
+        return className.substring(0, MAX_REPORTED_CLASS_NAME_LENGTH)
+                + "...(truncated, length="
+                + className.length()
+                + ")";
     }
 
     /**

--- a/json-common/json-common-core/src/test/java/org/apache/seata/common/json/JsonAllowlistManagerTest.java
+++ b/json-common/json-common-core/src/test/java/org/apache/seata/common/json/JsonAllowlistManagerTest.java
@@ -272,6 +272,18 @@ public class JsonAllowlistManagerTest {
     }
 
     @Test
+    public void testCheckClass_overlongNameIsTruncatedInMessage() {
+        JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
+        String className = buildClassName(1100);
+
+        assertThatThrownBy(() -> manager.checkClass(className))
+                .isInstanceOf(SecurityException.class)
+                .hasMessageContaining("not in JSON deserialization allowlist")
+                .hasMessageContaining("truncated, length=1100")
+                .hasMessageNotContaining(className);
+    }
+
+    @Test
     public void testCheckClass_userAllowed() {
         JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
 

--- a/json-common/json-common-core/src/test/java/org/apache/seata/common/json/JsonAllowlistManagerTest.java
+++ b/json-common/json-common-core/src/test/java/org/apache/seata/common/json/JsonAllowlistManagerTest.java
@@ -371,9 +371,10 @@ public class JsonAllowlistManagerTest {
     public void testAllowedClassCacheIsBounded() {
         JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
         manager.clearUserAllowlist();
+        manager.addUserPrefix("com.allowed.generated.");
 
         for (int i = 0; i < 5000; i++) {
-            assertThat(manager.isAllowed("org.apache.seata.generated.AllowedClass" + i))
+            assertThat(manager.isAllowed("com.allowed.generated.AllowedClass" + i))
                     .isTrue();
         }
 

--- a/json-common/json-common-core/src/test/java/org/apache/seata/common/json/JsonAllowlistManagerTest.java
+++ b/json-common/json-common-core/src/test/java/org/apache/seata/common/json/JsonAllowlistManagerTest.java
@@ -19,6 +19,9 @@ package org.apache.seata.common.json;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -318,6 +321,7 @@ public class JsonAllowlistManagerTest {
     @Test
     public void testCacheWorks() {
         JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
+        manager.clearUserAllowlist();
 
         boolean result1 = manager.isAllowed("java.lang.String");
 
@@ -325,6 +329,43 @@ public class JsonAllowlistManagerTest {
 
         assertThat(result1).isTrue();
         assertThat(result2).isTrue();
+        assertThat(cacheSize(manager)).isEqualTo(1);
+    }
+
+    @Test
+    public void testRejectedClassesAreNotCached() {
+        JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
+        manager.clearUserAllowlist();
+
+        for (int i = 0; i < 100; i++) {
+            assertThat(manager.isAllowed("com.malicious.EvilClass" + i)).isFalse();
+        }
+
+        assertThat(cacheSize(manager)).isZero();
+    }
+
+    @Test
+    public void testOverlongClassNameIsRejectedAndNotCached() {
+        JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
+        manager.clearUserAllowlist();
+        String className = buildClassName(1100);
+
+        assertThat(manager.isAllowed(className)).isFalse();
+
+        assertThat(cacheSize(manager)).isZero();
+    }
+
+    @Test
+    public void testAllowedClassCacheIsBounded() {
+        JsonAllowlistManager manager = JsonAllowlistManager.getInstance();
+        manager.clearUserAllowlist();
+
+        for (int i = 0; i < 5000; i++) {
+            assertThat(manager.isAllowed("org.apache.seata.generated.AllowedClass" + i))
+                    .isTrue();
+        }
+
+        assertThat(cacheSize(manager)).isEqualTo(4096);
     }
 
     @Test
@@ -336,5 +377,27 @@ public class JsonAllowlistManagerTest {
         manager.loadUserAllowlist("com.example.CacheTest");
 
         assertThat(manager.isAllowed("com.example.CacheTest")).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int cacheSize(JsonAllowlistManager manager) {
+        try {
+            Field cacheField = JsonAllowlistManager.class.getDeclaredField("cache");
+            cacheField.setAccessible(true);
+            Map<String, Boolean> cache = (Map<String, Boolean>) cacheField.get(manager);
+            return cache.size();
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Failed to read JsonAllowlistManager cache", e);
+        }
+    }
+
+    private static String buildClassName(int length) {
+        String prefix = "com.example.";
+        StringBuilder builder = new StringBuilder(length);
+        builder.append(prefix);
+        while (builder.length() < length) {
+            builder.append('A');
+        }
+        return builder.toString();
     }
 }


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Limit the growth of the JSON deserialization allowlist cache.

This PR updates `JsonAllowlistManager` to:
- reject overlong class names before allowlist checking
- cache only allowed class names
- avoid caching rejected class names
- cap the allowlist cache size to prevent unbounded memory growth

It also adds unit tests covering rejected class names, overlong class names, cache hits, and cache size limits.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Added unit tests in `JsonAllowlistManagerTest`.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

