### PR TITLE
bugfix: fix SeataSagaAutoConfiguration @AutoConfigureAfter fails on Spring Boot 4.x due to hardcoded old DataSourceAutoConfiguration class path

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -24,6 +24,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### bugfix:
 
+- [[#8154](https://github.com/apache/incubator-seata/pull/8154)] fix SeataSagaAutoConfiguration @AutoConfigureAfter fails on Spring Boot 4.x due to hardcoded old DataSourceAutoConfiguration class path
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) fix global lock batch acquire false-failure on Dameng(DM)
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -24,6 +24,7 @@
 
 ### bugfix:
 
+- [[#8154](https://github.com/apache/incubator-seata/pull/8154)] 修复 SeataSagaAutoConfiguration 在 Spring Boot 4.x 下因硬编码旧 DataSourceAutoConfiguration 类路径导致自动配置失败的问题
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 

--- a/spring/seata-spring-boot-starter/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSagaAutoConfiguration.java
+++ b/spring/seata-spring-boot-starter/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSagaAutoConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,7 +46,9 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty({StarterConstants.SEATA_PREFIX + ".enabled", StarterConstants.SAGA_PREFIX + ".enabled"})
-@AutoConfigureAfter({DataSourceAutoConfiguration.class, SeataAutoConfiguration.class})
+@AutoConfigureAfter(value = {SeataAutoConfiguration.class},
+    name = {"org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
 public class SeataSagaAutoConfiguration {
 
     public static final String SAGA_DATA_SOURCE_BEAN_NAME = "seataSagaDataSource";


### PR DESCRIPTION
### Ⅰ. Issue Link

fix #8154

### Ⅱ. Describe what happened

In Spring Boot 4.x, `DataSourceAutoConfiguration` was moved from `org.springframework.boot.autoconfigure.jdbc` to `org.springframework.boot.jdbc.autoconfigure`. The hardcoded class reference in `SeataSagaAutoConfiguration`:

```java
@AutoConfigureAfter({DataSourceAutoConfiguration.class, SeataAutoConfiguration.class})
```

causes JVM to throw `TypeNotPresentException` when introspecting the meta-annotation at startup:

```
WARN  --- Failed to introspect meta-annotation @AutoConfigureAfter on 
SeataSagaAutoConfiguration: java.lang.TypeNotPresentException: 
Type org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration not present
```

This silently skips the entire Saga auto-configuration, making `seata.saga.enabled=true` ineffective.

### Ⅲ. How you fixed it

Replaced the hardcoded class reference with string-based class names covering both old and new paths:

```java
@AutoConfigureAfter(value = {SeataAutoConfiguration.class},
    name = {"org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"})
```

This is consistent with:
- `SeataDataSourceAutoConfiguration` (already uses string name for the same reason)
- PR #7839 (same fix for `TransactionAutoConfiguration` in `SeataSpringFenceAutoConfiguration`)

### Ⅳ. Describe how to verify it

1. Run a Spring Boot 4.x project with `seata.saga.enabled=true` and Saga auto-configuration enabled
2. Verify that `SeataSagaAutoConfiguration` loads without `TypeNotPresentException`
3. Verify backward compatibility on Spring Boot 2.x/3.x