### PR TITLE
bugfix: fix Groovy dependency conflict causing saga test failure

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -212,6 +212,10 @@
                         <groupId>org.apache.tomcat.embed</groupId>
                         <artifactId>tomcat-embed-el</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
                 <type>pom</type>
                 <scope>import</scope>

--- a/saga/seata-saga-engine/src/main/java/org/apache/seata/saga/engine/pcext/handlers/ScriptTaskStateHandler.java
+++ b/saga/seata-saga-engine/src/main/java/org/apache/seata/saga/engine/pcext/handlers/ScriptTaskStateHandler.java
@@ -147,9 +147,13 @@ public class ScriptTaskStateHandler implements StateHandler, InterceptableStateH
                     scriptType,
                     e);
 
-            ((HierarchicalProcessContext) context).setVariableLocally(DomainConstants.VAR_NAME_CURRENT_EXCEPTION, e);
+            Exception exceptionToStore = (e instanceof Exception)
+                    ? (Exception) e
+                    : new RuntimeException("Script execution failed: " + e.getMessage(), e);
+            ((HierarchicalProcessContext) context)
+                    .setVariableLocally(DomainConstants.VAR_NAME_CURRENT_EXCEPTION, exceptionToStore);
 
-            EngineUtils.handleException(context, state, e);
+            EngineUtils.handleException(context, state, exceptionToStore);
         }
     }
 


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
  **Root cause:**                                                                                                                                                                  
  Spring Boot 2.x BOM (`spring-boot-dependencies`) manages `org.codehaus.groovy:groovy-all` (2.4.x), which conflicts with Seata's explicit dependency on
  `org.apache.groovy:groovy-all` (4.0.31). Because they have different groupIds, Maven treats them as separate artifacts and loads both onto the classpath. The legacy Groovy 2.4.4
   is incompatible with the current Java version, causing `GroovyBugError` during script execution.

  Additionally, `ScriptTaskStateHandler` catches `Throwable` and stores it directly into the process context, but downstream code casts it to `Exception`. Since `GroovyBugError`  
  is an `Error`, not an `Exception`, this produces a `ClassCastException` that masks the real problem.

  **Changes:**
  1. Exclude `org.codehaus.groovy` from the `spring-boot-dependencies` import in `dependencies/pom.xml`
  2. Wrap non-`Exception` throwables into `RuntimeException` before storing them in `ScriptTaskStateHandler`


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #8133 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

