### PR TITLE
bugfix : fastjson2 JSONB concurrent ref deserialization

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -27,6 +27,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [[#8145](https://github.com/apache/incubator-seata/pull/8145)] fix global lock batch acquire false-failure on Dameng(DM)
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
+- [[#8160](https://github.com/apache/incubator-seata/pull/8160)]  fix fastjson2 JSONB concurrent ref deserialization
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,6 +27,8 @@
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
+- [[#8160](https://github.com/apache/incubator-seata/pull/8160)] 修复 fastjson2 JSONB 并发反序列化问题
+
 
 
 ### optimize:

--- a/json-common/json-common-core/src/main/java/org/apache/seata/common/json/Fastjson2ObjectReaderWarmup.java
+++ b/json-common/json-common-core/src/main/java/org/apache/seata/common/json/Fastjson2ObjectReaderWarmup.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.json;
+
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+
+import java.util.Arrays;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Initializes fastjson2 object readers before concurrent deserialization begins.
+ */
+public final class Fastjson2ObjectReaderWarmup {
+
+    private static final Lock WARMUP_LOCK = new ReentrantLock();
+
+    private Fastjson2ObjectReaderWarmup() {}
+
+    public static void warmup(Iterable<Class<?>> types) {
+        WARMUP_LOCK.lock();
+        try {
+            ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
+            for (Class<?> type : types) {
+                provider.getObjectReader(type, true);
+            }
+        } finally {
+            WARMUP_LOCK.unlock();
+        }
+    }
+
+    public static void warmup(Class<?>... types) {
+        warmup(Arrays.asList(types));
+    }
+}

--- a/json-common/json-common-core/src/test/java/org/apache/seata/common/json/Fastjson2ObjectReaderWarmupTest.java
+++ b/json-common/json-common-core/src/test/java/org/apache/seata/common/json/Fastjson2ObjectReaderWarmupTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.json;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class Fastjson2ObjectReaderWarmupTest {
+
+    @Test
+    public void warmupAcceptsIterableTypes() {
+        assertThatCode(() -> Fastjson2ObjectReaderWarmup.warmup(Arrays.<Class<?>>asList(String.class, Integer.class)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void warmupAcceptsVarargsTypes() {
+        assertThatCode(() -> Fastjson2ObjectReaderWarmup.warmup(String.class, Integer.class))
+                .doesNotThrowAnyException();
+    }
+}

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
@@ -17,6 +17,7 @@
 package org.apache.seata.rm.datasource.undo.parser;
 
 import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
 import org.apache.seata.common.executor.Initialize;
@@ -27,8 +28,6 @@ import org.apache.seata.rm.datasource.undo.UndoLogParser;
 @LoadLevel(name = Fastjson2UndoLogParser.NAME)
 public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
     public static final String NAME = "fastjson2";
-
-    private static final Object PARSE_LOCK = new Object();
 
     private JSONReader.Feature[] jsonReaderFeature;
     private JSONWriter.Feature[] jsonWriterFeature;
@@ -77,7 +76,9 @@ public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
 
     @Override
     public BranchUndoLog decode(byte[] bytes) {
-        synchronized (PARSE_LOCK) {
+        // JSONB initializes readers in the shared provider lazily. Synchronization prevents $ref fields from being lost
+        // when fastjson2 initializes readers concurrently.
+        synchronized (JSONFactory.class) {
             return JSONB.parseObject(bytes, BranchUndoLog.class, jsonReaderFeature);
         }
     }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
@@ -17,7 +17,6 @@
 package org.apache.seata.rm.datasource.undo.parser;
 
 import com.alibaba.fastjson2.JSONB;
-import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
 import org.apache.seata.common.executor.Initialize;
@@ -25,9 +24,14 @@ import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.rm.datasource.undo.BranchUndoLog;
 import org.apache.seata.rm.datasource.undo.UndoLogParser;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 @LoadLevel(name = Fastjson2UndoLogParser.NAME)
 public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
     public static final String NAME = "fastjson2";
+
+    private static final Lock PARSE_LOCK = new ReentrantLock();
 
     private JSONReader.Feature[] jsonReaderFeature;
     private JSONWriter.Feature[] jsonWriterFeature;
@@ -76,10 +80,13 @@ public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
 
     @Override
     public BranchUndoLog decode(byte[] bytes) {
-        // JSONB initializes readers in the shared provider lazily. Synchronization prevents $ref fields from being lost
+        // JSONB initializes readers in the shared provider lazily. The lock prevents $ref fields from being lost
         // when fastjson2 initializes readers concurrently.
-        synchronized (JSONFactory.class) {
+        PARSE_LOCK.lock();
+        try {
             return JSONB.parseObject(bytes, BranchUndoLog.class, jsonReaderFeature);
+        } finally {
+            PARSE_LOCK.unlock();
         }
     }
 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
@@ -28,6 +28,8 @@ import org.apache.seata.rm.datasource.undo.UndoLogParser;
 public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
     public static final String NAME = "fastjson2";
 
+    private static final Object PARSE_LOCK = new Object();
+
     private JSONReader.Feature[] jsonReaderFeature;
     private JSONWriter.Feature[] jsonWriterFeature;
 
@@ -75,6 +77,8 @@ public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
 
     @Override
     public BranchUndoLog decode(byte[] bytes) {
-        return JSONB.parseObject(bytes, BranchUndoLog.class, jsonReaderFeature);
+        synchronized (PARSE_LOCK) {
+            return JSONB.parseObject(bytes, BranchUndoLog.class, jsonReaderFeature);
+        }
     }
 }

--- a/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
+++ b/rm-datasource/src/main/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2UndoLogParser.java
@@ -20,18 +20,21 @@ import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
 import org.apache.seata.common.executor.Initialize;
+import org.apache.seata.common.json.Fastjson2ObjectReaderWarmup;
 import org.apache.seata.common.loader.LoadLevel;
+import org.apache.seata.rm.datasource.sql.struct.Field;
+import org.apache.seata.rm.datasource.sql.struct.Row;
+import org.apache.seata.rm.datasource.sql.struct.TableRecords;
 import org.apache.seata.rm.datasource.undo.BranchUndoLog;
+import org.apache.seata.rm.datasource.undo.SQLUndoLog;
 import org.apache.seata.rm.datasource.undo.UndoLogParser;
+import org.apache.seata.sqlparser.SQLType;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.ArrayList;
 
 @LoadLevel(name = Fastjson2UndoLogParser.NAME)
 public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
     public static final String NAME = "fastjson2";
-
-    private static final Lock PARSE_LOCK = new ReentrantLock();
 
     private JSONReader.Feature[] jsonReaderFeature;
     private JSONWriter.Feature[] jsonWriterFeature;
@@ -59,6 +62,16 @@ public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
             JSONWriter.Feature.WriteNameAsSymbol
         };
 
+        Fastjson2ObjectReaderWarmup.warmup(
+                Object.class,
+                ArrayList.class,
+                BranchUndoLog.class,
+                SQLUndoLog.class,
+                SQLType.class,
+                TableRecords.class,
+                Row.class,
+                Field.class);
+
         // SerialArray support: Fastjson2 with FieldBased and SupportAutoType features
         // can handle SerialArray serialization automatically through field access
     }
@@ -80,13 +93,6 @@ public class Fastjson2UndoLogParser implements UndoLogParser, Initialize {
 
     @Override
     public BranchUndoLog decode(byte[] bytes) {
-        // JSONB initializes readers in the shared provider lazily. The lock prevents $ref fields from being lost
-        // when fastjson2 initializes readers concurrently.
-        PARSE_LOCK.lock();
-        try {
-            return JSONB.parseObject(bytes, BranchUndoLog.class, jsonReaderFeature);
-        } finally {
-            PARSE_LOCK.unlock();
-        }
+        return JSONB.parseObject(bytes, BranchUndoLog.class, jsonReaderFeature);
     }
 }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2ConcurrentRefDeserializationTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2ConcurrentRefDeserializationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.rm.datasource.undo.parser;
+
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.rm.datasource.sql.struct.Field;
+import org.apache.seata.rm.datasource.sql.struct.Row;
+import org.apache.seata.rm.datasource.sql.struct.TableRecords;
+import org.apache.seata.rm.datasource.undo.BranchUndoLog;
+import org.apache.seata.rm.datasource.undo.SQLUndoLog;
+import org.apache.seata.rm.datasource.undo.UndoLogParser;
+import org.apache.seata.sqlparser.SQLType;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Fastjson2ConcurrentRefDeserializationTest {
+
+    private static final String ENABLE_STRESS_TEST_PROPERTY = "seata.fastjson2.concurrentRef";
+
+    private final Fastjson2UndoLogParser parser =
+            (Fastjson2UndoLogParser) EnhancedServiceLoader.load(UndoLogParser.class, Fastjson2UndoLogParser.NAME);
+
+    @Test
+    public void deserializeReferenceHeavyUndoLogDoesNotDropRefFields() {
+        byte[] bytes = parser.encode(referenceHeavyUndoLog());
+
+        assertThat(countNullRefFields(parser.decode(bytes))).isZero();
+    }
+
+    @Test
+    public void concurrentDeserializeReferenceHeavyUndoLogDoesNotDropRefFields() throws Exception {
+        Assumptions.assumeTrue(
+                Boolean.getBoolean(ENABLE_STRESS_TEST_PROPERTY),
+                "set -D" + ENABLE_STRESS_TEST_PROPERTY + "=true to run the concurrent test");
+
+        byte[] bytes = parser.encode(referenceHeavyUndoLog());
+        assertThat(countNullRefFields(parser.decode(bytes))).isZero();
+
+        int nullTasks = runConcurrentStress(() -> countNullRefFields(parser.decode(bytes)));
+
+        assertThat(nullTasks).isZero();
+    }
+
+    private static BranchUndoLog referenceHeavyUndoLog() {
+        BranchUndoLog branchUndoLog = new BranchUndoLog();
+        branchUndoLog.setXid("127.0.0.1:8091:123456");
+        branchUndoLog.setBranchId(123456L);
+
+        TableRecords sharedImage = tableRecords();
+        List<SQLUndoLog> sqlUndoLogs = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            SQLUndoLog sqlUndoLog = new SQLUndoLog();
+            sqlUndoLog.setSqlType(SQLType.UPDATE);
+            sqlUndoLog.setTableName("ref_test");
+            sqlUndoLog.setBeforeImage(sharedImage);
+            sqlUndoLog.setAfterImage(sharedImage);
+            sqlUndoLogs.add(sqlUndoLog);
+        }
+        branchUndoLog.setSqlUndoLogs(sqlUndoLogs);
+        return branchUndoLog;
+    }
+
+    private static TableRecords tableRecords() {
+        TableRecords tableRecords = new TableRecords();
+        tableRecords.setTableName("ref_test");
+        List<Row> rows = new ArrayList<>();
+        Row row = new Row();
+        row.add(new Field("id", Types.INTEGER, 1));
+        row.add(new Field("name", Types.VARCHAR, "seata"));
+        rows.add(row);
+        tableRecords.setRows(rows);
+        return tableRecords;
+    }
+
+    private static int countNullRefFields(BranchUndoLog branchUndoLog) {
+        if (branchUndoLog == null || branchUndoLog.getSqlUndoLogs() == null) {
+            return 1;
+        }
+        int nullCount = 0;
+        for (SQLUndoLog sqlUndoLog : branchUndoLog.getSqlUndoLogs()) {
+            if (sqlUndoLog == null) {
+                nullCount++;
+                continue;
+            }
+            if (sqlUndoLog.getBeforeImage() == null
+                    || sqlUndoLog.getBeforeImage().getRows() == null) {
+                nullCount++;
+            }
+            if (sqlUndoLog.getAfterImage() == null || sqlUndoLog.getAfterImage().getRows() == null) {
+                nullCount++;
+            }
+        }
+        return nullCount;
+    }
+
+    private static int runConcurrentStress(NullCounter nullCounter) throws Exception {
+        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 10);
+        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 200);
+        AtomicInteger totalNullTasks = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        for (int round = 0; round < rounds; round++) {
+            clearObjectReaderCache();
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            AtomicInteger roundNullTasks = new AtomicInteger();
+            for (int i = 0; i < threadCount; i++) {
+                Thread thread = new Thread(
+                        () -> {
+                            try {
+                                barrier.await();
+                                if (nullCounter.countNulls() > 0) {
+                                    roundNullTasks.incrementAndGet();
+                                }
+                            } catch (Throwable throwable) {
+                                failure.compareAndSet(null, throwable);
+                            } finally {
+                                endLatch.countDown();
+                            }
+                        },
+                        "fastjson2-undolog-ref-" + i);
+                thread.start();
+            }
+            endLatch.await();
+            if (failure.get() != null) {
+                throw new AssertionError("Concurrent deserialization failed", failure.get());
+            }
+            totalNullTasks.addAndGet(roundNullTasks.get());
+        }
+
+        return totalNullTasks.get();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearObjectReaderCache() throws Exception {
+        ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
+        for (String fieldName : new String[] {"cache", "cacheFieldBased"}) {
+            java.lang.reflect.Field field = ObjectReaderProvider.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object cache = field.get(provider);
+            if (cache instanceof Map) {
+                ((Map<?, ?>) cache).clear();
+            }
+        }
+
+        try {
+            java.lang.reflect.Field readerCacheField = ObjectReaderProvider.class.getDeclaredField("readerCache");
+            readerCacheField.setAccessible(true);
+            readerCacheField.set(null, null);
+        } catch (NoSuchFieldException ignored) {
+            // fastjson2 versions differ in internal cache fields.
+        }
+    }
+
+    private interface NullCounter {
+        int countNulls() throws Exception;
+    }
+}

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2ConcurrentRefDeserializationTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2ConcurrentRefDeserializationTest.java
@@ -26,7 +26,6 @@ import org.apache.seata.rm.datasource.undo.BranchUndoLog;
 import org.apache.seata.rm.datasource.undo.SQLUndoLog;
 import org.apache.seata.rm.datasource.undo.UndoLogParser;
 import org.apache.seata.sqlparser.SQLType;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
@@ -35,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class Fastjson2ConcurrentRefDeserializationTest {
 
-    private static final String ENABLE_STRESS_TEST_PROPERTY = "seata.fastjson2.concurrentRef";
+    private static final long CONCURRENT_TEST_TIMEOUT_SECONDS = 30;
 
     private final Fastjson2UndoLogParser parser =
             (Fastjson2UndoLogParser) EnhancedServiceLoader.load(UndoLogParser.class, Fastjson2UndoLogParser.NAME);
@@ -56,10 +56,6 @@ public class Fastjson2ConcurrentRefDeserializationTest {
 
     @Test
     public void concurrentDeserializeReferenceHeavyUndoLogDoesNotDropRefFields() throws Exception {
-        Assumptions.assumeTrue(
-                Boolean.getBoolean(ENABLE_STRESS_TEST_PROPERTY),
-                "set -D" + ENABLE_STRESS_TEST_PROPERTY + "=true to run the concurrent test");
-
         byte[] bytes = parser.encode(referenceHeavyUndoLog());
         assertThat(countNullRefFields(parser.decode(bytes))).isZero();
 
@@ -121,8 +117,8 @@ public class Fastjson2ConcurrentRefDeserializationTest {
     }
 
     private static int runConcurrentStress(NullCounter nullCounter) throws Exception {
-        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 10);
-        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 200);
+        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 3);
+        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 50);
         AtomicInteger totalNullTasks = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
@@ -135,7 +131,7 @@ public class Fastjson2ConcurrentRefDeserializationTest {
                 Thread thread = new Thread(
                         () -> {
                             try {
-                                barrier.await();
+                                barrier.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                                 if (nullCounter.countNulls() > 0) {
                                     roundNullTasks.incrementAndGet();
                                 }
@@ -148,7 +144,9 @@ public class Fastjson2ConcurrentRefDeserializationTest {
                         "fastjson2-undolog-ref-" + i);
                 thread.start();
             }
-            endLatch.await();
+            if (!endLatch.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new AssertionError("Timed out waiting for concurrent deserialization");
+            }
             if (failure.get() != null) {
                 throw new AssertionError("Concurrent deserialization failed", failure.get());
             }

--- a/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2ConcurrentRefDeserializationTest.java
+++ b/rm-datasource/src/test/java/org/apache/seata/rm/datasource/undo/parser/Fastjson2ConcurrentRefDeserializationTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.seata.rm.datasource.undo.parser;
 
-import com.alibaba.fastjson2.JSONFactory;
-import com.alibaba.fastjson2.reader.ObjectReaderProvider;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.rm.datasource.sql.struct.Field;
 import org.apache.seata.rm.datasource.sql.struct.Row;
@@ -28,40 +26,39 @@ import org.apache.seata.rm.datasource.undo.UndoLogParser;
 import org.apache.seata.sqlparser.SQLType;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class Fastjson2ConcurrentRefDeserializationTest {
 
     private static final long CONCURRENT_TEST_TIMEOUT_SECONDS = 30;
 
-    private final Fastjson2UndoLogParser parser =
-            (Fastjson2UndoLogParser) EnhancedServiceLoader.load(UndoLogParser.class, Fastjson2UndoLogParser.NAME);
-
-    @Test
-    public void deserializeReferenceHeavyUndoLogDoesNotDropRefFields() {
-        byte[] bytes = parser.encode(referenceHeavyUndoLog());
-
-        assertThat(countNullRefFields(parser.decode(bytes))).isZero();
-    }
-
     @Test
     public void concurrentDeserializeReferenceHeavyUndoLogDoesNotDropRefFields() throws Exception {
+        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 3);
+        for (int round = 0; round < rounds; round++) {
+            assertChildProcessSucceeds();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Fastjson2UndoLogParser parser =
+                (Fastjson2UndoLogParser) EnhancedServiceLoader.load(UndoLogParser.class, Fastjson2UndoLogParser.NAME);
         byte[] bytes = parser.encode(referenceHeavyUndoLog());
-        assertThat(countNullRefFields(parser.decode(bytes))).isZero();
 
-        int nullTasks = runConcurrentStress(() -> countNullRefFields(parser.decode(bytes)));
-
-        assertThat(nullTasks).isZero();
+        int nullTasks =
+                runConcurrentStress(parser, bytes, Integer.getInteger("seata.fastjson2.concurrentRef.threads", 200));
+        if (nullTasks > 0) {
+            throw new AssertionError("Concurrent deserialization dropped $ref fields: " + nullTasks);
+        }
     }
 
     private static BranchUndoLog referenceHeavyUndoLog() {
@@ -116,68 +113,64 @@ public class Fastjson2ConcurrentRefDeserializationTest {
         return nullCount;
     }
 
-    private static int runConcurrentStress(NullCounter nullCounter) throws Exception {
-        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 3);
-        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 50);
-        AtomicInteger totalNullTasks = new AtomicInteger();
+    private static int runConcurrentStress(Fastjson2UndoLogParser parser, byte[] bytes, int threadCount)
+            throws Exception {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        for (int round = 0; round < rounds; round++) {
-            clearObjectReaderCache();
-            CyclicBarrier barrier = new CyclicBarrier(threadCount);
-            CountDownLatch endLatch = new CountDownLatch(threadCount);
-            AtomicInteger roundNullTasks = new AtomicInteger();
-            for (int i = 0; i < threadCount; i++) {
-                Thread thread = new Thread(
-                        () -> {
-                            try {
-                                barrier.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                                if (nullCounter.countNulls() > 0) {
-                                    roundNullTasks.incrementAndGet();
-                                }
-                            } catch (Throwable throwable) {
-                                failure.compareAndSet(null, throwable);
-                            } finally {
-                                endLatch.countDown();
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger nullTasks = new AtomicInteger();
+        for (int i = 0; i < threadCount; i++) {
+            Thread thread = new Thread(
+                    () -> {
+                        try {
+                            barrier.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                            if (countNullRefFields(parser.decode(bytes)) > 0) {
+                                nullTasks.incrementAndGet();
                             }
-                        },
-                        "fastjson2-undolog-ref-" + i);
-                thread.start();
-            }
-            if (!endLatch.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                throw new AssertionError("Timed out waiting for concurrent deserialization");
-            }
-            if (failure.get() != null) {
-                throw new AssertionError("Concurrent deserialization failed", failure.get());
-            }
-            totalNullTasks.addAndGet(roundNullTasks.get());
+                        } catch (Throwable throwable) {
+                            failure.compareAndSet(null, throwable);
+                        } finally {
+                            endLatch.countDown();
+                        }
+                    },
+                    "fastjson2-undolog-ref-" + i);
+            thread.start();
+        }
+        if (!endLatch.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            throw new AssertionError("Timed out waiting for concurrent deserialization");
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent deserialization failed", failure.get());
         }
 
-        return totalNullTasks.get();
+        return nullTasks.get();
     }
 
-    @SuppressWarnings("unchecked")
-    private static void clearObjectReaderCache() throws Exception {
-        ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
-        for (String fieldName : new String[] {"cache", "cacheFieldBased"}) {
-            java.lang.reflect.Field field = ObjectReaderProvider.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            Object cache = field.get(provider);
-            if (cache instanceof Map) {
-                ((Map<?, ?>) cache).clear();
-            }
+    private static void assertChildProcessSucceeds() throws Exception {
+        Process process = new ProcessBuilder(
+                        System.getProperty("java.home") + "/bin/java",
+                        "-cp",
+                        System.getProperty("java.class.path"),
+                        Fastjson2ConcurrentRefDeserializationTest.class.getName())
+                .redirectErrorStream(true)
+                .start();
+        if (!process.waitFor(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            throw new AssertionError("Timed out waiting for child process");
         }
-
-        try {
-            java.lang.reflect.Field readerCacheField = ObjectReaderProvider.class.getDeclaredField("readerCache");
-            readerCacheField.setAccessible(true);
-            readerCacheField.set(null, null);
-        } catch (NoSuchFieldException ignored) {
-            // fastjson2 versions differ in internal cache fields.
+        if (process.exitValue() != 0) {
+            throw new AssertionError("Child process failed: " + readOutput(process.getInputStream()));
         }
     }
 
-    private interface NullCounter {
-        int countNulls() throws Exception;
+    private static String readOutput(InputStream inputStream) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = inputStream.read(buffer)) != -1) {
+            output.write(buffer, 0, length);
+        }
+        return output.toString("UTF-8");
     }
 }

--- a/serializer/seata-serializer-fastjson2/pom.xml
+++ b/serializer/seata-serializer-fastjson2/pom.xml
@@ -43,6 +43,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>json-common-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba.fastjson2</groupId>
             <artifactId>fastjson2</artifactId>
         </dependency>

--- a/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
+++ b/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
@@ -23,6 +23,8 @@ import org.apache.seata.core.serializer.Serializer;
 @LoadLevel(name = "FASTJSON2")
 public class Fastjson2Serializer implements Serializer {
 
+    private static final Object PARSE_LOCK = new Object();
+
     @Override
     public <T> byte[] serialize(T t) {
         return JSONB.toBytes(t, Fastjson2SerializerFactory.getInstance().getJsonWriterFeatureList());
@@ -30,10 +32,12 @@ public class Fastjson2Serializer implements Serializer {
 
     @Override
     public <T> T deserialize(byte[] bytes) {
-        return (T) JSONB.parseObject(
-                bytes,
-                Object.class,
-                Fastjson2SerializerFactory.getInstance().getFilter(),
-                Fastjson2SerializerFactory.getInstance().getJsonReaderFeatureList());
+        synchronized (PARSE_LOCK) {
+            return (T) JSONB.parseObject(
+                    bytes,
+                    Object.class,
+                    Fastjson2SerializerFactory.getInstance().getFilter(),
+                    Fastjson2SerializerFactory.getInstance().getJsonReaderFeatureList());
+        }
     }
 }

--- a/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
+++ b/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
@@ -17,12 +17,16 @@
 package org.apache.seata.serializer.fastjson2;
 
 import com.alibaba.fastjson2.JSONB;
-import com.alibaba.fastjson2.JSONFactory;
 import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.core.serializer.Serializer;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 @LoadLevel(name = "FASTJSON2")
 public class Fastjson2Serializer implements Serializer {
+
+    private static final Lock PARSE_LOCK = new ReentrantLock();
 
     @Override
     public <T> byte[] serialize(T t) {
@@ -31,14 +35,17 @@ public class Fastjson2Serializer implements Serializer {
 
     @Override
     public <T> T deserialize(byte[] bytes) {
-        // JSONB initializes readers in the shared provider lazily. Synchronization prevents $ref fields from being lost
+        // JSONB initializes readers in the shared provider lazily. The lock prevents $ref fields from being lost
         // when fastjson2 initializes readers concurrently.
-        synchronized (JSONFactory.class) {
+        PARSE_LOCK.lock();
+        try {
             return (T) JSONB.parseObject(
                     bytes,
                     Object.class,
                     Fastjson2SerializerFactory.getInstance().getFilter(),
                     Fastjson2SerializerFactory.getInstance().getJsonReaderFeatureList());
+        } finally {
+            PARSE_LOCK.unlock();
         }
     }
 }

--- a/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
+++ b/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
@@ -17,16 +17,19 @@
 package org.apache.seata.serializer.fastjson2;
 
 import com.alibaba.fastjson2.JSONB;
+import org.apache.seata.common.executor.Initialize;
+import org.apache.seata.common.json.Fastjson2ObjectReaderWarmup;
 import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.core.serializer.Serializer;
-
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import org.apache.seata.core.serializer.SerializerSecurityRegistry;
 
 @LoadLevel(name = "FASTJSON2")
-public class Fastjson2Serializer implements Serializer {
+public class Fastjson2Serializer implements Serializer, Initialize {
 
-    private static final Lock PARSE_LOCK = new ReentrantLock();
+    @Override
+    public void init() {
+        Fastjson2ObjectReaderWarmup.warmup(SerializerSecurityRegistry.getAllowClassType());
+    }
 
     @Override
     public <T> byte[] serialize(T t) {
@@ -35,17 +38,10 @@ public class Fastjson2Serializer implements Serializer {
 
     @Override
     public <T> T deserialize(byte[] bytes) {
-        // JSONB initializes readers in the shared provider lazily. The lock prevents $ref fields from being lost
-        // when fastjson2 initializes readers concurrently.
-        PARSE_LOCK.lock();
-        try {
-            return (T) JSONB.parseObject(
-                    bytes,
-                    Object.class,
-                    Fastjson2SerializerFactory.getInstance().getFilter(),
-                    Fastjson2SerializerFactory.getInstance().getJsonReaderFeatureList());
-        } finally {
-            PARSE_LOCK.unlock();
-        }
+        return (T) JSONB.parseObject(
+                bytes,
+                Object.class,
+                Fastjson2SerializerFactory.getInstance().getFilter(),
+                Fastjson2SerializerFactory.getInstance().getJsonReaderFeatureList());
     }
 }

--- a/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
+++ b/serializer/seata-serializer-fastjson2/src/main/java/org.apache.seata.serializer.fastjson2/Fastjson2Serializer.java
@@ -17,13 +17,12 @@
 package org.apache.seata.serializer.fastjson2;
 
 import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONFactory;
 import org.apache.seata.common.loader.LoadLevel;
 import org.apache.seata.core.serializer.Serializer;
 
 @LoadLevel(name = "FASTJSON2")
 public class Fastjson2Serializer implements Serializer {
-
-    private static final Object PARSE_LOCK = new Object();
 
     @Override
     public <T> byte[] serialize(T t) {
@@ -32,7 +31,9 @@ public class Fastjson2Serializer implements Serializer {
 
     @Override
     public <T> T deserialize(byte[] bytes) {
-        synchronized (PARSE_LOCK) {
+        // JSONB initializes readers in the shared provider lazily. Synchronization prevents $ref fields from being lost
+        // when fastjson2 initializes readers concurrently.
+        synchronized (JSONFactory.class) {
             return (T) JSONB.parseObject(
                     bytes,
                     Object.class,

--- a/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2ConcurrentRefDeserializationTest.java
+++ b/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2ConcurrentRefDeserializationTest.java
@@ -16,46 +16,44 @@
  */
 package org.apache.seata.serializer.fastjson2;
 
-import com.alibaba.fastjson2.JSONFactory;
-import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import org.apache.seata.common.executor.Initialize;
 import org.apache.seata.core.protocol.AbstractMessage;
 import org.apache.seata.core.protocol.BatchResultMessage;
 import org.apache.seata.core.protocol.MergedWarpMessage;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class Fastjson2ConcurrentRefDeserializationTest {
 
     private static final long CONCURRENT_TEST_TIMEOUT_SECONDS = 30;
 
-    private final Fastjson2Serializer serializer = new Fastjson2Serializer();
-
-    @Test
-    public void deserializeReferenceHeavyProtocolMessageDoesNotDropRefFields() {
-        byte[] bytes = serializer.serialize(referenceHeavyMessage());
-
-        assertThat(countNullRefFields(serializer.deserialize(bytes))).isZero();
-    }
-
     @Test
     public void concurrentDeserializeReferenceHeavyProtocolMessageDoesNotDropRefFields() throws Exception {
+        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 3);
+        for (int round = 0; round < rounds; round++) {
+            assertChildProcessSucceeds();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Fastjson2Serializer serializer = new Fastjson2Serializer();
+        ((Initialize) serializer).init();
         byte[] bytes = serializer.serialize(referenceHeavyMessage());
-        assertThat(countNullRefFields(serializer.deserialize(bytes))).isZero();
 
-        int nullTasks = runConcurrentStress(() -> countNullRefFields(serializer.deserialize(bytes)));
-
-        assertThat(nullTasks).isZero();
+        int nullTasks = runConcurrentStress(
+                serializer, bytes, Integer.getInteger("seata.fastjson2.concurrentRef.threads", 200));
+        if (nullTasks > 0) {
+            throw new AssertionError("Concurrent deserialization dropped $ref fields: " + nullTasks);
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -93,68 +91,64 @@ public class Fastjson2ConcurrentRefDeserializationTest {
         return nullCount;
     }
 
-    private static int runConcurrentStress(NullCounter nullCounter) throws Exception {
-        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 3);
-        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 50);
-        AtomicInteger totalNullTasks = new AtomicInteger();
+    private static int runConcurrentStress(Fastjson2Serializer serializer, byte[] bytes, int threadCount)
+            throws Exception {
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
-        for (int round = 0; round < rounds; round++) {
-            clearObjectReaderCache();
-            CyclicBarrier barrier = new CyclicBarrier(threadCount);
-            CountDownLatch endLatch = new CountDownLatch(threadCount);
-            AtomicInteger roundNullTasks = new AtomicInteger();
-            for (int i = 0; i < threadCount; i++) {
-                Thread thread = new Thread(
-                        () -> {
-                            try {
-                                barrier.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                                if (nullCounter.countNulls() > 0) {
-                                    roundNullTasks.incrementAndGet();
-                                }
-                            } catch (Throwable throwable) {
-                                failure.compareAndSet(null, throwable);
-                            } finally {
-                                endLatch.countDown();
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger nullTasks = new AtomicInteger();
+        for (int i = 0; i < threadCount; i++) {
+            Thread thread = new Thread(
+                    () -> {
+                        try {
+                            barrier.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                            if (countNullRefFields((MergedWarpMessage) serializer.deserialize(bytes)) > 0) {
+                                nullTasks.incrementAndGet();
                             }
-                        },
-                        "fastjson2-rpc-ref-" + i);
-                thread.start();
-            }
-            if (!endLatch.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                throw new AssertionError("Timed out waiting for concurrent deserialization");
-            }
-            if (failure.get() != null) {
-                throw new AssertionError("Concurrent deserialization failed", failure.get());
-            }
-            totalNullTasks.addAndGet(roundNullTasks.get());
+                        } catch (Throwable throwable) {
+                            failure.compareAndSet(null, throwable);
+                        } finally {
+                            endLatch.countDown();
+                        }
+                    },
+                    "fastjson2-rpc-ref-" + i);
+            thread.start();
+        }
+        if (!endLatch.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            throw new AssertionError("Timed out waiting for concurrent deserialization");
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent deserialization failed", failure.get());
         }
 
-        return totalNullTasks.get();
+        return nullTasks.get();
     }
 
-    @SuppressWarnings("unchecked")
-    private static void clearObjectReaderCache() throws Exception {
-        ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
-        for (String fieldName : new String[] {"cache", "cacheFieldBased"}) {
-            Field field = ObjectReaderProvider.class.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            Object cache = field.get(provider);
-            if (cache instanceof Map) {
-                ((Map<?, ?>) cache).clear();
-            }
+    private static void assertChildProcessSucceeds() throws Exception {
+        Process process = new ProcessBuilder(
+                        System.getProperty("java.home") + "/bin/java",
+                        "-cp",
+                        System.getProperty("java.class.path"),
+                        Fastjson2ConcurrentRefDeserializationTest.class.getName())
+                .redirectErrorStream(true)
+                .start();
+        if (!process.waitFor(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            throw new AssertionError("Timed out waiting for child process");
         }
-
-        try {
-            Field readerCacheField = ObjectReaderProvider.class.getDeclaredField("readerCache");
-            readerCacheField.setAccessible(true);
-            readerCacheField.set(null, null);
-        } catch (NoSuchFieldException ignored) {
-            // fastjson2 versions differ in internal cache fields.
+        if (process.exitValue() != 0) {
+            throw new AssertionError("Child process failed: " + readOutput(process.getInputStream()));
         }
     }
 
-    private interface NullCounter {
-        int countNulls() throws Exception;
+    private static String readOutput(InputStream inputStream) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = inputStream.read(buffer)) != -1) {
+            output.write(buffer, 0, length);
+        }
+        return output.toString("UTF-8");
     }
 }

--- a/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2ConcurrentRefDeserializationTest.java
+++ b/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2ConcurrentRefDeserializationTest.java
@@ -21,7 +21,6 @@ import com.alibaba.fastjson2.reader.ObjectReaderProvider;
 import org.apache.seata.core.protocol.AbstractMessage;
 import org.apache.seata.core.protocol.BatchResultMessage;
 import org.apache.seata.core.protocol.MergedWarpMessage;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class Fastjson2ConcurrentRefDeserializationTest {
 
-    private static final String ENABLE_STRESS_TEST_PROPERTY = "seata.fastjson2.concurrentRef";
+    private static final long CONCURRENT_TEST_TIMEOUT_SECONDS = 30;
 
     private final Fastjson2Serializer serializer = new Fastjson2Serializer();
 
@@ -50,10 +50,6 @@ public class Fastjson2ConcurrentRefDeserializationTest {
 
     @Test
     public void concurrentDeserializeReferenceHeavyProtocolMessageDoesNotDropRefFields() throws Exception {
-        Assumptions.assumeTrue(
-                Boolean.getBoolean(ENABLE_STRESS_TEST_PROPERTY),
-                "set -D" + ENABLE_STRESS_TEST_PROPERTY + "=true to run the concurrent test");
-
         byte[] bytes = serializer.serialize(referenceHeavyMessage());
         assertThat(countNullRefFields(serializer.deserialize(bytes))).isZero();
 
@@ -98,8 +94,8 @@ public class Fastjson2ConcurrentRefDeserializationTest {
     }
 
     private static int runConcurrentStress(NullCounter nullCounter) throws Exception {
-        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 10);
-        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 200);
+        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 3);
+        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 50);
         AtomicInteger totalNullTasks = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
 
@@ -112,7 +108,7 @@ public class Fastjson2ConcurrentRefDeserializationTest {
                 Thread thread = new Thread(
                         () -> {
                             try {
-                                barrier.await();
+                                barrier.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                                 if (nullCounter.countNulls() > 0) {
                                     roundNullTasks.incrementAndGet();
                                 }
@@ -125,7 +121,9 @@ public class Fastjson2ConcurrentRefDeserializationTest {
                         "fastjson2-rpc-ref-" + i);
                 thread.start();
             }
-            endLatch.await();
+            if (!endLatch.await(CONCURRENT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new AssertionError("Timed out waiting for concurrent deserialization");
+            }
             if (failure.get() != null) {
                 throw new AssertionError("Concurrent deserialization failed", failure.get());
             }

--- a/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2ConcurrentRefDeserializationTest.java
+++ b/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2ConcurrentRefDeserializationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.serializer.fastjson2;
+
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import org.apache.seata.core.protocol.AbstractMessage;
+import org.apache.seata.core.protocol.BatchResultMessage;
+import org.apache.seata.core.protocol.MergedWarpMessage;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Fastjson2ConcurrentRefDeserializationTest {
+
+    private static final String ENABLE_STRESS_TEST_PROPERTY = "seata.fastjson2.concurrentRef";
+
+    private final Fastjson2Serializer serializer = new Fastjson2Serializer();
+
+    @Test
+    public void deserializeReferenceHeavyProtocolMessageDoesNotDropRefFields() {
+        byte[] bytes = serializer.serialize(referenceHeavyMessage());
+
+        assertThat(countNullRefFields(serializer.deserialize(bytes))).isZero();
+    }
+
+    @Test
+    public void concurrentDeserializeReferenceHeavyProtocolMessageDoesNotDropRefFields() throws Exception {
+        Assumptions.assumeTrue(
+                Boolean.getBoolean(ENABLE_STRESS_TEST_PROPERTY),
+                "set -D" + ENABLE_STRESS_TEST_PROPERTY + "=true to run the concurrent test");
+
+        byte[] bytes = serializer.serialize(referenceHeavyMessage());
+        assertThat(countNullRefFields(serializer.deserialize(bytes))).isZero();
+
+        int nullTasks = runConcurrentStress(() -> countNullRefFields(serializer.deserialize(bytes)));
+
+        assertThat(nullTasks).isZero();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static MergedWarpMessage referenceHeavyMessage() {
+        MergedWarpMessage message = new MergedWarpMessage();
+        List sharedList = new ArrayList();
+        for (int i = 0; i < 20; i++) {
+            BatchResultMessage resultMessage = new BatchResultMessage();
+            resultMessage.setResultMessages(sharedList);
+            resultMessage.setMsgIds(sharedList);
+            message.msgs.add(resultMessage);
+            message.msgIds.add(i);
+        }
+        return message;
+    }
+
+    private static int countNullRefFields(MergedWarpMessage message) {
+        if (message == null || message.msgs == null) {
+            return 1;
+        }
+        int nullCount = 0;
+        for (AbstractMessage child : message.msgs) {
+            if (!(child instanceof BatchResultMessage)) {
+                nullCount++;
+                continue;
+            }
+            BatchResultMessage batchResult = (BatchResultMessage) child;
+            if (batchResult.getResultMessages() == null) {
+                nullCount++;
+            }
+            if (batchResult.getMsgIds() == null) {
+                nullCount++;
+            }
+        }
+        return nullCount;
+    }
+
+    private static int runConcurrentStress(NullCounter nullCounter) throws Exception {
+        int rounds = Integer.getInteger("seata.fastjson2.concurrentRef.rounds", 10);
+        int threadCount = Integer.getInteger("seata.fastjson2.concurrentRef.threads", 200);
+        AtomicInteger totalNullTasks = new AtomicInteger();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        for (int round = 0; round < rounds; round++) {
+            clearObjectReaderCache();
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            CountDownLatch endLatch = new CountDownLatch(threadCount);
+            AtomicInteger roundNullTasks = new AtomicInteger();
+            for (int i = 0; i < threadCount; i++) {
+                Thread thread = new Thread(
+                        () -> {
+                            try {
+                                barrier.await();
+                                if (nullCounter.countNulls() > 0) {
+                                    roundNullTasks.incrementAndGet();
+                                }
+                            } catch (Throwable throwable) {
+                                failure.compareAndSet(null, throwable);
+                            } finally {
+                                endLatch.countDown();
+                            }
+                        },
+                        "fastjson2-rpc-ref-" + i);
+                thread.start();
+            }
+            endLatch.await();
+            if (failure.get() != null) {
+                throw new AssertionError("Concurrent deserialization failed", failure.get());
+            }
+            totalNullTasks.addAndGet(roundNullTasks.get());
+        }
+
+        return totalNullTasks.get();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearObjectReaderCache() throws Exception {
+        ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
+        for (String fieldName : new String[] {"cache", "cacheFieldBased"}) {
+            Field field = ObjectReaderProvider.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object cache = field.get(provider);
+            if (cache instanceof Map) {
+                ((Map<?, ?>) cache).clear();
+            }
+        }
+
+        try {
+            Field readerCacheField = ObjectReaderProvider.class.getDeclaredField("readerCache");
+            readerCacheField.setAccessible(true);
+            readerCacheField.set(null, null);
+        } catch (NoSuchFieldException ignored) {
+            // fastjson2 versions differ in internal cache fields.
+        }
+    }
+
+    private interface NullCounter {
+        int countNulls() throws Exception;
+    }
+}

--- a/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2SerializerTest.java
+++ b/serializer/seata-serializer-fastjson2/src/test/java/org/apache/seata/serializer/fastjson2/Fastjson2SerializerTest.java
@@ -34,6 +34,7 @@ public class Fastjson2SerializerTest {
     @BeforeAll
     public static void before() {
         fastjson2Serializer = new Fastjson2Serializer();
+        fastjson2Serializer.init();
     }
 
     @Test


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR fixes a fastjson2 JSONB deserialization issue where reference-heavy payloads may lose `$ref` fields under concurrent deserialization.

The affected paths are:

- `seata-serializer-fastjson2`
- `Fastjson2UndoLogParser`

Both paths enable `JSONWriter.Feature.ReferenceDetection` and deserialize through `JSONB.parseObject(...)`. This PR synchronizes the JSONB parse section to avoid concurrent fastjson2 reader initialization causing referenced fields to be restored as `null`.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #8159

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

