### PR TITLE
bugfix: resolve Saga auto-configuration compatibility with Spring Boot 4.x

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -24,6 +24,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### bugfix:
 
+- [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) fix global lock batch acquire false-failure on Dameng(DM)
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -24,9 +24,9 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### bugfix:
 
-- [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
-- [#8145](https://github.com/apache/incubator-seata/pull/8145) fix global lock batch acquire false-failure on Dameng(DM)
+- [[#8145](https://github.com/apache/incubator-seata/pull/8145)] fix global lock batch acquire false-failure on Dameng(DM)
+- [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -24,9 +24,9 @@
 
 ### bugfix:
 
-- [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
+- [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -24,6 +24,7 @@
 
 ### bugfix:
 
+- [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 

--- a/spring/seata-spring-boot-starter/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSagaAutoConfiguration.java
+++ b/spring/seata-spring-boot-starter/src/main/java/org/apache/seata/spring/boot/autoconfigure/SeataSagaAutoConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,7 +46,14 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty({StarterConstants.SEATA_PREFIX + ".enabled", StarterConstants.SAGA_PREFIX + ".enabled"})
-@AutoConfigureAfter({DataSourceAutoConfiguration.class, SeataAutoConfiguration.class})
+@AutoConfigureAfter(
+        value = {SeataAutoConfiguration.class},
+        name = {
+            // Spring Boot 2.x, 3.x
+            "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+            // Spring Boot 4.x
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration"
+        })
 public class SeataSagaAutoConfiguration {
 
     public static final String SAGA_DATA_SOURCE_BEAN_NAME = "seataSagaDataSource";

--- a/spring/seata-spring-boot-starter/src/test/java/org/apache/seata/spring/boot/autoconfigure/SeataSagaAutoConfigurationTest.java
+++ b/spring/seata-spring-boot-starter/src/test/java/org/apache/seata/spring/boot/autoconfigure/SeataSagaAutoConfigurationTest.java
@@ -32,6 +32,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -44,6 +45,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -68,6 +70,11 @@ import static org.mockito.Mockito.when;
             "seata.saga.state-machine.enable-async=true"
         })
 class SeataSagaAutoConfigurationTest {
+    private static final String SPRING_BOOT_2_3_DATA_SOURCE_AUTO_CONFIGURATION =
+            "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration";
+    private static final String SPRING_BOOT_4_DATA_SOURCE_AUTO_CONFIGURATION =
+            "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration";
+
     @Autowired
     private ApplicationContext applicationContext;
 
@@ -135,5 +142,17 @@ class SeataSagaAutoConfigurationTest {
         assertThat(asyncExecutor).isNotNull();
         assertThat(rejectedExecutionHandler).isNotNull();
         assertThat(rejectedExecutionHandler).isInstanceOf(ThreadPoolExecutor.CallerRunsPolicy.class);
+    }
+
+    @Test
+    void testAutoConfigureAfterSupportsSpringBoot4DataSourceAutoConfiguration() {
+        AutoConfigureAfter autoConfigureAfter =
+                SeataSagaAutoConfiguration.class.getAnnotation(AutoConfigureAfter.class);
+
+        AssertionsForClassTypes.assertThat(autoConfigureAfter).isNotNull();
+        assertThat(autoConfigureAfter.value()).containsExactly(SeataAutoConfiguration.class);
+        assertThat(Arrays.asList(autoConfigureAfter.name()))
+                .containsExactly(
+                        SPRING_BOOT_2_3_DATA_SOURCE_AUTO_CONFIGURATION, SPRING_BOOT_4_DATA_SOURCE_AUTO_CONFIGURATION);
     }
 }


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR fixes a Spring Boot 4.x compatibility issue in `SeataSagaAutoConfiguration`.

`SeataSagaAutoConfiguration` previously used a hard class reference to `org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration` in `@AutoConfigureAfter`. On Spring Boot 4.x, `DataSourceAutoConfiguration` was moved to `org.springframework.boot.jdbc.autoconfigure`, so the old class reference could trigger `TypeNotPresentException` during meta-annotation introspection and cause the whole Saga auto-configuration to be skipped.

This PR updates the auto-configuration ordering to use string-based class names for both Spring Boot 2.x/3.x and Spring Boot 4.x, following the same compatibility pattern already used in other Seata auto-configuration classes. It also adds a regression test to verify the annotation metadata.

### Ⅱ. Does this pull request fix one issue?

fixes #8153

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

A regression test was added in `SeataSagaAutoConfigurationTest` to verify that `@AutoConfigureAfter` keeps `SeataAutoConfiguration.class` in `value()` and uses both Spring Boot 2.x/3.x and 4.x `DataSourceAutoConfiguration` class names in `name()`.

### Ⅳ. Describe how to verify it

Run:

`mvn -pl spring/seata-spring-boot-starter -am -Dtest=SeataSagaAutoConfigurationTest -DfailIfNoTests=false -Dmaven.repo.local=/private/tmp/incubator-seata-m2 test`

### Ⅴ. Special notes for reviews

I have not registered the `changes` entry yet. If this direction looks good, I can add the corresponding `changes/en-us/2.x.md` and `changes/zh-cn/2.x.md` entries before merge.