### PR TITLE
bugfix: wrap Throwable as Exception in saga task handlers to prevent ClassCastException

### DIFF
--- a/saga/seata-saga-engine/src/main/java/org/apache/seata/saga/engine/pcext/handlers/ScriptTaskStateHandler.java
+++ b/saga/seata-saga-engine/src/main/java/org/apache/seata/saga/engine/pcext/handlers/ScriptTaskStateHandler.java
@@ -147,9 +147,12 @@ public class ScriptTaskStateHandler implements StateHandler, InterceptableStateH
                     scriptType,
                     e);
 
-            ((HierarchicalProcessContext) context).setVariableLocally(DomainConstants.VAR_NAME_CURRENT_EXCEPTION, e);
+            Exception ex = (e instanceof Exception)
+                    ? (Exception) e
+                    : new EngineExecutionException(e, e.getMessage(), FrameworkErrorCode.UnknownAppError);
+            ((HierarchicalProcessContext) context).setVariableLocally(DomainConstants.VAR_NAME_CURRENT_EXCEPTION, ex);
 
-            EngineUtils.handleException(context, state, e);
+            EngineUtils.handleException(context, state, ex);
         }
     }
 

--- a/saga/seata-saga-engine/src/main/java/org/apache/seata/saga/engine/pcext/handlers/ServiceTaskStateHandler.java
+++ b/saga/seata-saga-engine/src/main/java/org/apache/seata/saga/engine/pcext/handlers/ServiceTaskStateHandler.java
@@ -126,9 +126,12 @@ public class ServiceTaskStateHandler implements StateHandler, InterceptableState
                     methodName,
                     e);
 
-            ((HierarchicalProcessContext) context).setVariableLocally(DomainConstants.VAR_NAME_CURRENT_EXCEPTION, e);
+            Exception ex = (e instanceof Exception)
+                    ? (Exception) e
+                    : new EngineExecutionException(e, e.getMessage(), FrameworkErrorCode.UnknownAppError);
+            ((HierarchicalProcessContext) context).setVariableLocally(DomainConstants.VAR_NAME_CURRENT_EXCEPTION, ex);
 
-            EngineUtils.handleException(context, state, e);
+            EngineUtils.handleException(context, state, ex);
         }
     }
 


### PR DESCRIPTION

ScriptTaskStateHandler and ServiceTaskStateHandler catch Throwable (e.g. GroovyBugError) but store it into the process context as VAR_NAME_CURRENT_EXCEPTION. Downstream code retrieves this variable with an (Exception) cast, causing ClassCastException when the caught object is an Error rather than an Exception.

Wrap non-Exception Throwables in EngineExecutionException before storing them in the context, preserving the original as the cause.

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

fix #8133 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

