### PR TITLE
bugfix: use UTF-8 for ConfigTools encryption

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -27,6 +27,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [[#8145](https://github.com/apache/incubator-seata/pull/8145)] fix global lock batch acquire false-failure on Dameng(DM)
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
+- [[#8170](https://github.com/apache/incubator-seata/pull/8170)] fix ConfigTools encryption corrupting non-ASCII content on non-UTF-8 platforms
 
 
 
@@ -58,6 +59,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [lhozy](https://github.com/lhozy)
 - [Zhengcy05](https://github.com/Zhengcy05)
 - [neu-hsc](https://github.com/neu-hsc)
+- [pyshiweijia](https://github.com/pyshiweijia)
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,6 +27,7 @@
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
+- [[#8170](https://github.com/apache/incubator-seata/pull/8170)] 修复 ConfigTools 加密在非 UTF-8 默认字符集平台损坏非 ASCII 内容的问题
 
 
 ### optimize:
@@ -57,6 +58,7 @@
 - [lhozy](https://github.com/lhozy)
 - [Zhengcy05](https://github.com/Zhengcy05)
 - [neu-hsc](https://github.com/neu-hsc)
+- [pyshiweijia](https://github.com/pyshiweijia)
 
 
 

--- a/common/src/main/java/org/apache/seata/common/util/ConfigTools.java
+++ b/common/src/main/java/org/apache/seata/common/util/ConfigTools.java
@@ -111,7 +111,7 @@ public class ConfigTools {
         PublicKey publicKey = string2PublicKey(pubStr);
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-        byte[] bytes = cipher.doFinal(content.getBytes());
+        byte[] bytes = cipher.doFinal(content.getBytes(StandardCharsets.UTF_8));
         return byte2Base64(bytes);
     }
 
@@ -143,7 +143,7 @@ public class ConfigTools {
         PrivateKey privateKey = string2PrivateKey(priStr);
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.ENCRYPT_MODE, privateKey);
-        byte[] bytes = cipher.doFinal(content.getBytes());
+        byte[] bytes = cipher.doFinal(content.getBytes(StandardCharsets.UTF_8));
         return byte2Base64(bytes);
     }
 

--- a/common/src/test/java/org/apache/seata/common/util/ConfigToolsTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/ConfigToolsTest.java
@@ -184,11 +184,11 @@ public class ConfigToolsTest {
     }
 
     @Test
-    public void testRoundTripEncryption() throws Exception {
+    public void testRoundTripEncryptionWithUnicodeContent() throws Exception {
         KeyPair keyPair = ConfigTools.getKeyPair();
         String publicKeyStr = ConfigTools.getPublicKey(keyPair);
         String privateKeyStr = ConfigTools.getPrivateKey(keyPair);
-        String content = "This is a test message for encryption round trip";
+        String content = "This is a test message for encryption round trip: \u4e2d\u6587";
 
         // Public encrypt, private decrypt
         String encrypted1 = ConfigTools.publicEncrypt(content, publicKeyStr);


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### I. Describe what this PR did

Use UTF-8 explicitly when `ConfigTools` converts plaintext to bytes for public-key and private-key encryption. Extend the round-trip test with Unicode content.

### II. Does this pull request fix one issue?

fixes #8168

### III. Why don't you add test cases (unit test/integration test)?

A regression test is included. Before the fix, it fails on a Windows/GBK environment because the Unicode text `中文` is decrypted as `????`.

### IV. Describe how to verify it

`mvn -pl common -am test -Dlicense.skip=true -B`

Result: 689 tests run, 0 failures, 0 errors, 4 skipped.

Compatibility checks:

- JDK 17: complete `common` suite passed.
- JDK 8: the Unicode regression test passed.
- JDK 8 complete-suite baseline currently has two unrelated failures in `HttpClientUtilTest`: it expects `ConnectException`, while this Windows environment returns `SocketTimeoutException` for `localhost:9999`.

### V. Special notes for reviews

Decryption already decodes plaintext bytes with UTF-8. This change makes both encryption paths use the same deterministic charset and removes platform-dependent behavior. ASCII input is unchanged.