### PR TITLE
test: fix laky testCachedConfigurationChangeListener due to async race condition

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -41,6 +41,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### test:
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: cover rm-datasource resource id initializers
+- [[#8175](https://github.com/apache/incubator-seata/pull/8175)] fix flaky testCachedConfigurationChangeListener due to async race condition
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -40,6 +40,7 @@
 ### test:
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: 覆盖 rm-datasource resource id initializers
+- [[#8175](https://github.com/apache/incubator-seata/pull/8175)] 修复 testCachedConfigurationChangeListener 因异步竞态条件导致的偶发失败
 
 ### refactor:
 

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/ConfigurationChangeListenerTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/ConfigurationChangeListenerTest.java
@@ -19,8 +19,10 @@ package org.apache.seata.config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -216,12 +218,14 @@ class ConfigurationChangeListenerTest {
     }
 
     @Test
-    void testCachedConfigurationChangeListener() {
+    void testCachedConfigurationChangeListener() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean changeEventCalled = new AtomicBoolean(false);
         CachedConfigurationChangeListener listener = new CachedConfigurationChangeListener() {
             @Override
             public void onChangeEvent(ConfigurationChangeEvent event) {
                 changeEventCalled.set(true);
+                latch.countDown();
             }
         };
 
@@ -231,6 +235,7 @@ class ConfigurationChangeListenerTest {
 
         try {
             listener.onProcessEvent(event);
+            latch.await(5, TimeUnit.SECONDS);
             Assertions.assertTrue(changeEventCalled.get());
         } catch (Exception e) {
             // ignore executor service related exceptions


### PR DESCRIPTION
onProcessEvent() submits onChangeEvent async to a thread pool by default. The test asserted changeEventCalled immediately, racing the executor thread. Use CountDownLatch with 5s timeout to wait for the async callback before asserting.

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Fix flaky `ConfigurationChangeListenerTest.testCachedConfigurationChangeListener()`.

**Problem:** The default implementation of `ConfigurationChangeListener.onProcessEvent()` submits the `onChangeEvent()` callback to a thread pool via `ExecutorService.submit()`, returning immediately. The original test asserted `changeEventCalled == true` **right after** calling `onProcessEvent()`, creating a race condition with the pool worker thread. Under CI load this fails intermittently:

```
[ERROR]   ConfigurationChangeListenerTest.testCachedConfigurationChangeListener:234 expected: <true> but was: <false>
```

**Fix:** Introduce a `CountDownLatch` synchronization mechanism:

- Call `latch.countDown()` inside the anonymous `CachedConfigurationChangeListener.onChangeEvent()` callback.
- Call `latch.await(5, TimeUnit.SECONDS)` to wait for async callback completion with a 5-second timeout.
- Add `throws InterruptedException` to the test method signature.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/apache/incubator-seata/issues/8174

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This change is the test fix itself — no additional test cases are needed. The updated test uses `CountDownLatch` to ensure the async callback completes before asserting, eliminating the race condition.

### Ⅳ. Describe how to verify it


```bash
# Single run
mvn test -pl config/seata-config-core -Dtest=ConfigurationChangeListenerTest#testCachedConfigurationChangeListener

# Stress test (loop to ensure stability)
for i in $(seq 1 50); do
  mvn test -pl config/seata-config-core -Dtest=ConfigurationChangeListenerTest#testCachedConfigurationChangeListener -q
  echo "Run $i: $?"
done
```

Before the fix, failures occur intermittently. After the fix, the test should pass 100% of the time.

### Ⅴ. Special notes for reviews

- Test-only change — no production code is touched.
- `CountDownLatch` is the lightest-weight "wait for async completion" mechanism in the Java concurrency standard library with zero external dependencies.
- The 5-second timeout is sufficient for normal execution while preventing the test from hanging indefinitely in extreme scenarios.
