### PR TITLE
test: fix flaky AuthControllerWithRandomPasswordTest by isolating context with TestPropertySource

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -42,6 +42,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: cover rm-datasource resource id initializers
 - [[#8175](https://github.com/apache/incubator-seata/pull/8175)] fix flaky testCachedConfigurationChangeListener due to async race condition
+- [[#8181](https://github.com/apache/incubator-seata/pull/8181)] fix AuthControllerWithRandomPasswordTest flaky failure caused by Spring Boot test context caching
 
 ### refactor:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -41,6 +41,7 @@
 
 - [[#8146](https://github.com/apache/incubator-seata/pull/8146)] test: 覆盖 rm-datasource resource id initializers
 - [[#8175](https://github.com/apache/incubator-seata/pull/8175)] 修复 testCachedConfigurationChangeListener 因异步竞态条件导致的偶发失败
+- [[#8181](https://github.com/apache/incubator-seata/pull/8181)] 修复 AuthControllerWithRandomPasswordTest 因 Spring Boot 测试上下文缓存导致的偶发失败
 
 ### refactor:
 

--- a/namingserver/src/test/java/org/apache/seata/namingserver/AuthControllerWithRandomPasswordTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/AuthControllerWithRandomPasswordTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import tools.jackson.databind.ObjectMapper;
@@ -41,6 +42,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Use a unique UUID property to ensure this test class gets its own isolated
+ * Spring Boot application context rather than reusing a cached context from
+ * other RANDOM_PORT tests (e.g. NamingControllerPropertiesSmokeTest).
+ * Without this, when all namingserver tests run together, the test framework
+ * may reuse a cached context whose startup logs don't contain the
+ * "Use the auto-generated password: [...]" line, causing the test to fail.
+ */
+@TestPropertySource(properties = {"uuid=26d766d7-8aee-4940-bc50-d02ffa6e8a3a"})
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
 @AutoConfigureMockMvc

--- a/namingserver/src/test/java/org/apache/seata/namingserver/AuthControllerWithRandomPasswordTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/AuthControllerWithRandomPasswordTest.java
@@ -43,14 +43,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Use a unique UUID property to ensure this test class gets its own isolated
- * Spring Boot application context rather than reusing a cached context from
- * other RANDOM_PORT tests (e.g. NamingControllerPropertiesSmokeTest).
- * Without this, when all namingserver tests run together, the test framework
- * may reuse a cached context whose startup logs don't contain the
- * "Use the auto-generated password: [...]" line, causing the test to fail.
+ * Add a unique, namespaced test property so Spring's test context cache treats this class as a distinct configuration.
+ * This prevents reuse of an already-started context (e.g. other @SpringBootTest + @AutoConfigureMockMvc tests),
+ * which would omit the startup log line "Use the auto-generated password: [...]" from {@link CapturedOutput}.
  */
-@TestPropertySource(properties = {"uuid=26d766d7-8aee-4940-bc50-d02ffa6e8a3a"})
+@TestPropertySource(properties = "seata.test.context.cache.key=AuthControllerWithRandomPasswordTest")
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
 @AutoConfigureMockMvc


### PR DESCRIPTION
Fix `AuthControllerWithRandomPasswordTest` by adding a unique `@TestPropertySource` property to ensure Spring Boot creates a dedicated application context, preventing occasional test failures when running alongside other naming server tests.

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Fix `AuthControllerWithRandomPasswordTest` to prevent occasional test failures when running alongside other naming server tests.

The test uses `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)` with `@AutoConfigureMockMvc` and relies on `CapturedOutput` to extract an auto-generated random password from application startup logs. When all naming server tests run together, Spring Boot's test context caching mechanism may reuse a context from another `RANDOM_PORT` test (e.g., `NamingControllerPropertiesSmokeTest`). Since `CapturedOutput` only captures the startup log from the first time that cached context was created, the password log line `"Use the auto-generated password: [...]"` will not appear in the output, causing the test to fail.

The fix adds `@TestPropertySource(properties = {"uuid=26d766d7-8aee-4940-bc50-d02ffa6e8a3a"})` — a unique UUID property that differentiates this test's configuration from all other `RANDOM_PORT` tests. Spring Boot includes `@TestPropertySource` properties in the context cache key, so this ensures `AuthControllerWithRandomPasswordTest` always gets its own fresh application context with its own random password and clean startup log output.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/apache/incubator-seata/issues/8180

### Ⅲ. Why don't you add test cases (unit test/integration test)?
This PR itself fixes an existing test. No new test cases are needed.


### Ⅳ. Describe how to verify it

1. Run the individual test to confirm it still passes:
   ```
   mvn test -pl namingserver -Dtest=AuthControllerWithRandomPasswordTest
   ```

2. Run the full naming server test suite to confirm the test now passes in the suite context:
   ```
   mvn test -pl namingserver
   ```

3. Verify all other naming server tests continue to pass.


### Ⅴ. Special notes for reviews


**Root Cause Analysis:**

The `AuthControllerWithRandomPasswordTest` has the following Spring Boot test configuration:
- `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)`
- `@AutoConfigureMockMvc`
- `@ExtendWith(OutputCaptureExtension.class)`
- No explicit `properties` or `classes`

Other naming server tests have different context configurations:

| Test Class | webEnvironment | Properties |
|---|---|---|
| `NamingControllerLoggerPrintSmokeTest` | `RANDOM_PORT` | `console.user.password=` (empty) |
| `NamingControllerPropertiesSmokeTest` | `RANDOM_PORT` | `console.user.username=seata, console.user.password=foo` |
| `AuthControllerWithCustomPropertiesTest` | `MOCK` | `console.user.username=seata, console.user.password=foo` |
| `WebSecurityConfigTest` | `MOCK` | None |
| `NamingControllerTest` | `MOCK` | None |

Since `AuthControllerWithRandomPasswordTest` relies on `CapturedOutput.getOut()` containing the auto-generated password log line (`"Use the auto-generated password: [...]"`) from application startup, it requires a fresh context. Without distinguishing properties, Spring Boot's test context caching may reuse a context from another `RANDOM_PORT` test (e.g., `NamingControllerPropertiesSmokeTest`), whose `CapturedOutput` does not contain the password log line.

The fix adds `@TestPropertySource(properties = {"uuid=26d766d7-8aee-4940-bc50-d02ffa6e8a3a"})` — a unique UUID property. Spring Boot includes `@TestPropertySource` properties in the context cache key, so this differentiates the test's configuration from all other tests, ensuring it always gets its own fresh application context.

**Alternative approaches considered:**
1. **Add a unique `@TestPropertySource` property** (chosen) — Ensures context isolation with minimal change; the UUID property serves purely as a cache-key differentiator without affecting any application logic
2. **Add `@DirtiesContext`** — Would work, but dirties all contexts rather than providing targeted isolation; heavier side effect on overall test suite performance
3. **Specify explicit password properties** — Would make the test configuration identical to a smoke test, but defeats the purpose of testing random password generation
4. **Restructure test execution** (e.g., `@Suite` classes) — More invasive, changes test organization
