### PR TITLE
bugfix: fix TCC fence cleanup deleting in-progress/unexpired sibling branch records

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -23,6 +23,8 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### bugfix:
 
+- [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
+
 
 ### optimize:
 
@@ -44,6 +46,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 <!-- Please make sure your Github ID is in the list below -->
 
 - [slievrly](https://github.com/slievrly)
+- [Seol-JY](https://github.com/Seol-JY)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -23,6 +23,8 @@
 
 ### bugfix:
 
+- [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
+
 
 ### optimize:
 
@@ -44,6 +46,7 @@
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 
 - [slievrly](https://github.com/slievrly)
+- [Seol-JY](https://github.com/Seol-JY)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/fence/store/CommonFenceStore.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/fence/store/CommonFenceStore.java
@@ -74,12 +74,15 @@ public interface CommonFenceStore {
     boolean deleteCommonFenceDO(Connection conn, String xid, Long branchId);
 
     /**
-     * Delete tcc fence do boolean.
+     * Delete tcc fence by the given xids, restricted to expired end-status rows.
+     * The datetime and end-status predicates guard against removing sibling branch rows of the same xid
+     * that are still in progress (TRIED) or not yet expired.
      * @param conn the connection
      * @param xids the global transaction ids
-     * @return the boolean
+     * @param datetime the expiry threshold; only rows with gmt_modified before this are deleted
+     * @return the deleted row count
      */
-    int deleteTCCFenceDO(Connection conn, List<String> xids);
+    int deleteTCCFenceDO(Connection conn, List<String> xids, Date datetime);
 
     /**
      * Set LogTable Name

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/fence/store/db/CommonFenceStoreDataBaseDAO.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/fence/store/db/CommonFenceStoreDataBaseDAO.java
@@ -180,7 +180,7 @@ public class CommonFenceStoreDataBaseDAO implements CommonFenceStore {
     }
 
     @Override
-    public int deleteTCCFenceDO(Connection conn, List<String> xids) {
+    public int deleteTCCFenceDO(Connection conn, List<String> xids, Date datetime) {
         PreparedStatement ps = null;
         try {
             String paramsPlaceHolder = org.apache.commons.lang3.StringUtils.repeat("?", ",", xids.size());
@@ -189,6 +189,8 @@ public class CommonFenceStoreDataBaseDAO implements CommonFenceStore {
             for (int i = 0; i < xids.size(); i++) {
                 ps.setString(i + 1, xids.get(i));
             }
+            // gmt_modified threshold, bound after the xid placeholders
+            ps.setTimestamp(xids.size() + 1, new Timestamp(datetime.getTime()));
             return ps.executeUpdate();
         } catch (SQLException e) {
             throw new StoreException(e);

--- a/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/fence/store/db/sql/CommonFenceStoreSqls.java
+++ b/integration-tx-api/src/main/java/org/apache/seata/integration/tx/api/fence/store/db/sql/CommonFenceStoreSqls.java
@@ -56,8 +56,10 @@ public class CommonFenceStoreSqls {
 
     /**
      * The constant QUERY_END_STATUS_BY_DATE.
+     * Selects distinct xids so the query limit bounds the number of distinct xids returned,
+     * which keeps the limit comparison in the cleanup loop consistent (one xid may have multiple branch rows).
      */
-    protected static final String QUERY_END_STATUS_BY_DATE = "select xid, branch_id, status, gmt_create, gmt_modified "
+    protected static final String QUERY_END_STATUS_BY_DATE = "select distinct xid "
             + " from " + LOCAL_TCC_LOG_PLACEHOLD
             + " where  gmt_modified < ? "
             + " and status in (" + CommonFenceConstant.STATUS_COMMITTED + " , " + CommonFenceConstant.STATUS_ROLLBACKED
@@ -86,16 +88,14 @@ public class CommonFenceStoreSqls {
             "delete from " + LOCAL_TCC_LOG_PLACEHOLD + " where xid = ? and  branch_id = ? ";
 
     /**
-     * The constant DELETE_BY_BRANCH_ID_AND_XID.
+     * The constant DELETE_BY_BRANCH_XIDS.
+     * The gmt_modified and status predicates must match {@link #QUERY_END_STATUS_BY_DATE}: deleting by xid alone
+     * would also remove sibling branch rows of the same global transaction that are still in a non-end status
+     * (e.g. TRIED) or not yet expired, which must be preserved.
      */
-    protected static final String DELETE_BY_BRANCH_XIDS =
-            "delete from " + LOCAL_TCC_LOG_PLACEHOLD + " where xid in (" + PRAMETER_PLACEHOLD + ")";
-
-    /**
-     * The constant DELETE_BY_DATE_AND_STATUS.
-     */
-    protected static final String DELETE_BY_DATE_AND_STATUS = "delete from " + LOCAL_TCC_LOG_PLACEHOLD
-            + " where gmt_modified < ? "
+    protected static final String DELETE_BY_BRANCH_XIDS = "delete from " + LOCAL_TCC_LOG_PLACEHOLD + " where xid in ("
+            + PRAMETER_PLACEHOLD + ")"
+            + " and gmt_modified < ? "
             + " and status in (" + CommonFenceConstant.STATUS_COMMITTED + " , " + CommonFenceConstant.STATUS_ROLLBACKED
             + " , " + CommonFenceConstant.STATUS_SUSPENDED + ")";
 

--- a/integration-tx-api/src/test/java/org/apache/seata/integration/tx/api/fence/store/db/CommonFenceStoreDataBaseDAOTest.java
+++ b/integration-tx-api/src/test/java/org/apache/seata/integration/tx/api/fence/store/db/CommonFenceStoreDataBaseDAOTest.java
@@ -169,9 +169,12 @@ public class CommonFenceStoreDataBaseDAOTest {
         when(connection.prepareStatement(anyString())).thenReturn(statement);
         when(statement.executeUpdate()).thenReturn(2);
 
-        assertEquals(2, dao.deleteTCCFenceDO(connection, Arrays.asList("xid1", "xid2")));
+        assertEquals(2, dao.deleteTCCFenceDO(connection, Arrays.asList("xid1", "xid2"), new Date(1000L)));
         verify(statement).setString(1, "xid1");
         verify(statement).setString(2, "xid2");
+        // the gmt_modified threshold must be bound right after the xid placeholders,
+        // so the delete only removes expired end-status rows and never a sibling branch row by xid alone
+        verify(statement).setTimestamp(3, new Timestamp(1000L));
     }
 
     @Test
@@ -184,7 +187,9 @@ public class CommonFenceStoreDataBaseDAOTest {
         assertThrows(StoreException.class, () -> dao.insertCommonFenceDO(connection, newFenceDO()));
         assertThrows(StoreException.class, () -> dao.updateCommonFenceDO(connection, "xid", 1L, 2, 1));
         assertThrows(StoreException.class, () -> dao.deleteCommonFenceDO(connection, "xid", 1L));
-        assertThrows(StoreException.class, () -> dao.deleteTCCFenceDO(connection, Arrays.asList("xid1", "xid2")));
+        assertThrows(
+                StoreException.class,
+                () -> dao.deleteTCCFenceDO(connection, Arrays.asList("xid1", "xid2"), new Date(1000L)));
     }
 
     private static CommonFenceDO newFenceDO() {

--- a/integration-tx-api/src/test/java/org/apache/seata/integration/tx/api/fence/store/db/sql/CommonFenceStoreSqlsTest.java
+++ b/integration-tx-api/src/test/java/org/apache/seata/integration/tx/api/fence/store/db/sql/CommonFenceStoreSqlsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.integration.tx.api.fence.store.db.sql;
+
+import org.apache.seata.integration.tx.api.fence.constant.CommonFenceConstant;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CommonFenceStoreSqlsTest {
+
+    private static final String TABLE = "tcc_fence_log";
+
+    private static final String END_STATUS_IN = "status in (" + CommonFenceConstant.STATUS_COMMITTED + " , "
+            + CommonFenceConstant.STATUS_ROLLBACKED + " , " + CommonFenceConstant.STATUS_SUSPENDED + ")";
+
+    /**
+     * The date-based cleanup must select distinct xids, so a row limit bounds the number of distinct xids
+     * (one xid may own multiple branch rows) and the limit comparison in the cleanup loop stays consistent.
+     */
+    @Test
+    public void queryEndStatusByDateSelectsDistinctXids() {
+        String mysql = CommonFenceStoreSqls.getQueryEndStatusSQLByDate(TABLE, false);
+        assertTrue(mysql.contains("select distinct xid"), mysql);
+        assertTrue(mysql.contains("gmt_modified <"), mysql);
+        assertTrue(mysql.contains(END_STATUS_IN), mysql);
+        assertTrue(mysql.contains("limit ?"), mysql);
+
+        String oracle = CommonFenceStoreSqls.getQueryEndStatusSQLByDate(TABLE, true);
+        assertTrue(oracle.contains("ROWNUM <= ?"), oracle);
+    }
+
+    /**
+     * Core regression: deleting expired fence logs by xid must also be restricted by gmt_modified and end status.
+     * Without these predicates, deleting by xid alone would purge sibling branch rows of the same global
+     * transaction that are still in progress (TRIED) or not yet expired.
+     */
+    @Test
+    public void deleteByXidsIsRestrictedByDateAndEndStatus() {
+        String sql = CommonFenceStoreSqls.getDeleteSQLByXids(TABLE, "?, ?");
+
+        assertTrue(sql.contains("xid in (?, ?)"), sql);
+        // must not be a bare delete-by-xid: the date and end-status guards have to be present
+        assertTrue(sql.contains("gmt_modified <"), sql);
+        assertTrue(sql.contains(END_STATUS_IN), sql);
+        // the in-progress status must never be a deletion target
+        assertFalse(sql.contains("status in (" + CommonFenceConstant.STATUS_TRIED), sql);
+    }
+}

--- a/integration-tx-api/src/test/java/org/apache/seata/integration/tx/api/fence/store/db/sql/CommonFenceStoreSqlsTest.java
+++ b/integration-tx-api/src/test/java/org/apache/seata/integration/tx/api/fence/store/db/sql/CommonFenceStoreSqlsTest.java
@@ -16,49 +16,38 @@
  */
 package org.apache.seata.integration.tx.api.fence.store.db.sql;
 
-import org.apache.seata.integration.tx.api.fence.constant.CommonFenceConstant;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommonFenceStoreSqlsTest {
 
     private static final String TABLE = "tcc_fence_log";
 
-    private static final String END_STATUS_IN = "status in (" + CommonFenceConstant.STATUS_COMMITTED + " , "
-            + CommonFenceConstant.STATUS_ROLLBACKED + " , " + CommonFenceConstant.STATUS_SUSPENDED + ")";
-
     /**
-     * The date-based cleanup must select distinct xids, so a row limit bounds the number of distinct xids
+     * The date-based cleanup selects distinct xids, so a row limit bounds the number of distinct xids
      * (one xid may own multiple branch rows) and the limit comparison in the cleanup loop stays consistent.
      */
     @Test
     public void queryEndStatusByDateSelectsDistinctXids() {
-        String mysql = CommonFenceStoreSqls.getQueryEndStatusSQLByDate(TABLE, false);
-        assertTrue(mysql.contains("select distinct xid"), mysql);
-        assertTrue(mysql.contains("gmt_modified <"), mysql);
-        assertTrue(mysql.contains(END_STATUS_IN), mysql);
-        assertTrue(mysql.contains("limit ?"), mysql);
+        assertEquals(
+                "select distinct xid  from tcc_fence_log where  gmt_modified < ?  and status in (2 , 3 , 4) limit ? ",
+                CommonFenceStoreSqls.getQueryEndStatusSQLByDate(TABLE, false));
 
-        String oracle = CommonFenceStoreSqls.getQueryEndStatusSQLByDate(TABLE, true);
-        assertTrue(oracle.contains("ROWNUM <= ?"), oracle);
+        assertEquals(
+                "select distinct xid  from tcc_fence_log where  gmt_modified < ?  and status in (2 , 3 , 4) and ROWNUM <= ? ",
+                CommonFenceStoreSqls.getQueryEndStatusSQLByDate(TABLE, true));
     }
 
     /**
-     * Core regression: deleting expired fence logs by xid must also be restricted by gmt_modified and end status.
+     * Core regression: deleting expired fence logs by xid is also restricted by gmt_modified and end status.
      * Without these predicates, deleting by xid alone would purge sibling branch rows of the same global
      * transaction that are still in progress (TRIED) or not yet expired.
      */
     @Test
     public void deleteByXidsIsRestrictedByDateAndEndStatus() {
-        String sql = CommonFenceStoreSqls.getDeleteSQLByXids(TABLE, "?, ?");
-
-        assertTrue(sql.contains("xid in (?, ?)"), sql);
-        // must not be a bare delete-by-xid: the date and end-status guards have to be present
-        assertTrue(sql.contains("gmt_modified <"), sql);
-        assertTrue(sql.contains(END_STATUS_IN), sql);
-        // the in-progress status must never be a deletion target
-        assertFalse(sql.contains("status in (" + CommonFenceConstant.STATUS_TRIED), sql);
+        assertEquals(
+                "delete from tcc_fence_log where xid in (?, ?) and gmt_modified < ?  and status in (2 , 3 , 4)",
+                CommonFenceStoreSqls.getDeleteSQLByXids(TABLE, "?, ?"));
     }
 }

--- a/spring/seata-spring/src/main/java/org/apache/seata/rm/fence/SpringFenceHandler.java
+++ b/spring/seata-spring/src/main/java/org/apache/seata/rm/fence/SpringFenceHandler.java
@@ -397,7 +397,7 @@ public class SpringFenceHandler implements FenceHandler {
                 if (xidSet.isEmpty()) {
                     break;
                 }
-                total += COMMON_FENCE_DAO.deleteTCCFenceDO(connection, new ArrayList<>(xidSet));
+                total += COMMON_FENCE_DAO.deleteTCCFenceDO(connection, new ArrayList<>(xidSet), datetime);
                 if (xidSet.size() < LIMIT_DELETE) {
                     break;
                 }


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

`SpringFenceHandler#deleteFenceByDate` selects expired end-status xids (`gmt_modified < ?` and `status in (COMMITTED, ROLLBACKED, SUSPENDED)`), but then deletes them with `DELETE ... WHERE xid IN (...)`, without the date and status predicates. Since the `tcc_fence_log` primary key is `(xid, branch_id)`, one global transaction can have multiple branch rows, so deleting by xid also removes sibling branches that are still `TRIED` or not yet expired.

- Add the `gmt_modified` and end-status predicates to the delete so it matches the query. The now-redundant unused `DELETE_BY_DATE_AND_STATUS` constant is removed.
- Change the query to `select distinct xid`, so the row limit bounds the number of distinct xids and the `xidSet.size() < LIMIT_DELETE` loop check stays correct when an xid has multiple branch rows.

### Ⅱ. Does this pull request fix one issue?

No linked issue, found by code review.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Added `CommonFenceStoreSqlsTest` and extended `CommonFenceStoreDataBaseDAOTest` to cover the delete predicate and the parameter binding.

### Ⅳ. Describe how to verify it

`mvn -pl integration-tx-api -am test`

### Ⅴ. Special notes for reviews

`CommonFenceStore#deleteTCCFenceDO` takes an extra `Date` parameter; its only implementation and caller are updated. On Oracle the limit still bounds raw rows via `ROWNUM`; the distinct-xid limit applies to MySQL/PostgreSQL/MariaDB.
