### PR TITLE
bugfix: fix xid carrying the host name when SEATA_IP is set to a host name

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -27,6 +27,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [[#8145](https://github.com/apache/incubator-seata/pull/8145)] fix global lock batch acquire false-failure on Dameng(DM)
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
+- [[#8159](https://github.com/apache/incubator-seata/pull/8159)] fix xid carrying the host name instead of the ip address when `SEATA_IP` is set to a host name
 
 
 

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -27,7 +27,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [[#8145](https://github.com/apache/incubator-seata/pull/8145)] fix global lock batch acquire false-failure on Dameng(DM)
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
-- [[#8159](https://github.com/apache/incubator-seata/pull/8159)] fix xid carrying the host name instead of the ip address when `SEATA_IP` is set to a host name
+- [[#8167](https://github.com/apache/incubator-seata/pull/8167)] fix xid carrying the host name instead of the ip address when `SEATA_IP` is set to a host name
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,7 +27,7 @@
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
-- [[#8159](https://github.com/apache/incubator-seata/pull/8159)] 修复 `SEATA_IP` 配置为域名时 xid 中携带域名而非 IP 的问题
+- [[#8167](https://github.com/apache/incubator-seata/pull/8167)] 修复 `SEATA_IP` 配置为域名时 xid 中携带域名而非 IP 的问题
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,6 +27,7 @@
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
+- [[#8159](https://github.com/apache/incubator-seata/pull/8159)] 修复 `SEATA_IP` 配置为域名时 xid 中携带域名而非 IP 的问题
 
 
 ### optimize:

--- a/common/src/main/java/org/apache/seata/common/util/NetUtil.java
+++ b/common/src/main/java/org/apache/seata/common/util/NetUtil.java
@@ -411,12 +411,12 @@ public class NetUtil {
     }
 
     /**
-     * convert ip if necessary
+     * Convert a host name to its ip address, an ip literal is returned as is.
      *
-     * @param ip
-     * @return java.lang.String
+     * @param ip the ip literal or host name
+     * @return the ip address
      */
-    private static String convertIpIfNecessary(String ip) {
+    public static String convertIpIfNecessary(String ip) {
         if (isValidIPv4(ip) || isValidIPv6(ip)) {
             return ip;
         } else {

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -228,6 +228,24 @@ public class NetUtilTest {
     }
 
     @Test
+    public void testConvertIpIfNecessary() {
+        // an ip literal is returned as is
+        assertThat(NetUtil.convertIpIfNecessary("127.0.0.1")).isEqualTo("127.0.0.1");
+        assertThat(NetUtil.convertIpIfNecessary("8.210.212.91")).isEqualTo("8.210.212.91");
+        assertThat(NetUtil.convertIpIfNecessary("2000:0000:0000:0000:0001:2345:6789:abcd"))
+                .isEqualTo("2000:0000:0000:0000:0001:2345:6789:abcd");
+
+        // a host name is resolved to its ip address
+        assertThat(NetUtil.convertIpIfNecessary("localhost")).isIn("127.0.0.1", "0:0:0:0:0:0:0:1");
+
+        assertThatThrownBy(() -> {
+                    NetUtil.convertIpIfNecessary("knownHost");
+                })
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("UnknownHostException");
+    }
+
+    @Test
     public void testSplitIPPortStr() {
         String[] ipPort = new String[] {"127.0.0.1", "8080"};
         assertThat(NetUtil.splitIPPortStr("127.0.0.1:8080")).isEqualTo(ipPort);

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -238,8 +238,9 @@ public class NetUtilTest {
         // a host name is resolved to its ip address
         assertThat(NetUtil.convertIpIfNecessary("localhost")).isIn("127.0.0.1", "0:0:0:0:0:0:0:1");
 
+        // a reserved name from RFC 2606, so it cannot be resolved by a dns search domain
         assertThatThrownBy(() -> {
-                    NetUtil.convertIpIfNecessary("knownHost");
+                    NetUtil.convertIpIfNecessary("unresolvable.invalid");
                 })
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("UnknownHostException");

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -236,7 +236,7 @@ public class NetUtilTest {
                 .isEqualTo("2000:0000:0000:0000:0001:2345:6789:abcd");
 
         // a host name is resolved to its ip address
-        assertThat(NetUtil.convertIpIfNecessary("localhost")).isIn("127.0.0.1", "0:0:0:0:0:0:0:1");
+        assertThat(NetUtil.convertIpIfNecessary("localhost")).isIn("127.0.0.1", "::1", "0:0:0:0:0:0:0:1");
 
         // a reserved name from RFC 2606, so it cannot be resolved by a dns search domain
         assertThatThrownBy(() -> {

--- a/server/src/main/java/org/apache/seata/server/Server.java
+++ b/server/src/main/java/org/apache/seata/server/Server.java
@@ -88,8 +88,10 @@ public class Server {
             // XIDLoadBalance has to resolve it on every branch register, or fails to match the tc at all.
             String host = NetUtil.convertIpIfNecessary(parameterParser.getHost());
             if (!host.equals(parameterParser.getHost())) {
-                LOGGER.info("the host {} is resolved to {}, which will be used in the xid",
-                        parameterParser.getHost(), host);
+                LOGGER.info(
+                        "the host {} is resolved to {}, which will be used in the xid",
+                        parameterParser.getHost(),
+                        host);
             }
             XID.setIpAddress(host);
         } else {

--- a/server/src/main/java/org/apache/seata/server/Server.java
+++ b/server/src/main/java/org/apache/seata/server/Server.java
@@ -82,40 +82,7 @@ public class Server {
                 new LinkedBlockingQueue<>(NettyServerConfig.getMaxTaskQueueSize()),
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
-        // a host name must be resolved to its ip address, otherwise the xid carries the host name and
-        // XIDLoadBalance has to resolve it on every branch register, or fails to match the tc at all.
-        // resolving it once here also keeps the validated value and the stored value the same one.
-        String rawHost = parameterParser.getHost();
-        String host = StringUtils.isNotBlank(rawHost) ? NetUtil.convertIpIfNecessary(rawHost) : rawHost;
-        // 127.0.0.1 and 0.0.0.0 are not valid here.
-        if (NetUtil.isValidIp(host, false)) {
-            if (!host.equals(rawHost)) {
-                LOGGER.info("the host {} is resolved to {}, which will be used in the xid", rawHost, host);
-            }
-            XID.setIpAddress(host);
-        } else {
-            // Get preferred network patterns from configuration (regex or prefix match)
-            // Used to select specific network interfaces when multiple are available
-            String preferredNetworks = ConfigurationFactory.getInstance().getConfig(REGISTRY_PREFERRED_NETWORKS);
-
-            // Get ignored interface patterns from configuration (regex supported)
-            // Useful for filtering out virtual interfaces like VMware, VirtualBox, Docker, etc.
-            // Example: "VMware.*,VirtualBox.*,bridge.*,docker.*,veth.*"
-            String ignoredInterfaces = ConfigurationFactory.getInstance().getConfig(REGISTRY_IGNORED_INTERFACES);
-            String[] ignoredInterfacesSplit = null;
-            if (ignoredInterfaces != null) {
-                ignoredInterfacesSplit = ignoredInterfaces.split(",");
-            }
-
-            // Get local IP address with interface filtering
-            // Priority: ignored interfaces filter -> preferred networks match -> first valid IP
-            if (StringUtils.isNotBlank(preferredNetworks)) {
-                XID.setIpAddress(NetUtil.getIgnoredInterfacesLocalIp(
-                        ignoredInterfacesSplit, preferredNetworks.split(REGEX_SPLIT_CHAR)));
-            } else {
-                XID.setIpAddress(NetUtil.getIgnoredInterfacesLocalIp(ignoredInterfacesSplit));
-            }
-        }
+        XID.setIpAddress(resolveXidHost(parameterParser.getHost()));
         NettyRemotingServer nettyRemotingServer = new NettyRemotingServer(workingThreads);
         XID.setPort(nettyRemotingServer.getListenPort());
         UUIDGenerator.init(parameterParser.getServerNode());
@@ -138,5 +105,44 @@ public class Server {
         // let ServerRunner do destroy instead ShutdownHook, see https://github.com/seata/seata/issues/4028
         ServerRunner.addDisposable(coordinator);
         nettyRemotingServer.init();
+    }
+
+    /**
+     * Resolve the host stored in the xid. A configured host name is resolved to its ip literal once here, so the
+     * xid never carries a host name; otherwise the local ip is selected according to the configured interface
+     * filters. Resolving the host name here also keeps the validated value and the stored value the same one.
+     *
+     * @param rawHost the configured host, from the {@code --host} arg or the {@code SEATA_IP} env, may be null
+     * @return the ip literal to store in {@link XID}
+     */
+    static String resolveXidHost(String rawHost) {
+        String host = StringUtils.isNotBlank(rawHost) ? NetUtil.convertIpIfNecessary(rawHost) : rawHost;
+        // 127.0.0.1 and 0.0.0.0 are not valid here.
+        if (NetUtil.isValidIp(host, false)) {
+            if (!host.equals(rawHost)) {
+                LOGGER.info("the host {} is resolved to {}, which will be used in the xid", rawHost, host);
+            }
+            return host;
+        }
+        // Get preferred network patterns from configuration (regex or prefix match)
+        // Used to select specific network interfaces when multiple are available
+        String preferredNetworks = ConfigurationFactory.getInstance().getConfig(REGISTRY_PREFERRED_NETWORKS);
+
+        // Get ignored interface patterns from configuration (regex supported)
+        // Useful for filtering out virtual interfaces like VMware, VirtualBox, Docker, etc.
+        // Example: "VMware.*,VirtualBox.*,bridge.*,docker.*,veth.*"
+        String ignoredInterfaces = ConfigurationFactory.getInstance().getConfig(REGISTRY_IGNORED_INTERFACES);
+        String[] ignoredInterfacesSplit = null;
+        if (ignoredInterfaces != null) {
+            ignoredInterfacesSplit = ignoredInterfaces.split(",");
+        }
+
+        // Get local IP address with interface filtering
+        // Priority: ignored interfaces filter -> preferred networks match -> first valid IP
+        if (StringUtils.isNotBlank(preferredNetworks)) {
+            return NetUtil.getIgnoredInterfacesLocalIp(
+                    ignoredInterfacesSplit, preferredNetworks.split(REGEX_SPLIT_CHAR));
+        }
+        return NetUtil.getIgnoredInterfacesLocalIp(ignoredInterfacesSplit);
     }
 }

--- a/server/src/main/java/org/apache/seata/server/Server.java
+++ b/server/src/main/java/org/apache/seata/server/Server.java
@@ -31,6 +31,8 @@ import org.apache.seata.server.instance.SeataInstanceStrategy;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.metrics.MetricsManager;
 import org.apache.seata.server.session.SessionHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -51,6 +53,8 @@ import static org.apache.seata.spring.boot.autoconfigure.StarterConstants.REGIST
  */
 @Component("seataServer")
 public class Server {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
 
     @Resource
     SeataInstanceStrategy seataInstanceStrategy;
@@ -80,7 +84,14 @@ public class Server {
 
         // 127.0.0.1 and 0.0.0.0 are not valid here.
         if (NetUtil.isValidIp(parameterParser.getHost(), false)) {
-            XID.setIpAddress(parameterParser.getHost());
+            // a host name must be converted to its ip address, otherwise the xid carries the host name and
+            // XIDLoadBalance has to resolve it on every branch register, or fails to match the tc at all.
+            String host = NetUtil.convertIpIfNecessary(parameterParser.getHost());
+            if (!host.equals(parameterParser.getHost())) {
+                LOGGER.info("the host {} is resolved to {}, which will be used in the xid",
+                        parameterParser.getHost(), host);
+            }
+            XID.setIpAddress(host);
         } else {
             // Get preferred network patterns from configuration (regex or prefix match)
             // Used to select specific network interfaces when multiple are available

--- a/server/src/main/java/org/apache/seata/server/Server.java
+++ b/server/src/main/java/org/apache/seata/server/Server.java
@@ -82,16 +82,15 @@ public class Server {
                 new LinkedBlockingQueue<>(NettyServerConfig.getMaxTaskQueueSize()),
                 new ThreadPoolExecutor.CallerRunsPolicy());
 
+        // a host name must be resolved to its ip address, otherwise the xid carries the host name and
+        // XIDLoadBalance has to resolve it on every branch register, or fails to match the tc at all.
+        // resolving it once here also keeps the validated value and the stored value the same one.
+        String rawHost = parameterParser.getHost();
+        String host = StringUtils.isNotBlank(rawHost) ? NetUtil.convertIpIfNecessary(rawHost) : rawHost;
         // 127.0.0.1 and 0.0.0.0 are not valid here.
-        if (NetUtil.isValidIp(parameterParser.getHost(), false)) {
-            // a host name must be converted to its ip address, otherwise the xid carries the host name and
-            // XIDLoadBalance has to resolve it on every branch register, or fails to match the tc at all.
-            String host = NetUtil.convertIpIfNecessary(parameterParser.getHost());
-            if (!host.equals(parameterParser.getHost())) {
-                LOGGER.info(
-                        "the host {} is resolved to {}, which will be used in the xid",
-                        parameterParser.getHost(),
-                        host);
+        if (NetUtil.isValidIp(host, false)) {
+            if (!host.equals(rawHost)) {
+                LOGGER.info("the host {} is resolved to {}, which will be used in the xid", rawHost, host);
             }
             XID.setIpAddress(host);
         } else {

--- a/server/src/test/java/org/apache/seata/server/ServerXidHostTest.java
+++ b/server/src/test/java/org/apache/seata/server/ServerXidHostTest.java
@@ -45,13 +45,17 @@ public class ServerXidHostTest {
     public void testResolveXidHostConvertsHostNameToIpLiteral() throws UnknownHostException {
         // the local host name is the only name guaranteed to resolve without external dns
         String hostName = InetAddress.getLocalHost().getHostName();
-        // in some environments the host name is already an ip literal, then there is nothing to convert
-        Assumptions.assumeFalse(NetUtil.isValidIp(hostName, true), "host name is already an ip literal");
+        // skip only when the host name is literally an ip, then there is nothing to convert. note that
+        // NetUtil.isValidIp resolves the name first, so it cannot be used to detect a literal here.
+        Assumptions.assumeFalse(
+                NetUtil.isValidIPv4(hostName) || NetUtil.isValidIPv6(hostName), "host name is already an ip literal");
 
-        String resolved = Server.resolveXidHost(hostName);
+        String expected = InetAddress.getByName(hostName).getHostAddress();
+        // resolveXidHost keeps the resolved literal only when it is a routable (non-forbidden) address;
+        // a loopback resolution would take the local-ip fallback path instead
+        Assumptions.assumeTrue(NetUtil.isValidIp(expected, false), "host name resolves to a forbidden address");
 
-        // the value stored in the xid must be the resolved ip literal, never the host name
-        Assertions.assertNotEquals(hostName, resolved);
-        Assertions.assertTrue(NetUtil.isValidIp(resolved, true), "resolved host is not an ip literal: " + resolved);
+        // the regression: the value stored in the xid is the resolved ip literal, not the host name
+        Assertions.assertEquals(expected, Server.resolveXidHost(hostName));
     }
 }

--- a/server/src/test/java/org/apache/seata/server/ServerXidHostTest.java
+++ b/server/src/test/java/org/apache/seata/server/ServerXidHostTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server;
+
+import org.apache.seata.common.util.NetUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Test the host selection that feeds {@link org.apache.seata.common.XID}.
+ */
+public class ServerXidHostTest {
+
+    /**
+     * An ip literal is stored as is, no resolution happens.
+     */
+    @Test
+    public void testResolveXidHostKeepsIpLiteral() {
+        Assertions.assertEquals("8.210.212.91", Server.resolveXidHost("8.210.212.91"));
+    }
+
+    /**
+     * Guards the regression reported in #8158: a configured host name must be resolved to its ip literal
+     * before it is stored, otherwise the xid carries the host name and XIDLoadBalance cannot match the tc.
+     */
+    @Test
+    public void testResolveXidHostConvertsHostNameToIpLiteral() throws UnknownHostException {
+        // the local host name is the only name guaranteed to resolve without external dns
+        String hostName = InetAddress.getLocalHost().getHostName();
+        // in some environments the host name is already an ip literal, then there is nothing to convert
+        Assumptions.assumeFalse(NetUtil.isValidIp(hostName, true), "host name is already an ip literal");
+
+        String resolved = Server.resolveXidHost(hostName);
+
+        // the value stored in the xid must be the resolved ip literal, never the host name
+        Assertions.assertNotEquals(hostName, resolved);
+        Assertions.assertTrue(NetUtil.isValidIp(resolved, true), "resolved host is not an ip literal: " + resolved);
+    }
+}


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

When `SEATA_IP` (or `--host`) is set to a host name, the xid carries the host name instead of an ip address, e.g. `seata.aaa.com:8091:123456`.

`Server#start` validates the host with `NetUtil.isValidIp`, which internally calls `convertIpIfNecessary` to resolve a host name to its ip address before validating it. But the validation result is thrown away and the **original** string is stored:

```java
if (NetUtil.isValidIp(parameterParser.getHost(), false)) {
    XID.setIpAddress(parameterParser.getHost());   // the raw host name
}
```

The host name then propagates into every xid, and `XIDLoadBalance#select` has to build an `InetSocketAddress` from it on every branch register to compare against the resolved addresses in the channel list. That has three consequences:

1. A DNS lookup on the branch register hot path. The JVM positive cache defaults to 30s, so this is a recurring cost rather than a one-off.
2. If the lookup fails at select time, the `InetSocketAddress` is unresolved. `InetSocketAddress#equals` then compares host name strings against resolved invokers, never matches, and every branch register silently degrades to the random fallback — sticky routing to the tc owning the global transaction is lost.
3. If the name has multiple A records, `getByName` returns the first one, which may point at a different tc than the one that created the xid.

This PR resolves the host name once, at startup, so the xid always carries an ip literal:

- Store `NetUtil.convertIpIfNecessary(host)` instead of the raw host. `isValidIp` on the preceding line already performed the same resolution, so this hits the JVM cache and adds no startup cost.
- Log the `host name -> ip` mapping at INFO, which makes case 3 above diagnosable.
- Make `NetUtil#convertIpIfNecessary` public (it was private and only used by `isValidIp`); behaviour unchanged.

`XIDLoadBalance` is deliberately left alone. Resolving there would repeat work already done by the `InetSocketAddress` constructor and would keep the DNS lookup on the hot path; fixing the value at the source removes the problem for all three cases at once.

The other three `XID.setIpAddress` call sites already pass ip literals (`NetUtil.getIgnoredInterfacesLocalIp` / `NetUtil.getLocalIp`), so `Server.java` is the only place where a host name can reach an xid.

### Ⅱ. Does this pull request fix one issue?

fixes #8158

Note that the root cause differs from the analysis in the issue: `new InetSocketAddress(host, port)` does resolve the name, and `InetSocketAddress#equals` compares the resolved `InetAddress` while ignoring the host name, so a host name and an ip do match in the common case. The failure only appears when resolution fails at select time or when the name resolves to a different address, as described above.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Added `NetUtilTest#testConvertIpIfNecessary`, covering the ipv4/ipv6 literal pass-through, host name resolution (using `localhost`, so it does not depend on external DNS) and the unresolvable host case.

### Ⅳ. Describe how to verify it

`mvn -pl common -am test -Dtest=NetUtilTest`

End to end: start a server with `SEATA_IP` set to a resolvable host name and check that the generated xid carries the ip address rather than the name, and that the startup log records the resolution.

### Ⅴ. Special notes for reviews

`convertIpIfNecessary` throws an unchecked `RuntimeException` wrapping `UnknownHostException` when the host name cannot be resolved, so an unresolvable `SEATA_IP` fails server startup instead of falling back to the local ip branch. That behaviour is pre-existing — `isValidIp` on the preceding line already throws for the same input — and this PR does not change it. It seems worth addressing separately.