### PR TITLE
optimize: fix import order in LockStoreDataBaseDAOBatchAcquireTest

### DIFF
--- a/server/src/test/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAOBatchAcquireTest.java
+++ b/server/src/test/java/org/apache/seata/server/storage/db/lock/LockStoreDataBaseDAOBatchAcquireTest.java
@@ -16,14 +16,6 @@
  */
 package org.apache.seata.server.storage.db.lock;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-import javax.sql.DataSource;
-
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.core.model.LockStatus;
@@ -32,6 +24,14 @@ import org.apache.seata.server.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

`LockStoreDataBaseDAOBatchAcquireTest` (added in #8145) orders its `java`/`javax` imports before the `org.*` imports, which violates the Spotless import order (`,javax|java,#`) and makes `spotless:check` fail on 2.x. Reorder the imports so the build passes.

### Ⅱ. Does this pull request fix one issue?

Fixes the Spotless failure on 2.x introduced by #8145.

### Ⅳ. Describe how to verify it

`./mvnw spotless:check -pl server`
