### PR TITLE
test: add regression tests for FileConfiguration

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -41,6 +41,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### test:
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: cover rm-datasource resource id initializers
+- [[#8151](https://github.com/apache/incubator-seata/pull/8151)] add regression coverage for the file-backed Configuration API
 - [[#8175](https://github.com/apache/incubator-seata/pull/8175)] fix flaky testCachedConfigurationChangeListener due to async race condition
 
 ### refactor:
@@ -59,6 +60,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [lhozy](https://github.com/lhozy)
 - [Zhengcy05](https://github.com/Zhengcy05)
 - [neu-hsc](https://github.com/neu-hsc)
+- [amirdeljouyi](https://github.com/amirdeljouyi)
 
 
 

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/FileConfigurationTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/FileConfigurationTest.java
@@ -484,6 +484,7 @@ class FileConfigurationTest {
             ConfigurationFactory.reload();
             Configuration fileConfig = ConfigurationFactory.getInstance();
 
+            // These values come from src/test/resources/file.conf.
             Assertions.assertEquals("127.0.0.1:8091", fileConfig.getConfig(groupListDataId));
             Assertions.assertFalse(fileConfig.getBoolean(disableGlobalTransactionDataId));
         } finally {
@@ -507,10 +508,12 @@ class FileConfigurationTest {
     void shouldReportMutationOperationOutcomeThroughConfigurationFactory() {
         Configuration fileConfig = ConfigurationFactory.getInstance();
 
+        // The current file-backed mutation branches acknowledge completion but do not rewrite the source file.
         Assertions.assertTrue(fileConfig.putConfig("adopted.put.key", "value", 5000L));
         Assertions.assertTrue(fileConfig.putConfigIfAbsent("adopted.put-if-absent.key", "value", 5000L));
         Assertions.assertTrue(fileConfig.removeConfig("adopted.remove.key", 5000L));
 
+        // A negative timeout expires before the operation can be processed.
         Assertions.assertFalse(fileConfig.putConfig("adopted.expired.put.key", "value", -1L));
         Assertions.assertFalse(fileConfig.putConfigIfAbsent("adopted.expired.put-if-absent.key", "value", -1L));
         Assertions.assertFalse(fileConfig.removeConfig("adopted.expired.remove.key", -1L));

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/FileConfigurationTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/FileConfigurationTest.java
@@ -471,4 +471,48 @@ class FileConfigurationTest {
         String path = fileConfig.getConfigFromSys("PATH");
         Assertions.assertNotNull(path);
     }
+
+    @Test
+    void shouldDelegateFileBackedReadsThroughConfigurationFactory() {
+        String dataId = "service.disableGlobalTransaction";
+        String previousValue = System.getProperty(dataId);
+        try {
+            System.clearProperty(dataId);
+            ConfigurationFactory.reload();
+            Configuration fileConfig = ConfigurationFactory.getInstance();
+
+            Assertions.assertEquals("127.0.0.1:8091", fileConfig.getConfig("service.default.grouplist"));
+            Assertions.assertFalse(fileConfig.getBoolean(dataId));
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(dataId);
+            } else {
+                System.setProperty(dataId, previousValue);
+            }
+            ConfigurationFactory.reload();
+        }
+    }
+
+    @Test
+    void shouldReturnDefaultsForMissingConfigurationThroughConfigurationFactory() {
+        Configuration fileConfig = ConfigurationFactory.getInstance();
+
+        Assertions.assertNull(fileConfig.getConfig("adopted.missing.key"));
+        Assertions.assertEquals("fallback", fileConfig.getLatestConfig("adopted.missing.key", "fallback", 1000L));
+        Assertions.assertEquals(39, fileConfig.getInt("adopted.missing.int", 39));
+        Assertions.assertEquals((short) 2, fileConfig.getShort("adopted.missing.short", (short) 2));
+    }
+
+    @Test
+    void shouldReportMutationOperationOutcomeThroughConfigurationFactory() {
+        Configuration fileConfig = ConfigurationFactory.getInstance();
+
+        Assertions.assertTrue(fileConfig.putConfig("adopted.put.key", "value", 1000L));
+        Assertions.assertTrue(fileConfig.putConfigIfAbsent("adopted.put-if-absent.key", "value", 1000L));
+        Assertions.assertTrue(fileConfig.removeConfig("adopted.remove.key", 1000L));
+
+        Assertions.assertFalse(fileConfig.putConfig("adopted.expired.put.key", "value", -1L));
+        Assertions.assertFalse(fileConfig.putConfigIfAbsent("adopted.expired.put-if-absent.key", "value", -1L));
+        Assertions.assertFalse(fileConfig.removeConfig("adopted.expired.remove.key", -1L));
+    }
 }

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/FileConfigurationTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/FileConfigurationTest.java
@@ -474,21 +474,21 @@ class FileConfigurationTest {
 
     @Test
     void shouldDelegateFileBackedReadsThroughConfigurationFactory() {
-        String dataId = "service.disableGlobalTransaction";
-        String previousValue = System.getProperty(dataId);
+        String groupListDataId = "service.default.grouplist";
+        String disableGlobalTransactionDataId = "service.disableGlobalTransaction";
+        String previousGroupList = System.getProperty(groupListDataId);
+        String previousDisableGlobalTransaction = System.getProperty(disableGlobalTransactionDataId);
         try {
-            System.clearProperty(dataId);
+            System.clearProperty(groupListDataId);
+            System.clearProperty(disableGlobalTransactionDataId);
             ConfigurationFactory.reload();
             Configuration fileConfig = ConfigurationFactory.getInstance();
 
-            Assertions.assertEquals("127.0.0.1:8091", fileConfig.getConfig("service.default.grouplist"));
-            Assertions.assertFalse(fileConfig.getBoolean(dataId));
+            Assertions.assertEquals("127.0.0.1:8091", fileConfig.getConfig(groupListDataId));
+            Assertions.assertFalse(fileConfig.getBoolean(disableGlobalTransactionDataId));
         } finally {
-            if (previousValue == null) {
-                System.clearProperty(dataId);
-            } else {
-                System.setProperty(dataId, previousValue);
-            }
+            restoreSystemProperty(groupListDataId, previousGroupList);
+            restoreSystemProperty(disableGlobalTransactionDataId, previousDisableGlobalTransaction);
             ConfigurationFactory.reload();
         }
     }
@@ -507,12 +507,20 @@ class FileConfigurationTest {
     void shouldReportMutationOperationOutcomeThroughConfigurationFactory() {
         Configuration fileConfig = ConfigurationFactory.getInstance();
 
-        Assertions.assertTrue(fileConfig.putConfig("adopted.put.key", "value", 1000L));
-        Assertions.assertTrue(fileConfig.putConfigIfAbsent("adopted.put-if-absent.key", "value", 1000L));
-        Assertions.assertTrue(fileConfig.removeConfig("adopted.remove.key", 1000L));
+        Assertions.assertTrue(fileConfig.putConfig("adopted.put.key", "value", 5000L));
+        Assertions.assertTrue(fileConfig.putConfigIfAbsent("adopted.put-if-absent.key", "value", 5000L));
+        Assertions.assertTrue(fileConfig.removeConfig("adopted.remove.key", 5000L));
 
         Assertions.assertFalse(fileConfig.putConfig("adopted.expired.put.key", "value", -1L));
         Assertions.assertFalse(fileConfig.putConfigIfAbsent("adopted.expired.put-if-absent.key", "value", -1L));
         Assertions.assertFalse(fileConfig.removeConfig("adopted.expired.remove.key", -1L));
+    }
+
+    private static void restoreSystemProperty(String dataId, String value) {
+        if (value == null) {
+            System.clearProperty(dataId);
+        } else {
+            System.setProperty(dataId, value);
+        }
     }
 }


### PR DESCRIPTION
# test: add regression tests for FileConfiguration

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

I added three regression tests for the file-backed configuration API.

The tests cover reads, default-value behavior for missing keys, and mutation operation outcomes.

Impact on coverage:

The tests cover the main file-backed read and mutation paths in [`FileConfiguration`](https://github.com/seata/seata/blob/2.x/config/seata-config-core/src/main/java/org/apache/seata/config/FileConfiguration.java#L109-L247), plus timeout handling in the config operation runnable. In the focused JaCoCo
run, `FileConfiguration.java` branch coverage increases around 3%.

### Ⅱ. Does this pull request fix one issue?

No linked issue; this is a test-only regression-coverage change.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR consists entirely of unit tests.

### Ⅳ. Describe how to verify it

Run `./mvnw -pl config/seata-config-core -am -Dtest=FileConfigurationTest -DfailIfNoTests=false test`.

### Ⅴ. Special notes for reviews

No production code or API behavior is changed.
