### PR TITLE
bugfix: set java.version to 17 for console module to fix compilation error

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -27,6 +27,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] fix TCC fence cleanup deleting in-progress/unexpired sibling branch records
 - [[#8145](https://github.com/apache/incubator-seata/pull/8145)] fix global lock batch acquire false-failure on Dameng(DM)
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
+- [[#8179](https://github.com/apache/incubator-seata/pull/8179)] set java.version to 17 for console module to fix compilation error
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -27,6 +27,7 @@
 - [[#8138](https://github.com/apache/incubator-seata/pull/8138)] 修复 TCC fence 清理时误删同一全局事务中仍在进行(TRIED)或未过期的分支记录的问题
 - [#8145](https://github.com/apache/incubator-seata/pull/8145) 修复达梦(DM)数据库下全局锁批量获取被误判为失败的问题
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
+- [[#8179](https://github.com/apache/incubator-seata/pull/8179)] 将 console 模块的 java.version 设置为 17 以修复编译错误
 
 
 ### optimize:

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -32,6 +32,9 @@
     <description>console for Seata built with Maven</description>
 
     <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <spring-boot-for-server.version>4.0.6</spring-boot-for-server.version>
         <spring-framework-for-server.version>7.0.7</spring-framework-for-server.version>
         <snakeyaml-for-server.version>2.0</snakeyaml-for-server.version>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -32,6 +32,7 @@
     <description>console for Seata built with Maven</description>
 
     <properties>
+        <!-- required for java.net.http.HttpClient in RestClientConfig -->
         <java.version>17</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot-for-server.version>4.0.6</spring-boot-for-server.version>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -33,8 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot-for-server.version>4.0.6</spring-boot-for-server.version>
         <spring-framework-for-server.version>7.0.7</spring-framework-for-server.version>
         <snakeyaml-for-server.version>2.0</snakeyaml-for-server.version>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did


Fix the `console` module compilation error caused by `java.net.http.HttpClient` requiring Java 11+ while the module inherited Java 1.8 compiler settings from the parent POM.

**Changes:**

In `console/pom.xml`, add Java version properties under `<properties>`:

```xml
<java.version>17</java.version>
<maven.compiler.source>${java.version}</maven.compiler.source>
<maven.compiler.target>${java.version}</maven.compiler.target>
```

This overrides the inherited `<java.version>1.8</java.version>` from `org.apache.seata:seata-build`, ensuring the `console` module compiles with Java 17, which is consistent with the Spring Boot 4.0.6 and Spring Framework 7.0.7 baseline already used by the console module.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/apache/incubator-seata/issues/8178

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
This is a build configuration change only (Maven compiler properties). The existing test suite covers the runtime behavior. No new test cases are needed for compile-level configuration adjustments.

### Ⅳ. Describe how to verify it
1. Import the project in IntelliJ IDEA.
2. Open the `console` module — confirm that `java.net.http.HttpClient` usages no longer show compilation errors.
3. Run `mvn compile -pl console` — the build should succeed without errors.


### Ⅴ. Special notes for reviews

- `java.net.http.HttpClient` was introduced in Java 11, so the `<java.version>` must be ≥ 11.
- Java 17 is chosen to align with Spring Boot 4.0.6 / Spring Framework 7.0.7 (which require Java 17+).
- The `console` module already specifies `spring-boot-for-server.version=4.0.6` and `spring-framework-for-server.version=7.0.7`, confirming Java 17 is the correct baseline.

