### PR TITLE
test: fix flaky testCachedConfigurationChangeListener on 2.7.0

### DIFF
--- a/changes/en-us/2.7.0.md
+++ b/changes/en-us/2.7.0.md
@@ -101,7 +101,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] add unit tests for saga-engine module
 - [[#8051](https://github.com/apache/incubator-seata/pull/8051)] isolate compatibility tests from transport protocol interference
 - [[#8123](https://github.com/apache/incubator-seata/pull/8123)] add integration tx api mock tests
-- [[#8175](https://github.com/apache/incubator-seata/pull/8175)] fix flaky testCachedConfigurationChangeListener due to async race condition
+- [[#8184](https://github.com/apache/incubator-seata/pull/8184)] fix flaky testCachedConfigurationChangeListener due to async race condition (backport #8175)
 
 ### refactor:
 

--- a/changes/en-us/2.7.0.md
+++ b/changes/en-us/2.7.0.md
@@ -101,6 +101,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] add unit tests for saga-engine module
 - [[#8051](https://github.com/apache/incubator-seata/pull/8051)] isolate compatibility tests from transport protocol interference
 - [[#8123](https://github.com/apache/incubator-seata/pull/8123)] add integration tx api mock tests
+- [[#8175](https://github.com/apache/incubator-seata/pull/8175)] fix flaky testCachedConfigurationChangeListener due to async race condition
 
 ### refactor:
 

--- a/changes/zh-cn/2.7.0.md
+++ b/changes/zh-cn/2.7.0.md
@@ -103,6 +103,7 @@
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] 为 saga-engine 模块添加单元测试
 - [[#8051](https://github.com/apache/incubator-seata/pull/8051)] 隔离兼容性测试与传输协议的干扰
 - [[#8123](https://github.com/apache/incubator-seata/pull/8123)] 为integration-tx-api模块添加测试
+- [[#8175](https://github.com/apache/incubator-seata/pull/8175)] 修复 testCachedConfigurationChangeListener 因异步竞态条件导致的偶发失败
 
 
 ### refactor:

--- a/changes/zh-cn/2.7.0.md
+++ b/changes/zh-cn/2.7.0.md
@@ -103,7 +103,7 @@
 - [[#7915](https://github.com/apache/incubator-seata/pull/7915)] 为 saga-engine 模块添加单元测试
 - [[#8051](https://github.com/apache/incubator-seata/pull/8051)] 隔离兼容性测试与传输协议的干扰
 - [[#8123](https://github.com/apache/incubator-seata/pull/8123)] 为integration-tx-api模块添加测试
-- [[#8175](https://github.com/apache/incubator-seata/pull/8175)] 修复 testCachedConfigurationChangeListener 因异步竞态条件导致的偶发失败
+- [[#8184](https://github.com/apache/incubator-seata/pull/8184)] 修复 testCachedConfigurationChangeListener 因异步竞态条件导致的偶发失败（backport #8175）
 
 
 ### refactor:

--- a/config/seata-config-core/src/test/java/org/apache/seata/config/ConfigurationChangeListenerTest.java
+++ b/config/seata-config-core/src/test/java/org/apache/seata/config/ConfigurationChangeListenerTest.java
@@ -19,8 +19,10 @@ package org.apache.seata.config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -216,12 +218,14 @@ class ConfigurationChangeListenerTest {
     }
 
     @Test
-    void testCachedConfigurationChangeListener() {
+    void testCachedConfigurationChangeListener() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean changeEventCalled = new AtomicBoolean(false);
         CachedConfigurationChangeListener listener = new CachedConfigurationChangeListener() {
             @Override
             public void onChangeEvent(ConfigurationChangeEvent event) {
                 changeEventCalled.set(true);
+                latch.countDown();
             }
         };
 
@@ -231,6 +235,7 @@ class ConfigurationChangeListenerTest {
 
         try {
             listener.onProcessEvent(event);
+            latch.await(5, TimeUnit.SECONDS);
             Assertions.assertTrue(changeEventCalled.get());
         } catch (Exception e) {
             // ignore executor service related exceptions


### PR DESCRIPTION
## What this PR does?

Backport [#8175](https://github.com/apache/incubator-seata/pull/8175) to the `2.7.0` release branch.

`ConfigurationChangeListener.onProcessEvent` runs callbacks asynchronously. The test asserted immediately after submit, which raced and failed most `test-ubuntu` / `test-druid` jobs on `f59414ced` (#8166), blocking a green CI for the RC.

## Changes

- Wait for the async callback with `CountDownLatch` (5s timeout)
- Add changelog entries in `changes/*/2.7.0.md`

## Verify

```bash
./mvnw -pl config/seata-config-core -Dtest=ConfigurationChangeListenerTest test
```

Local stress: `testCachedConfigurationChangeListener` passed 5/5.

## Related

- Original fix on `2.x`: #8175
- Unblocks 2.7.0 release CI after #8166


Made with [Cursor](https://cursor.com)