### PR TITLE
bugfix: fix global lock batch acquire false-failure on Dameng(DM)

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -23,6 +23,8 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### bugfix:
 
+- [#8145](https://github.com/apache/incubator-seata/pull/8145) fix global lock batch acquire false-failure on Dameng(DM)
+
 
 ### optimize:
 
@@ -44,6 +46,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 <!-- Please make sure your Github ID is in the list below -->
 
 - [slievrly](https://github.com/slievrly)
+- [lhozy](https://github.com/lhozy)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -23,6 +23,8 @@
 
 ### bugfix:
 
+- [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
+
 
 ### optimize:
 
@@ -44,6 +46,7 @@
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 
 - [slievrly](https://github.com/slievrly)
+- [lhozy](https://github.com/lhozy)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/server/src/main/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAO.java
+++ b/server/src/main/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAO.java
@@ -390,7 +390,18 @@ public class LockStoreDataBaseDAO implements LockStore {
                 ps.setInt(8, lockDO.getStatus());
                 ps.addBatch();
             }
-            return ps.executeBatch().length == lockDOs.size();
+            // Do not rely on executeBatch().length == size: per the JDBC spec the length is
+            // not guaranteed to equal the number of statements, and some drivers (e.g. Dameng/DM)
+            // aggregate the per-statement results, returning an array of a different length.
+            // Detect failure via EXECUTE_FAILED instead; real conflicts (duplicate row_key) still
+            // throw SQLIntegrityConstraintViolationException and are handled by the catch block below.
+            int[] result = ps.executeBatch();
+            for (int updated : result) {
+                if (updated == java.sql.Statement.EXECUTE_FAILED) {
+                    return false;
+                }
+            }
+            return true;
         } catch (SQLIntegrityConstraintViolationException e) {
             LOGGER.error("Global lock batch acquire error: {}", e.getMessage(), e);
             // return false,let the caller go to conn.rollback()

--- a/server/src/test/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAOBatchAcquireTest.java
+++ b/server/src/test/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAOBatchAcquireTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.db.lock;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.config.ConfigurationFactory;
+import org.apache.seata.core.model.LockStatus;
+import org.apache.seata.core.store.LockDO;
+import org.apache.seata.server.BaseSpringBootTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link LockStoreDataBaseDAO#doAcquireLocks} batch-result handling.
+ *
+ * <p>Batch lock acquisition must not rely on {@code executeBatch().length == lockDOs.size()}.
+ * The JDBC spec does not guarantee that the returned array has one element per batched
+ * statement, and some drivers (e.g. Dameng/DM) aggregate the per-statement results into an
+ * array of a different length. The previous length comparison then evaluated to {@code false}
+ * even though every row was inserted, producing a bogus "global lock batch acquire failed"
+ * for any branch that acquires two or more locks at once.
+ *
+ * <p>The JDBC layer is mocked, so no database is required and the test runs in CI by default
+ * (unlike {@link LockStoreDataBaseDAOTest}, which is gated behind a live DB).
+ */
+public class LockStoreDataBaseDAOBatchAcquireTest extends BaseSpringBootTest {
+
+    private static LockStoreDataBaseDAO lockStoreDataBaseDAO;
+
+    @BeforeAll
+    public static void setUp(ApplicationContext context) {
+        // The DAO's static CONFIG needs the Spring-Boot test context (from BaseSpringBootTest)
+        // to initialize; feed it a db type so the constructor passes, then mock the data source
+        // since this test stubs the JDBC layer rather than hitting a real database.
+        ConfigurationFactory.getInstance().putConfig(ConfigurationKeys.STORE_DB_TYPE, "mysql");
+        ConfigurationFactory.getInstance().putConfig(ConfigurationKeys.LOCK_DB_TABLE, "lock_table");
+        lockStoreDataBaseDAO = new LockStoreDataBaseDAO(mock(DataSource.class));
+    }
+
+    /**
+     * Driver aggregates the batch result into an array shorter than the number of batched
+     * statements, with no {@link Statement#EXECUTE_FAILED}. Acquisition must still succeed.
+     * Before the fix this returned {@code false}.
+     */
+    @Test
+    public void doAcquireLocksSucceedsWhenDriverAggregatesBatchResult() throws SQLException {
+        // 3 statements batched, driver returns a single aggregated update count
+        Connection conn = mockConnReturning(new int[] {3});
+        assertTrue(
+                lockStoreDataBaseDAO.doAcquireLocks(conn, locks(3)),
+                "batch acquire must succeed when the driver aggregates executeBatch() results");
+    }
+
+    /**
+     * A spec-conforming driver returns one update count per statement. Acquisition succeeds.
+     */
+    @Test
+    public void doAcquireLocksSucceedsWhenDriverReturnsOneCountPerStatement() throws SQLException {
+        Connection conn = mockConnReturning(new int[] {1, 1, 1});
+        assertTrue(
+                lockStoreDataBaseDAO.doAcquireLocks(conn, locks(3)),
+                "batch acquire must succeed for a spec-conforming driver");
+    }
+
+    /**
+     * Any per-statement {@link Statement#EXECUTE_FAILED} in the returned array is a real
+     * failure and acquisition must report it.
+     */
+    @Test
+    public void doAcquireLocksFailsWhenAnyStatementReportsExecuteFailed() throws SQLException {
+        Connection conn = mockConnReturning(new int[] {1, Statement.EXECUTE_FAILED, 1});
+        assertFalse(
+                lockStoreDataBaseDAO.doAcquireLocks(conn, locks(3)),
+                "batch acquire must fail when any statement reports EXECUTE_FAILED");
+    }
+
+    private Connection mockConnReturning(int[] batchResult) throws SQLException {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        when(ps.executeBatch()).thenReturn(batchResult);
+        Connection conn = mock(Connection.class);
+        when(conn.prepareStatement(anyString())).thenReturn(ps);
+        return conn;
+    }
+
+    private List<LockDO> locks(int n) {
+        List<LockDO> lockDOs = new ArrayList<>();
+        for (int i = 1; i <= n; i++) {
+            LockDO lockDO = new LockDO();
+            lockDO.setXid("test-xid");
+            lockDO.setTransactionId(1L);
+            lockDO.setBranchId(1L);
+            lockDO.setResourceId("test-resource");
+            lockDO.setTableName("test_table");
+            lockDO.setPk(String.valueOf(i));
+            lockDO.setRowKey("test-resource^^^test_table^^^" + i);
+            lockDO.setStatus(LockStatus.Locked.getCode());
+            lockDOs.add(lockDO);
+        }
+        return lockDOs;
+    }
+}


### PR DESCRIPTION
# PR: bugfix: fix global lock batch acquire false-failure on Dameng(DM)

## Ⅰ. Describe what this PR does

Fix `LockStoreDataBaseDAO#doAcquireLocks` so that batch global-lock acquisition no longer produces a **false "lock acquire failed"** on databases (e.g. **Dameng / DM**) whose JDBC driver returns an `executeBatch()` array whose length differs from the number of batched statements.

Fixes #8144.

## Ⅱ. Why make this change

`doAcquireLocks` judged batch success with:

```java
return ps.executeBatch().length == lockDOs.size();
```

The JDBC spec does **not** guarantee `executeBatch()` returns exactly one element per batched statement (elements may be counts, `SUCCESS_NO_INFO`, or `EXECUTE_FAILED`, and some drivers aggregate). The DM driver aggregates the per-row results (`DmdbPreparedStatement.executeBatchByRow` → `ExecuteRetInfo.union`), so the returned array length ≠ statement count.

Consequence on DM: when a branch locks ≥ 2 rows, the lock rows are inserted successfully but the `length == size` check returns `false`, so the caller rolls back the inserted locks and the branch register is reported as a lock conflict. Single-row branches (non-batch `doAcquireLock`) are unaffected, so the bug only manifests for multi-row branches — making AT mode unusable on DM for typical multi-row business transactions.

## Ⅲ. The change

`server/src/main/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAO.java`

```diff
             for (LockDO lockDO : lockDOs) {
                 ...
                 ps.addBatch();
             }
-            return ps.executeBatch().length == lockDOs.size();
+            // Do not rely on executeBatch().length == size: per the JDBC spec the
+            // length is not guaranteed to equal the number of statements, and some
+            // drivers (e.g. Dameng/DM) aggregate the per-statement results, returning
+            // an array of a different length. Detect failure via EXECUTE_FAILED instead;
+            // real conflicts (duplicate row_key) still throw SQLIntegrityConstraintViolationException
+            // and are handled by the catch block below.
+            int[] result = ps.executeBatch();
+            for (int updated : result) {
+                if (updated == java.sql.Statement.EXECUTE_FAILED) {
+                    return false;
+                }
+            }
+            return true;
         } catch (SQLIntegrityConstraintViolationException e) {
             LOGGER.error("Global lock batch acquire error: {}", e.getMessage(), e);
             // return false,let the caller go to conn.rollback()
             return false;
```

## Ⅳ. How tested

- **Unit test (new): `LockStoreDataBaseDAOBatchAcquireTest`** — pure Mockito, no database, runs in CI by default. It stubs `PreparedStatement.executeBatch()` to return:
  - (a) an aggregated array **shorter** than the batched-statement count (the DM behavior, e.g. `{3}` for 3 statements) → asserts acquisition **succeeds**;
  - (b) an array containing `Statement.EXECUTE_FAILED` → asserts acquisition **fails**;
  - (c) one update count per statement (`{1,1,1}`) → asserts **success**.

  Reverting this PR's change makes (a) and (b) fail, confirming the test guards the regression. Run: `mvn -pl server test -Dtest=LockStoreDataBaseDAOBatchAcquireTest`.
- Existing behavior preserved on databases that return one element per statement (MySQL, Oracle, PostgreSQL…): no `EXECUTE_FAILED` → returns `true`; genuine duplicate-`row_key` conflicts still throw `SQLIntegrityConstraintViolationException` → handled → `false`.
- On DM8 (store.mode=db): a branch acquiring multiple row locks now succeeds; a cross-resource global transaction with multi-row branches both commits and rolls back correctly, where before every multi-row branch register failed with `Global lock batch acquire failed`.

## Ⅴ. Checklist

- [x] Unit test added — `LockStoreDataBaseDAOBatchAcquireTest` asserts `doAcquireLocks` returns `true` when `executeBatch()` returns an aggregated/short array, and `false` on `EXECUTE_FAILED`.
- [x] Changelog entry — registered in `changes/en-us/2.x.md` and `changes/zh-cn/2.x.md`.
