### PR TITLE
optimize: renew table meta cache entries during refresh

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -87,7 +87,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8109](https://github.com/apache/incubator-seata/pull/8109)] reduce npmjs dependencies in saga module
 - [[#8112](https://github.com/apache/incubator-seata/pull/8112)] optimize seata-server test performance
 - [[#8116](https://github.com/apache/incubator-seata/pull/8116)] fix incompatible dependencies
-- [[#8125](https://github.com/apache/incubator-seata/pull/8125)] Fix cache expiration caused by missing metadata cache renewal
+- [[#8125](https://github.com/apache/incubator-seata/pull/8125)] optimize: renew table meta cache entries during refresh
 
 ### security:
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -87,6 +87,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8109](https://github.com/apache/incubator-seata/pull/8109)] reduce npmjs dependencies in saga module
 - [[#8112](https://github.com/apache/incubator-seata/pull/8112)] optimize seata-server test performance
 - [[#8116](https://github.com/apache/incubator-seata/pull/8116)] fix incompatible dependencies
+- [[#8125](https://github.com/apache/incubator-seata/pull/8125)] Fix cache expiration caused by missing metadata cache renewal
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -89,7 +89,7 @@
 - [[#8109](https://github.com/apache/incubator-seata/pull/8109)] 精简 saga 模块 npmjs 依赖
 - [[#8112](https://github.com/apache/incubator-seata/pull/8112)] 优化 seata-server 测试性能
 - [[#8116](https://github.com/apache/incubator-seata/pull/8116)] 修复不兼容的依赖
-- [[#8125](https://github.com/apache/incubator-seata/pull/8125)] 修复表元数据缓存刷新未续期导致缓存过期的问题
+- [[#8125](https://github.com/apache/incubator-seata/pull/8125)] 优化：在刷新期间更新表元数据缓存
 
 ### security:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -89,6 +89,7 @@
 - [[#8109](https://github.com/apache/incubator-seata/pull/8109)] 精简 saga 模块 npmjs 依赖
 - [[#8112](https://github.com/apache/incubator-seata/pull/8112)] 优化 seata-server 测试性能
 - [[#8116](https://github.com/apache/incubator-seata/pull/8116)] 修复不兼容的依赖
+- [[#8125](https://github.com/apache/incubator-seata/pull/8125)] 修复表元数据缓存刷新未续期导致缓存过期的问题
 
 ### security:
 

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/AbstractTableMetaCache.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/AbstractTableMetaCache.java
@@ -99,7 +99,7 @@ public abstract class AbstractTableMetaCache implements TableMetaCache {
                     TableMeta tableMeta = fetchSchema(connection, tableNameForKey);
                     TABLE_META_CACHE.put(entry.getKey(), tableMeta);
                     if (!tableMeta.equals(entry.getValue())) {
-                        LOGGER.info("table meta change was found, update table meta cache automatically.");
+                        LOGGER.info("table meta cache refreshed automatically, table meta changes detected.");
                     }
                 } catch (SQLException e) {
                     LOGGER.error("get table meta error:{}", e.getMessage(), e);

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/AbstractTableMetaCache.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/sql/struct/cache/AbstractTableMetaCache.java
@@ -97,8 +97,8 @@ public abstract class AbstractTableMetaCache implements TableMetaCache {
                 try {
                     // Reuse tableNameForKey directly, no need to check again
                     TableMeta tableMeta = fetchSchema(connection, tableNameForKey);
+                    TABLE_META_CACHE.put(entry.getKey(), tableMeta);
                     if (!tableMeta.equals(entry.getValue())) {
-                        TABLE_META_CACHE.put(entry.getKey(), tableMeta);
                         LOGGER.info("table meta change was found, update table meta cache automatically.");
                     }
                 } catch (SQLException e) {


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR fixes the table metadata cache refresh behavior in `AbstractTableMetaCache`.

Previously, `TABLE_META_CACHE.put(...)` was only executed when the latest fetched `TableMeta` was different from the cached value. Since the cache uses `expireAfterWrite`, unchanged table metadata would not renew the write timestamp during periodic refresh, causing active cache entries to expire after 900 seconds.

This PR removes that restriction and always writes the refreshed `TableMeta` back to `TABLE_META_CACHE` during `refresh(...)`. The change detection logic is kept only for logging, so the cache write time is continuously renewed even when the schema has not changed.

### Ⅱ. Does this pull request fix one issue?

No.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This change is a small behavior adjustment in the cache refresh path and does not introduce new public behavior or API changes.

Also, verifying this issue through automated tests would require time-based cache expiration behavior and scheduled refresh coordination, which makes the test relatively heavy and less stable. The logic change itself is straightforward: always renew the cache entry during refresh, while preserving the existing schema change log behavior.

### Ⅳ. Describe how to verify it

1. Configure a datasource and ensure table metadata can be loaded into `TABLE_META_CACHE`.
2. Trigger periodic `refresh(...)` calls with unchanged table schema.
3. Confirm that `TABLE_META_CACHE.put(...)` is executed on every refresh.
4. Observe that the cache entry write timestamp is continuously renewed.
5. Verify that the cache entry does not expire after 900 seconds while refresh is running normally.
6. Optionally modify the table schema and confirm that the existing info log is still printed when metadata changes.

### Ⅴ. Special notes for reviews

This PR intentionally keeps the existing log behavior unchanged:
- cache entries are always rewritten during refresh
- the info log is still printed only when the fetched metadata differs from the previous cached value

The goal is only to ensure `expireAfterWrite` entries remain alive during normal periodic refresh.

