### PR TITLE
Wait for cached configuration listener callback in test

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -41,6 +41,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### test:
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: cover rm-datasource resource id initializers
+- [[#8172](https://github.com/apache/incubator-seata/pull/8172)] wait for the cached configuration listener callback in its asynchronous test
 
 ### refactor:
 
@@ -58,6 +59,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [lhozy](https://github.com/lhozy)
 - [Zhengcy05](https://github.com/Zhengcy05)
 - [neu-hsc](https://github.com/neu-hsc)
+- [coyaSONG](https://github.com/coyaSONG)
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -40,6 +40,7 @@
 ### test:
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: 覆盖 rm-datasource resource id initializers
+- [[#8172](https://github.com/apache/incubator-seata/pull/8172)] 在异步测试中等待缓存配置监听器回调
 
 ### refactor:
 
@@ -57,6 +58,7 @@
 - [lhozy](https://github.com/lhozy)
 - [Zhengcy05](https://github.com/Zhengcy05)
 - [neu-hsc](https://github.com/neu-hsc)
+- [coyaSONG](https://github.com/coyaSONG)
 
 
 

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/ConfigurationChangeListenerTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/ConfigurationChangeListenerTest.java
@@ -19,8 +19,10 @@ package org.apache.seata.config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -216,12 +218,12 @@ class ConfigurationChangeListenerTest {
     }
 
     @Test
-    void testCachedConfigurationChangeListener() {
-        AtomicBoolean changeEventCalled = new AtomicBoolean(false);
+    void testCachedConfigurationChangeListener() throws InterruptedException {
+        CountDownLatch changeEventCalled = new CountDownLatch(1);
         CachedConfigurationChangeListener listener = new CachedConfigurationChangeListener() {
             @Override
             public void onChangeEvent(ConfigurationChangeEvent event) {
-                changeEventCalled.set(true);
+                changeEventCalled.countDown();
             }
         };
 
@@ -229,13 +231,8 @@ class ConfigurationChangeListenerTest {
         event.setDataId("test.cached.key");
         event.setNewValue("test-value");
 
-        try {
-            listener.onProcessEvent(event);
-            Assertions.assertTrue(changeEventCalled.get());
-        } catch (Exception e) {
-            // ignore executor service related exceptions
-            // this may be caused by executor service being shutdown
-        }
+        listener.onProcessEvent(event);
+        Assertions.assertTrue(changeEventCalled.await(5, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Wait for the asynchronous `CachedConfigurationChangeListener` callback in `ConfigurationChangeListenerTest` before asserting that it ran. This replaces the immediate assertion and removes the broad exception handler that could hide executor failures.

### Ⅱ. Does this pull request fix one issue?

Fixes #8171.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

This change corrects the existing regression test itself; it does not change production behavior.

### Ⅳ. Describe how to verify it

On protected `2.x` at `e6d0860a4345b10cb59c65c78215ec51d67f59d1`, the targeted test class failed at `testCachedConfigurationChangeListener` because the assertion ran before the executor callback. After this change, the same command passes all 10 tests:

```shell
./mvnw -pl config/seata-config-core -am -Dtest=ConfigurationChangeListenerTest -DfailIfNoTests=false test
```

`git diff --check` also passes.

### Ⅴ. Special notes for reviews

The wait is bounded to five seconds and is released directly by the callback under test.
