### PR TITLE
refactor: centralize protobuf and grpc version properties to build/pom.xml

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -102,6 +102,8 @@
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <kotlin-maven-plugin.version>2.2.20</kotlin-maven-plugin.version>
+        <protobuf.version>3.25.5</protobuf.version>
+        <grpc.version>1.55.1</grpc.version>
         <!-- Check -->
         <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
         <license-maven-plugin.version>4.0</license-maven-plugin.version>

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -45,6 +45,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### refactor:
 
+- [[#8177](https://github.com/apache/incubator-seata/pull/8177)] centralize protobuf and grpc version properties to build/pom.xml
 
 ### doc:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -44,6 +44,7 @@
 
 ### refactor:
 
+- [[#8177](https://github.com/apache/incubator-seata/pull/8177)] 将 protobuf 和 grpc 版本属性集中到 build/pom.xml
 
 ### doc:
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -123,7 +123,7 @@
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/resources/protobuf/org/apache/seata/protocol/transcation/</protoSourceRoot>
                     <protocArtifact>
-                        com.google.protobuf:protoc:3.25.4:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>
                 </configuration>
                 <executions>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -78,8 +78,6 @@
         <netty.version>4.1.101.Final</netty.version>
         <sofa.hessian.version>4.0.3</sofa.hessian.version>
         <sofa.bolt.version>1.6.7</sofa.bolt.version>
-        <protobuf.version>3.25.5</protobuf.version>
-        <grpc.version>1.55.1</grpc.version>
         <kryo.version>5.4.0</kryo.version>
         <kryo-serializers.version>0.45</kryo-serializers.version>
         <hessian.version>4.0.63</hessian.version>

--- a/extensions/rpc/seata-grpc/pom.xml
+++ b/extensions/rpc/seata-grpc/pom.xml
@@ -82,9 +82,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.25.4:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.55.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>
@@ -97,5 +97,5 @@
             </plugin>
         </plugins>
     </build>
-    
+
 </project>

--- a/serializer/seata-serializer-protobuf/pom.xml
+++ b/serializer/seata-serializer-protobuf/pom.xml
@@ -57,7 +57,7 @@
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/resources/protobuf/org/apache/seata/protocol/transcation/</protoSourceRoot>
                     <protocArtifact>
-                        com.google.protobuf:protoc:3.25.4:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>
                 </configuration>
                 <executions>

--- a/test-suite/test-new-version/pom.xml
+++ b/test-suite/test-new-version/pom.xml
@@ -57,11 +57,11 @@
                         ${project.basedir}/src/test/resources/protobuf/org/apache/seata/protocol/transcation/
                     </protoSourceRoot>
                     <protocArtifact>
-                        com.google.protobuf:protoc:3.25.4:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>
-                        io.grpc:protoc-gen-grpc-java:1.55.1:exe:${os.detected.classifier}
+                        io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
                     </pluginArtifact>
                 </configuration>
                 <executions>


### PR DESCRIPTION
- Move protobuf.version and grpc.version from dependencies/pom.xml to build/pom.xml
- Replace hardcoded version numbers with property references in protobuf-maven-plugin configs
- Bump protoc from 3.25.4 to 3.25.5

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Moves the `<protobuf.version>` and `<grpc.version>` properties from `dependencies/pom.xml` up to `build/pom.xml` (`org.apache.seata:seata-build`), so that all child modules can properly inherit these properties. Also replaces the hardcoded protobuf version `3.25.4` with `${protobuf.version}` and the hardcoded gRPC version `1.55.1` with `${grpc.version}` in all sub-modules, enabling builds on architectures such as LoongArch to specify compatible versions via the `-Dprotobuf.version=x.y.z` and `-Dgrpc.version=x.y.z` parameters.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/apache/incubator-seata/issues/8176

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This change is a build configuration refactoring and does not involve business logic changes. It can be verified by running `mvn clean package -Dgrpc.version=1.54.2` on the LoongArch architecture.

### Ⅳ. Describe how to verify it

1. On a LoongArch machine, run:
   ```shell
   mvn clean package -Dgrpc.version=1.54.2
   ```
2. Confirm that the `seata-grpc` module builds successfully
3. On an x86_64 machine, run the standard build to confirm no regressions:
   ```shell
   mvn clean package
   ```

### Ⅴ. Special notes for reviews

This change involves six files:

| File | Change |
|------|--------|
| `build/pom.xml` | Added `<protobuf.version>3.25.5</protobuf.version>` and `<grpc.version>1.55.1</grpc.version>` property definitions |
| `dependencies/pom.xml` | Removed `<protobuf.version>3.25.5</protobuf.version>` and `<grpc.version>1.55.1</grpc.version>` (moved up to `build/pom.xml`) |
| `core/pom.xml` | `3.25.4` → `${protobuf.version}` |
| `extensions/rpc/seata-grpc/pom.xml` | `3.25.4` → `${protobuf.version}`, `1.55.1` → `${grpc.version}` |
| `serializer/seata-serializer-protobuf/pom.xml` | `3.25.4` → `${protobuf.version}` |
| `test-suite/test-new-version/pom.xml` | `3.25.4` → `${protobuf.version}`, `1.55.1` → `${grpc.version}` |

`dependencies/pom.xml` and `seata-grpc/pom.xml` (as well as other sub-modules like `core/pom.xml` and `serializer/seata-serializer-protobuf/pom.xml`) do not have a direct parent-child relationship with `dependencies/pom.xml` (their common parent is `org.apache.seata:seata-build`), so the `<protobuf.version>` and `<grpc.version>` properties originally defined in `dependencies/pom.xml` could not be resolved by these sub-modules. By moving them up to `build/pom.xml`, all child modules can now properly inherit these properties.
