### PR TITLE
feature: add HMAC-SHA256 mutual authentication between NamingServer and Server

### DIFF
--- a/common/src/main/java/org/apache/seata/common/security/CanonicalRequest.java
+++ b/common/src/main/java/org/apache/seata/common/security/CanonicalRequest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable value object representing everything the signer needs to know about a request.
+ *
+ * <p>The signature covers method + path + query + identity headers + body digest, so any
+ * tampering with any of these fields invalidates the signature. Headers other than the
+ * identity headers are intentionally excluded — proxies routinely add or rewrite them.
+ */
+public final class CanonicalRequest {
+
+    private final String method;
+
+    private final String path;
+
+    private final Map<String, String> queryParams;
+
+    private final String clusterId;
+
+    private final long timestampMillis;
+
+    private final String nonce;
+
+    private final SignatureAlgorithm algorithm;
+
+    private final byte[] body;
+
+    private CanonicalRequest(Builder builder) {
+        this.method = Objects.requireNonNull(builder.method, "method").toUpperCase();
+        this.path = Objects.requireNonNull(builder.path, "path");
+        this.queryParams = builder.queryParams == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(builder.queryParams));
+        this.clusterId = Objects.requireNonNull(builder.clusterId, "clusterId");
+        this.timestampMillis = builder.timestampMillis;
+        this.nonce = Objects.requireNonNull(builder.nonce, "nonce");
+        this.algorithm = builder.algorithm == null ? SignatureAlgorithm.HMAC_SHA256 : builder.algorithm;
+        this.body = builder.body == null ? new byte[0] : builder.body.clone();
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Map<String, String> getQueryParams() {
+        return queryParams;
+    }
+
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public long getTimestampMillis() {
+        return timestampMillis;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public SignatureAlgorithm getAlgorithm() {
+        return algorithm;
+    }
+
+    /** Defensive copy — never expose the internal array. */
+    public byte[] getBody() {
+        return body.clone();
+    }
+
+    /** UTF-8 view of the body, useful for logging and tests. */
+    public String getBodyAsString() {
+        return new String(body, StandardCharsets.UTF_8);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Fluent builder to keep call sites readable given the number of fields. */
+    public static final class Builder {
+        private String method;
+        private String path;
+        private Map<String, String> queryParams;
+        private String clusterId;
+        private long timestampMillis;
+        private String nonce;
+        private SignatureAlgorithm algorithm;
+        private byte[] body;
+
+        public Builder method(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder queryParams(Map<String, String> queryParams) {
+            this.queryParams = queryParams;
+            return this;
+        }
+
+        public Builder clusterId(String clusterId) {
+            this.clusterId = clusterId;
+            return this;
+        }
+
+        public Builder timestampMillis(long timestampMillis) {
+            this.timestampMillis = timestampMillis;
+            return this;
+        }
+
+        public Builder nonce(String nonce) {
+            this.nonce = nonce;
+            return this;
+        }
+
+        public Builder algorithm(SignatureAlgorithm algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        public Builder body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public CanonicalRequest build() {
+            return new CanonicalRequest(this);
+        }
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/HmacSigner.java
+++ b/common/src/main/java/org/apache/seata/common/security/HmacSigner.java
@@ -98,9 +98,15 @@ public final class HmacSigner {
     }
 
     /**
-     * Length-safe constant-time byte array comparison. Both inputs are walked to
-     * their full lengths before returning, so timing does not depend on which byte
-     * first differs.
+     * Length-safe constant-time byte array comparison. Any length or content difference
+     * fails; iteration never short-circuits on the first differing byte, so timing does
+     * not leak which byte first differs.
+     *
+     * <p>The loop is bounded by the shorter input because in this class the reference
+     * value {@code expected} always has a fixed algorithm-defined MAC length (32 bytes
+     * for HMAC-SHA-256). Only {@code received} is attacker-controlled, and its length is
+     * a value the attacker already picked, so timing tied to {@code received.length}
+     * cannot reveal any secret material.
      */
     static boolean constantTimeEquals(byte[] a, byte[] b) {
         if (a == null || b == null) {

--- a/common/src/main/java/org/apache/seata/common/security/HmacSigner.java
+++ b/common/src/main/java/org/apache/seata/common/security/HmacSigner.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Core HMAC sign / verify logic. Deliberately kept small and dependency-free so it can be
+ * shared between {@code common}, {@code namingserver}, {@code seata-server} and clients.
+ *
+ * <h3>Signing</h3>
+ * {@link #sign(CanonicalRequest, byte[])} produces the Base64-encoded MAC that goes into the
+ * {@link SecurityConstants#HEADER_SIGNATURE} header.
+ *
+ * <h3>Verifying</h3>
+ * {@link #verify(CanonicalRequest, byte[], String)} recomputes the MAC and compares it with the
+ * received value using a <b>constant-time</b> comparison. That defends against timing side
+ * channels that would otherwise let an attacker guess the signature one byte at a time.
+ *
+ * <p>The class is stateless and thread-safe: each call creates a fresh {@link Mac} instance.
+ * {@code Mac} itself is <em>not</em> thread-safe if reused across threads, but constructing one is
+ * cheap compared to the network round trip we are protecting.
+ */
+public final class HmacSigner {
+
+    /** Reject secrets shorter than this to prevent trivial brute force. 256 bit minimum. */
+    public static final int MIN_KEY_LENGTH_BYTES = 32;
+
+    private HmacSigner() {
+        // utility
+    }
+
+    /**
+     * Sign a canonical request.
+     *
+     * @param request the request being signed
+     * @param secret  raw shared secret bytes (≥ {@link #MIN_KEY_LENGTH_BYTES})
+     * @return Base64-encoded MAC
+     * @throws IllegalArgumentException if the secret is too short
+     * @throws IllegalStateException    if the JCA provider is missing the algorithm
+     */
+    public static String sign(CanonicalRequest request, byte[] secret) {
+        Objects.requireNonNull(request, "request");
+        validateSecret(secret);
+        byte[] mac = mac(
+                request.getAlgorithm(),
+                secret,
+                SignatureCanonicalizer.canonicalize(request).getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(mac);
+    }
+
+    /**
+     * Verify a signature. Returns {@code true} iff the recomputed signature exactly matches the
+     * received value, in constant time relative to the signature length.
+     *
+     * @param request           canonical request as the receiver reconstructed it
+     * @param secret            the shared secret for the caller identity
+     * @param receivedSignature Base64 string from {@link SecurityConstants#HEADER_SIGNATURE}
+     * @return {@code true} iff the signature is valid
+     */
+    public static boolean verify(CanonicalRequest request, byte[] secret, String receivedSignature) {
+        if (receivedSignature == null || receivedSignature.isEmpty()) {
+            return false;
+        }
+        byte[] received;
+        try {
+            received = Base64.getDecoder().decode(receivedSignature);
+        } catch (IllegalArgumentException badBase64) {
+            // Not valid Base64 → cannot possibly match. Do NOT surface the reason
+            // to the caller: it would leak information about the failure mode.
+            return false;
+        }
+        byte[] expected = mac(
+                request.getAlgorithm(),
+                secret,
+                SignatureCanonicalizer.canonicalize(request).getBytes(StandardCharsets.UTF_8));
+        return constantTimeEquals(expected, received);
+    }
+
+    /**
+     * Length-safe constant-time byte array comparison. Both inputs are walked to
+     * their full lengths before returning, so timing does not depend on which byte
+     * first differs.
+     */
+    static boolean constantTimeEquals(byte[] a, byte[] b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        // XOR the length difference into the accumulator too: mismatched lengths must
+        // never fast-fail (that would leak length via timing).
+        int diff = a.length ^ b.length;
+        int len = Math.min(a.length, b.length);
+        for (int i = 0; i < len; i++) {
+            diff |= (a[i] ^ b[i]);
+        }
+        return diff == 0;
+    }
+
+    static byte[] mac(SignatureAlgorithm algorithm, byte[] secret, byte[] message) {
+        try {
+            Mac mac = Mac.getInstance(algorithm.jcaName());
+            mac.init(new SecretKeySpec(secret, algorithm.jcaName()));
+            return mac.doFinal(message);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MAC algorithm " + algorithm.jcaName() + " not available on this JVM", e);
+        } catch (InvalidKeyException e) {
+            throw new IllegalArgumentException("invalid HMAC key", e);
+        }
+    }
+
+    private static void validateSecret(byte[] secret) {
+        if (secret == null || secret.length < MIN_KEY_LENGTH_BYTES) {
+            throw new IllegalArgumentException("shared secret must be at least "
+                    + MIN_KEY_LENGTH_BYTES + " bytes (256 bit); got "
+                    + (secret == null ? 0 : secret.length));
+        }
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/NonceCache.java
+++ b/common/src/main/java/org/apache/seata/common/security/NonceCache.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A per-JVM anti-replay cache. It stores nonces recently seen inside the replay window and
+ * refuses to re-admit any of them, so an attacker cannot capture a signed request and re-send it.
+ *
+ * <h3>Design notes</h3>
+ * <ul>
+ *   <li>Backed by {@link ConcurrentHashMap} of {@code cluster-id + '|' + nonce → insertion millis}
+ *       — namespacing by cluster-id prevents cross-tenant nonce collisions.</li>
+ *   <li>Lazy eviction: entries are removed on access when older than the TTL. A tiny amount of
+ *       cross-check work amortises against every {@link #putIfAbsent(String, String)} call,
+ *       so we do not need a background thread.</li>
+ *   <li>The single-node scope is intentional — this class only defends replay against the
+ *       exact same NamingServer node. To defend across nodes when the caller cycles hosts,
+ *       bind the target node id into the signature (see {@code CanonicalRequest}). A future
+ *       Redis-backed impl of this interface would close the multi-node gap.</li>
+ * </ul>
+ */
+public interface NonceCache {
+
+    /**
+     * Attempt to register a nonce for a given cluster identity.
+     *
+     * @param clusterId caller identity ({@code X-Seata-Cluster-Id} header value)
+     * @param nonce     the received nonce ({@code X-Seata-Nonce} header value)
+     * @return {@code true} if the nonce was fresh and has been recorded;
+     *         {@code false} if the same nonce was already seen inside the TTL
+     */
+    boolean putIfAbsent(String clusterId, String nonce);
+
+    /** Current cache size — exposed for metrics / tests. */
+    int size();
+
+    /** Force TTL eviction now — normally not needed; provided for tests. */
+    void evictExpired();
+
+    /**
+     * Default in-memory implementation. Thread-safe, lock-free on the fast path.
+     */
+    final class InMemory implements NonceCache {
+
+        private final ConcurrentHashMap<String, Long> entries = new ConcurrentHashMap<>();
+        private final long ttlMillis;
+        private final AtomicLong opsSinceLastSweep = new AtomicLong();
+        private final long sweepEveryOps;
+        private final Clock clock;
+
+        /**
+         * @param ttlMillis how long a nonce is remembered
+         * @param clock     time source (injectable for deterministic tests)
+         */
+        public InMemory(long ttlMillis, Clock clock) {
+            this(ttlMillis, clock, 1024L);
+        }
+
+        /**
+         * @param ttlMillis     nonce TTL
+         * @param clock         time source
+         * @param sweepEveryOps run a lazy TTL sweep once every N operations
+         */
+        public InMemory(long ttlMillis, Clock clock, long sweepEveryOps) {
+            if (ttlMillis <= 0) {
+                throw new IllegalArgumentException("ttlMillis must be > 0");
+            }
+            this.ttlMillis = ttlMillis;
+            this.clock = clock == null ? System::currentTimeMillis : clock;
+            this.sweepEveryOps = Math.max(1L, sweepEveryOps);
+        }
+
+        @Override
+        public boolean putIfAbsent(String clusterId, String nonce) {
+            if (clusterId == null || nonce == null) {
+                throw new IllegalArgumentException("clusterId and nonce must not be null");
+            }
+            long now = clock.now();
+            String key = key(clusterId, nonce);
+            Long prev = entries.putIfAbsent(key, now);
+            if (prev != null) {
+                // If the existing entry has itself expired, treat this as a fresh insert.
+                if (now - prev > ttlMillis) {
+                    // Replace only if nobody has moved the value in the meantime.
+                    if (entries.replace(key, prev, now)) {
+                        maybeSweep(now);
+                        return true;
+                    }
+                    // Someone else already registered it after expiry — treat as replay.
+                    return false;
+                }
+                return false;
+            }
+            maybeSweep(now);
+            return true;
+        }
+
+        @Override
+        public int size() {
+            return entries.size();
+        }
+
+        @Override
+        public void evictExpired() {
+            long now = clock.now();
+            Iterator<Map.Entry<String, Long>> it = entries.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, Long> e = it.next();
+                if (now - e.getValue() > ttlMillis) {
+                    it.remove();
+                }
+            }
+        }
+
+        private void maybeSweep(long now) {
+            long ops = opsSinceLastSweep.incrementAndGet();
+            if (ops % sweepEveryOps == 0) {
+                evictExpired();
+            }
+        }
+
+        private static String key(String clusterId, String nonce) {
+            // Deliberately a plain concatenation with a delimiter that cannot appear inside
+            // a UUID nonce or a cluster-id. Avoids the overhead of building a composite key object.
+            return clusterId + '|' + nonce;
+        }
+    }
+
+    /** Trivial injectable clock so we can advance time in tests without sleeping. */
+    @FunctionalInterface
+    interface Clock {
+        long now();
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/NonceCache.java
+++ b/common/src/main/java/org/apache/seata/common/security/NonceCache.java
@@ -27,8 +27,11 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <h3>Design notes</h3>
  * <ul>
- *   <li>Backed by {@link ConcurrentHashMap} of {@code cluster-id + '|' + nonce → insertion millis}
- *       — namespacing by cluster-id prevents cross-tenant nonce collisions.</li>
+ *   <li>Backed by {@link ConcurrentHashMap} keyed by a length-prefixed composite of
+ *       {@code cluster-id} and {@code nonce}. The length prefix makes the split point
+ *       unambiguous, so no two distinct {@code (clusterId, nonce)} pairs can collide even
+ *       when either value contains arbitrary characters — this prevents cross-tenant
+ *       DoS via crafted headers.</li>
  *   <li>Lazy eviction: entries are removed on access when older than the TTL. A tiny amount of
  *       cross-check work amortises against every {@link #putIfAbsent(String, String)} call,
  *       so we do not need a background thread.</li>
@@ -139,9 +142,10 @@ public interface NonceCache {
         }
 
         private static String key(String clusterId, String nonce) {
-            // Deliberately a plain concatenation with a delimiter that cannot appear inside
-            // a UUID nonce or a cluster-id. Avoids the overhead of building a composite key object.
-            return clusterId + '|' + nonce;
+            // Length-prefix the cluster-id so that (a, b) and (c, d) can never collide
+            // as long as they are distinct pairs — both values are attacker-controlled
+            // headers, so any delimiter alone is insufficient.
+            return clusterId.length() + ":" + clusterId + nonce;
         }
     }
 

--- a/common/src/main/java/org/apache/seata/common/security/SecurityConstants.java
+++ b/common/src/main/java/org/apache/seata/common/security/SecurityConstants.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+/**
+ * Header names and error codes used by the HMAC-based authentication protocol
+ * between Seata NamingServer and Seata Server (TC), and by Client (TM/RM) when
+ * upgraded to HMAC signing.
+ *
+ * <p>Header prefix {@code X-Seata-} keeps these fields distinguishable from
+ * platform-standard HTTP headers and easy to allow through reverse proxies.
+ */
+public final class SecurityConstants {
+
+    /** Identifies the caller cluster/tenant. Receiver uses this to look up the shared secret. */
+    public static final String HEADER_CLUSTER_ID = "X-Seata-Cluster-Id";
+
+    /** Millisecond timestamp of when the request was signed. Used to bound the replay window. */
+    public static final String HEADER_TIMESTAMP = "X-Seata-Timestamp";
+
+    /** Random nonce (typically a UUID). Combined with timestamp to prevent replay. */
+    public static final String HEADER_NONCE = "X-Seata-Nonce";
+
+    /** Signature algorithm identifier, e.g. {@code HMAC-SHA256}. Reserved for future upgrades. */
+    public static final String HEADER_SIGN_ALG = "X-Seata-Sign-Alg";
+
+    /** Base64-encoded signature bytes. */
+    public static final String HEADER_SIGNATURE = "X-Seata-Sign";
+
+    /**
+     * Default maximum clock skew allowed between caller and receiver, in seconds.
+     * Requests older or newer than {@code now ± this} are rejected.
+     */
+    public static final long DEFAULT_REPLAY_WINDOW_SECONDS = 300L;
+
+    /**
+     * Default nonce cache TTL, in minutes. Must be strictly greater than
+     * {@link #DEFAULT_REPLAY_WINDOW_SECONDS} to guarantee that any timestamp
+     * inside the window still finds its nonce in the cache.
+     */
+    public static final long DEFAULT_NONCE_CACHE_MINUTES = 10L;
+
+    private SecurityConstants() {
+        // constants holder
+    }
+
+    /**
+     * Machine-readable authentication error codes. Emitted via response header
+     * {@code X-Seata-Auth-Error} and logged for audit / metrics.
+     */
+    public enum ErrorCode {
+        /** No signature headers present. Only allowed when {@code security.mode=warn}. */
+        MISSING_SIGNATURE,
+        /** {@link SecurityConstants#HEADER_CLUSTER_ID} value has no matching identity on the receiver. */
+        UNKNOWN_CLUSTER_ID,
+        /** Timestamp is outside {@code now ± replayWindow}. */
+        TIMESTAMP_SKEW,
+        /** Nonce already seen inside the replay window. */
+        REPLAY_DETECTED,
+        /** Recomputed signature does not match the provided one. */
+        BAD_SIGNATURE,
+        /** Signature algorithm value is unknown / unsupported. */
+        UNSUPPORTED_ALG,
+        /** Caller identity is authentic but lacks the required permission for the resource. */
+        FORBIDDEN,
+        /** Malformed request: missing required field, bad Base64, etc. */
+        BAD_REQUEST
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/SignatureAlgorithm.java
+++ b/common/src/main/java/org/apache/seata/common/security/SignatureAlgorithm.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import java.util.Objects;
+
+/**
+ * Supported MAC / signature algorithms. Kept as an enum with a wire identifier so we can
+ * (a) advertise the algorithm in {@link SecurityConstants#HEADER_SIGN_ALG} for future upgrades,
+ * and (b) refuse unknown values instead of silently defaulting.
+ */
+public enum SignatureAlgorithm {
+
+    /** HMAC-SHA256 — 256 bit output; used as the default. */
+    HMAC_SHA256("HMAC-SHA256", "HmacSHA256"),
+
+    /** HMAC-SHA512 — 512 bit output; opt-in for higher security workloads. */
+    HMAC_SHA512("HMAC-SHA512", "HmacSHA512");
+
+    private final String wireName;
+
+    private final String jcaName;
+
+    SignatureAlgorithm(String wireName, String jcaName) {
+        this.wireName = wireName;
+        this.jcaName = jcaName;
+    }
+
+    /** The identifier that appears on the wire (in the {@code X-Seata-Sign-Alg} header). */
+    public String wireName() {
+        return wireName;
+    }
+
+    /** JCA {@code Mac.getInstance(...)} algorithm name. */
+    public String jcaName() {
+        return jcaName;
+    }
+
+    /**
+     * Parse a wire name back to an enum value.
+     *
+     * @param wireName value from the {@code X-Seata-Sign-Alg} header, e.g. {@code HMAC-SHA256}
+     * @return the matching enum
+     * @throws IllegalArgumentException if the value is null, blank, or unknown
+     */
+    public static SignatureAlgorithm fromWireName(String wireName) {
+        if (wireName == null || wireName.isEmpty()) {
+            throw new IllegalArgumentException("signature algorithm must not be blank");
+        }
+        for (SignatureAlgorithm alg : values()) {
+            if (Objects.equals(alg.wireName, wireName)) {
+                return alg;
+            }
+        }
+        throw new IllegalArgumentException("unsupported signature algorithm: " + wireName);
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/SignatureCanonicalizer.java
+++ b/common/src/main/java/org/apache/seata/common/security/SignatureCanonicalizer.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Produces the deterministic {@code signString} that both signer and verifier feed into HMAC.
+ *
+ * <p>Format:
+ * <pre>
+ * signString = METHOD          + "\n"
+ *            + PATH            + "\n"
+ *            + CANONICAL_QUERY + "\n"    // key1=v1&amp;key2=v2 sorted by key, URL-encoded
+ *            + CLUSTER_ID      + "\n"
+ *            + TIMESTAMP       + "\n"
+ *            + NONCE           + "\n"
+ *            + SHA256_HEX(body)
+ * </pre>
+ *
+ * <p>Rationale for each field:
+ * <ul>
+ *   <li><b>method</b>: prevents an attacker from replaying a signed GET as a DELETE.</li>
+ *   <li><b>path</b>: prevents routing a signed {@code /addVGroup} to {@code /removeVGroup}.</li>
+ *   <li><b>canonical query</b>: prevents parameter tampering (e.g. changing {@code vGroup}).
+ *       Keys are sorted to make the encoding deterministic across languages.</li>
+ *   <li><b>clusterId + timestamp + nonce</b>: bind the signature to a specific caller
+ *       and freshness window; the verifier extracts these from headers and reuses them here.</li>
+ *   <li><b>body digest</b>: signing the body directly would force the verifier to buffer
+ *       the entire payload; a fixed-size SHA-256 digest keeps the {@code signString} bounded.</li>
+ * </ul>
+ */
+public final class SignatureCanonicalizer {
+
+    private SignatureCanonicalizer() {
+        // utility
+    }
+
+    /**
+     * Build the canonical string for the given request.
+     *
+     * @param request the request being signed (or verified)
+     * @return the string to feed into the MAC
+     */
+    public static String canonicalize(CanonicalRequest request) {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append(request.getMethod()).append('\n');
+        sb.append(request.getPath()).append('\n');
+        sb.append(canonicalQuery(request.getQueryParams())).append('\n');
+        sb.append(request.getClusterId()).append('\n');
+        sb.append(request.getTimestampMillis()).append('\n');
+        sb.append(request.getNonce()).append('\n');
+        sb.append(sha256Hex(request.getBody()));
+        return sb.toString();
+    }
+
+    /**
+     * Sort {@code query} by key ascending and produce a URL-encoded {@code k=v&k=v} string.
+     * Empty map → empty string. Null values are treated as empty strings (avoids differing
+     * encoders producing {@code k=null} vs {@code k=}).
+     */
+    static String canonicalQuery(Map<String, String> query) {
+        if (query == null || query.isEmpty()) {
+            return "";
+        }
+        List<String> keys = new ArrayList<>(query.keySet());
+        Collections.sort(keys);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < keys.size(); i++) {
+            String key = keys.get(i);
+            String value = query.get(key);
+            if (i > 0) {
+                sb.append('&');
+            }
+            sb.append(urlEncode(key)).append('=').append(urlEncode(value == null ? "" : value));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Lowercase hex-encoded SHA-256 digest of the given bytes. Empty input still produces a
+     * well-defined digest ({@code e3b0c44298fc...}), which is what we want for empty-body requests.
+     */
+    static String sha256Hex(byte[] body) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] out = digest.digest(body == null ? new byte[0] : body);
+            return toHexLower(out);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandated by every JCA provider; this is effectively unreachable.
+            throw new IllegalStateException("SHA-256 not available in this JVM", e);
+        }
+    }
+
+    /** URL-encode using RFC 3986 semantics; wraps checked exception. */
+    private static String urlEncode(String value) {
+        try {
+            // URLEncoder produces application/x-www-form-urlencoded ('+' for space);
+            // convert to '%20' to match RFC 3986 which most servers expect on query strings.
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name())
+                    .replace("+", "%20")
+                    .replace("*", "%2A")
+                    .replace("%7E", "~");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 unavailable — impossible on a conforming JVM", e);
+        }
+    }
+
+    /** Lowercase hex encoding without external deps. */
+    private static String toHexLower(byte[] bytes) {
+        char[] hexArray = "0123456789abcdef".toCharArray();
+        char[] out = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xFF;
+            out[i * 2] = hexArray[v >>> 4];
+            out[i * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(out);
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/SignatureVerifier.java
+++ b/common/src/main/java/org/apache/seata/common/security/SignatureVerifier.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import java.util.Objects;
+
+/**
+ * Full verification pipeline for an inbound signed request. Combines four checks in this order:
+ *
+ * <ol>
+ *   <li><b>Freshness</b> — timestamp must be within {@code now ± replayWindow}. Rejects
+ *       captured-but-stale requests.</li>
+ *   <li><b>Nonce uniqueness</b> — the {@code (clusterId, nonce)} pair must not have been
+ *       seen in the recent past. Rejects verbatim replays inside the freshness window.</li>
+ *   <li><b>Signature validity</b> — the HMAC must match, computed in constant time.</li>
+ *   <li>(Caller-supplied) <b>Authorization</b> — mapping cluster-id to allowed namespaces /
+ *       clusters / vgroups happens outside this class in {@code PermissionChecker}, since it
+ *       depends on receiver-specific data models.</li>
+ * </ol>
+ *
+ * <p>The ordering matters: cheap checks first so that malformed traffic never reaches the
+ * expensive HMAC computation. This also prevents CPU-exhaustion DoS via forged signatures.
+ */
+public final class SignatureVerifier {
+
+    private final NonceCache nonceCache;
+
+    private final long replayWindowMillis;
+
+    private final NonceCache.Clock clock;
+
+    /**
+     * @param nonceCache          the replay-detection cache
+     * @param replayWindowMillis  maximum accepted clock skew, in milliseconds
+     * @param clock               time source (defaults to {@link System#currentTimeMillis()} if null)
+     */
+    public SignatureVerifier(NonceCache nonceCache, long replayWindowMillis, NonceCache.Clock clock) {
+        this.nonceCache = Objects.requireNonNull(nonceCache, "nonceCache");
+        if (replayWindowMillis <= 0) {
+            throw new IllegalArgumentException("replayWindowMillis must be > 0");
+        }
+        this.replayWindowMillis = replayWindowMillis;
+        this.clock = clock == null ? System::currentTimeMillis : clock;
+    }
+
+    /**
+     * Verify one canonical request against a shared secret.
+     *
+     * @param request           the reconstructed canonical request
+     * @param secret            the shared secret associated with {@code request.getClusterId()}
+     * @param receivedSignature Base64 signature from the {@code X-Seata-Sign} header
+     * @return a structured verdict — never {@code null}
+     */
+    public VerificationResult verify(CanonicalRequest request, byte[] secret, String receivedSignature) {
+        Objects.requireNonNull(request, "request");
+        if (secret == null || secret.length == 0) {
+            return VerificationResult.failure(
+                    SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID,
+                    "no secret configured for cluster-id: " + request.getClusterId());
+        }
+        if (receivedSignature == null || receivedSignature.isEmpty()) {
+            return VerificationResult.failure(
+                    SecurityConstants.ErrorCode.MISSING_SIGNATURE,
+                    "missing " + SecurityConstants.HEADER_SIGNATURE + " header");
+        }
+
+        // 1) Freshness — cheap, must come before any keyed hashing.
+        long now = clock.now();
+        long delta = Math.abs(now - request.getTimestampMillis());
+        if (delta > replayWindowMillis) {
+            return VerificationResult.failure(
+                    SecurityConstants.ErrorCode.TIMESTAMP_SKEW,
+                    "timestamp skew of " + delta + "ms exceeds window " + replayWindowMillis + "ms");
+        }
+
+        // 2) Nonce uniqueness — also cheap. Must precede signature check for two reasons:
+        //    (a) DoS resistance — a replay of a valid signature would otherwise pay full HMAC cost;
+        //    (b) it prevents attackers from probing (clusterId, nonce) admission timing.
+        boolean fresh;
+        try {
+            fresh = nonceCache.putIfAbsent(request.getClusterId(), request.getNonce());
+        } catch (IllegalArgumentException bad) {
+            return VerificationResult.failure(SecurityConstants.ErrorCode.BAD_REQUEST, bad.getMessage());
+        }
+        if (!fresh) {
+            return VerificationResult.failure(
+                    SecurityConstants.ErrorCode.REPLAY_DETECTED,
+                    "nonce already used for cluster-id " + request.getClusterId());
+        }
+
+        // 3) Signature — the expensive check runs last.
+        boolean valid;
+        try {
+            valid = HmacSigner.verify(request, secret, receivedSignature);
+        } catch (IllegalArgumentException bad) {
+            return VerificationResult.failure(SecurityConstants.ErrorCode.BAD_REQUEST, bad.getMessage());
+        }
+        if (!valid) {
+            return VerificationResult.failure(SecurityConstants.ErrorCode.BAD_SIGNATURE, "signature does not match");
+        }
+
+        return VerificationResult.ok();
+    }
+}

--- a/common/src/main/java/org/apache/seata/common/security/VerificationResult.java
+++ b/common/src/main/java/org/apache/seata/common/security/VerificationResult.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+/**
+ * Structured outcome of a signature verification. Using a rich result object instead of a
+ * boolean lets the caller build accurate audit logs / metrics without re-running the check.
+ */
+public final class VerificationResult {
+
+    private static final VerificationResult OK = new VerificationResult(true, null, null);
+
+    private final boolean success;
+
+    private final SecurityConstants.ErrorCode errorCode;
+
+    private final String message;
+
+    private VerificationResult(boolean success, SecurityConstants.ErrorCode errorCode, String message) {
+        this.success = success;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public static VerificationResult ok() {
+        return OK;
+    }
+
+    public static VerificationResult failure(SecurityConstants.ErrorCode code, String message) {
+        return new VerificationResult(false, code, message);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public SecurityConstants.ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/CanonicalRequestTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/CanonicalRequestTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CanonicalRequestTest {
+
+    @Test
+    void builder_populates_all_fields() {
+        Map<String, String> q = new HashMap<>();
+        q.put("k", "v");
+        CanonicalRequest req = CanonicalRequest.builder()
+                .method("post")
+                .path("/x")
+                .queryParams(q)
+                .clusterId("c")
+                .timestampMillis(42L)
+                .nonce("n")
+                .algorithm(SignatureAlgorithm.HMAC_SHA512)
+                .body("hi".getBytes())
+                .build();
+
+        assertEquals("POST", req.getMethod(), "method must be uppercased");
+        assertEquals("/x", req.getPath());
+        assertEquals("v", req.getQueryParams().get("k"));
+        assertEquals("c", req.getClusterId());
+        assertEquals(42L, req.getTimestampMillis());
+        assertEquals("n", req.getNonce());
+        assertEquals(SignatureAlgorithm.HMAC_SHA512, req.getAlgorithm());
+        assertEquals("hi", req.getBodyAsString());
+    }
+
+    @Test
+    void defaults_apply_when_optional_fields_omitted() {
+        CanonicalRequest req = CanonicalRequest.builder()
+                .method("GET")
+                .path("/")
+                .clusterId("c")
+                .timestampMillis(1L)
+                .nonce("n")
+                .build();
+        assertEquals(SignatureAlgorithm.HMAC_SHA256, req.getAlgorithm(), "algorithm should default to HMAC-SHA256");
+        assertEquals(0, req.getBody().length, "null body should be normalised to empty");
+        assertTrue(req.getQueryParams().isEmpty());
+    }
+
+    @Test
+    void body_getter_returns_defensive_copy() {
+        byte[] original = "abc".getBytes();
+        CanonicalRequest req = CanonicalRequest.builder()
+                .method("GET")
+                .path("/")
+                .clusterId("c")
+                .timestampMillis(1L)
+                .nonce("n")
+                .body(original)
+                .build();
+        byte[] a = req.getBody();
+        byte[] b = req.getBody();
+        assertNotSame(a, b, "each call should return a fresh copy");
+        a[0] = 0;
+        assertEquals('a', req.getBody()[0], "mutating the returned array must not affect state");
+    }
+
+    @Test
+    void required_fields_are_null_checked() {
+        assertThrows(NullPointerException.class, () -> CanonicalRequest.builder()
+                .method(null)
+                .path("/")
+                .clusterId("c")
+                .timestampMillis(0)
+                .nonce("n")
+                .build());
+        assertThrows(NullPointerException.class, () -> CanonicalRequest.builder()
+                .method("GET")
+                .path(null)
+                .clusterId("c")
+                .timestampMillis(0)
+                .nonce("n")
+                .build());
+        assertThrows(NullPointerException.class, () -> CanonicalRequest.builder()
+                .method("GET")
+                .path("/")
+                .clusterId(null)
+                .timestampMillis(0)
+                .nonce("n")
+                .build());
+        assertThrows(NullPointerException.class, () -> CanonicalRequest.builder()
+                .method("GET")
+                .path("/")
+                .clusterId("c")
+                .timestampMillis(0)
+                .nonce(null)
+                .build());
+    }
+
+    @Test
+    void query_params_are_immutable_view() {
+        Map<String, String> q = new HashMap<>();
+        q.put("k", "v");
+        CanonicalRequest req = CanonicalRequest.builder()
+                .method("GET")
+                .path("/")
+                .clusterId("c")
+                .timestampMillis(1L)
+                .nonce("n")
+                .queryParams(q)
+                .build();
+        assertThrows(
+                UnsupportedOperationException.class, () -> req.getQueryParams().put("x", "y"));
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/HmacSignerTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/HmacSignerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HmacSignerTest {
+
+    private static final byte[] SECRET_32 = new byte[] {
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+    };
+
+    @Test
+    void sign_then_verify_returns_true() {
+        CanonicalRequest req = req().build();
+        String sig = HmacSigner.sign(req, SECRET_32);
+        assertTrue(HmacSigner.verify(req, SECRET_32, sig), "self-verification must succeed");
+    }
+
+    @Test
+    void verify_fails_when_body_changes() {
+        CanonicalRequest signed = req().body("original".getBytes()).build();
+        String sig = HmacSigner.sign(signed, SECRET_32);
+
+        CanonicalRequest tampered = req().body("tampered".getBytes()).build();
+        assertFalse(HmacSigner.verify(tampered, SECRET_32, sig), "body tamper must be detected");
+    }
+
+    @Test
+    void verify_fails_when_secret_differs() {
+        CanonicalRequest req = req().build();
+        String sig = HmacSigner.sign(req, SECRET_32);
+        byte[] otherSecret = SECRET_32.clone();
+        otherSecret[0] ^= 0x55; // flip a few bits
+        assertFalse(HmacSigner.verify(req, otherSecret, sig));
+    }
+
+    @Test
+    void verify_returns_false_for_null_or_empty_signature() {
+        CanonicalRequest req = req().build();
+        assertFalse(HmacSigner.verify(req, SECRET_32, null));
+        assertFalse(HmacSigner.verify(req, SECRET_32, ""));
+    }
+
+    @Test
+    void verify_returns_false_for_non_base64_signature() {
+        CanonicalRequest req = req().build();
+        // Contains an illegal char for standard Base64 alphabet:
+        assertFalse(HmacSigner.verify(req, SECRET_32, "###not-base64###"));
+    }
+
+    @Test
+    void sign_rejects_short_secret() {
+        CanonicalRequest req = req().build();
+        byte[] tooShort = new byte[16];
+        assertThrows(IllegalArgumentException.class, () -> HmacSigner.sign(req, tooShort));
+    }
+
+    @Test
+    void sign_rejects_null_secret() {
+        CanonicalRequest req = req().build();
+        assertThrows(IllegalArgumentException.class, () -> HmacSigner.sign(req, null));
+    }
+
+    @Test
+    void sign_with_sha512_produces_different_output_than_sha256() {
+        CanonicalRequest sha256 =
+                req().algorithm(SignatureAlgorithm.HMAC_SHA256).build();
+        CanonicalRequest sha512 =
+                req().algorithm(SignatureAlgorithm.HMAC_SHA512).build();
+        String s256 = HmacSigner.sign(sha256, SECRET_32);
+        String s512 = HmacSigner.sign(sha512, SECRET_32);
+        assertFalse(s256.equals(s512), "different algorithms must produce different MACs");
+        assertTrue(HmacSigner.verify(sha512, SECRET_32, s512));
+    }
+
+    @Test
+    void constant_time_equals_returns_false_on_length_mismatch() {
+        assertFalse(HmacSigner.constantTimeEquals(new byte[] {1, 2, 3}, new byte[] {1, 2}));
+    }
+
+    @Test
+    void constant_time_equals_returns_true_on_equal_bytes() {
+        assertTrue(HmacSigner.constantTimeEquals(new byte[] {1, 2, 3}, new byte[] {1, 2, 3}));
+    }
+
+    @Test
+    void constant_time_equals_returns_false_on_null_input() {
+        assertFalse(HmacSigner.constantTimeEquals(null, new byte[] {1}));
+        assertFalse(HmacSigner.constantTimeEquals(new byte[] {1}, null));
+    }
+
+    @Test
+    void mac_output_length_matches_algorithm() {
+        byte[] out256 = HmacSigner.mac(SignatureAlgorithm.HMAC_SHA256, SECRET_32, "msg".getBytes());
+        byte[] out512 = HmacSigner.mac(SignatureAlgorithm.HMAC_SHA512, SECRET_32, "msg".getBytes());
+        assertEquals(32, out256.length, "HMAC-SHA256 must produce 256 bits");
+        assertEquals(64, out512.length, "HMAC-SHA512 must produce 512 bits");
+    }
+
+    @Test
+    void mac_is_deterministic() {
+        byte[] a = HmacSigner.mac(SignatureAlgorithm.HMAC_SHA256, SECRET_32, "same-input".getBytes());
+        byte[] b = HmacSigner.mac(SignatureAlgorithm.HMAC_SHA256, SECRET_32, "same-input".getBytes());
+        assertTrue(HmacSigner.constantTimeEquals(a, b), "same key + same input must yield identical MAC");
+    }
+
+    private static CanonicalRequest.Builder req() {
+        return CanonicalRequest.builder()
+                .method("POST")
+                .path("/naming/v1/register")
+                .clusterId("tenant-a")
+                .timestampMillis(1_700_000_000_000L)
+                .nonce("nonce-1");
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/NonceCacheTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/NonceCacheTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NonceCacheTest {
+
+    @Test
+    void first_nonce_admitted_then_replay_rejected() {
+        NonceCache cache = new NonceCache.InMemory(60_000L, () -> 1_000L);
+        assertTrue(cache.putIfAbsent("tenant-a", "nonce-1"));
+        assertFalse(cache.putIfAbsent("tenant-a", "nonce-1"), "second use inside TTL must be rejected");
+    }
+
+    @Test
+    void same_nonce_across_different_tenants_is_independent() {
+        NonceCache cache = new NonceCache.InMemory(60_000L, () -> 1_000L);
+        assertTrue(cache.putIfAbsent("tenant-a", "shared-nonce"));
+        assertTrue(cache.putIfAbsent("tenant-b", "shared-nonce"), "cluster-id must namespace the nonce");
+    }
+
+    @Test
+    void expired_nonce_can_be_reused() {
+        AtomicLong now = new AtomicLong(1_000L);
+        NonceCache cache = new NonceCache.InMemory(500L, now::get);
+
+        assertTrue(cache.putIfAbsent("tenant-a", "nonce"));
+        assertFalse(cache.putIfAbsent("tenant-a", "nonce")); // inside TTL
+
+        now.addAndGet(1_000L); // move well past TTL
+
+        assertTrue(cache.putIfAbsent("tenant-a", "nonce"), "after TTL, the same nonce is allowed again");
+    }
+
+    @Test
+    void evict_expired_clears_stale_entries() {
+        AtomicLong now = new AtomicLong(0L);
+        NonceCache cache = new NonceCache.InMemory(100L, now::get);
+
+        cache.putIfAbsent("t", "a");
+        cache.putIfAbsent("t", "b");
+        assertEquals(2, cache.size());
+
+        now.addAndGet(200L);
+        cache.evictExpired();
+        assertEquals(0, cache.size(), "all entries should have been swept");
+    }
+
+    @Test
+    void constructor_rejects_zero_or_negative_ttl() {
+        assertThrows(IllegalArgumentException.class, () -> new NonceCache.InMemory(0L, () -> 0L));
+        assertThrows(IllegalArgumentException.class, () -> new NonceCache.InMemory(-1L, () -> 0L));
+    }
+
+    @Test
+    void put_rejects_null_arguments() {
+        NonceCache cache = new NonceCache.InMemory(1000L, () -> 0L);
+        assertThrows(IllegalArgumentException.class, () -> cache.putIfAbsent(null, "n"));
+        assertThrows(IllegalArgumentException.class, () -> cache.putIfAbsent("t", null));
+    }
+
+    @Test
+    void concurrent_inserts_of_same_nonce_admit_exactly_one() throws Exception {
+        NonceCache cache = new NonceCache.InMemory(60_000L, System::currentTimeMillis);
+        int threads = 16;
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger admitted = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                pool.submit(() -> {
+                    try {
+                        latch.await();
+                        if (cache.putIfAbsent("t", "same")) {
+                            admitted.incrementAndGet();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            }
+            latch.countDown();
+            pool.shutdown();
+            assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+        assertEquals(1, admitted.get(), "even under contention, exactly one thread may register the nonce");
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/SignatureAlgorithmTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/SignatureAlgorithmTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SignatureAlgorithmTest {
+
+    @Test
+    void fromWireName_maps_to_expected_enum() {
+        assertEquals(SignatureAlgorithm.HMAC_SHA256, SignatureAlgorithm.fromWireName("HMAC-SHA256"));
+        assertEquals(SignatureAlgorithm.HMAC_SHA512, SignatureAlgorithm.fromWireName("HMAC-SHA512"));
+    }
+
+    @Test
+    void fromWireName_rejects_null_or_blank() {
+        assertThrows(IllegalArgumentException.class, () -> SignatureAlgorithm.fromWireName(null));
+        assertThrows(IllegalArgumentException.class, () -> SignatureAlgorithm.fromWireName(""));
+    }
+
+    @Test
+    void fromWireName_rejects_unknown_algorithm() {
+        assertThrows(IllegalArgumentException.class, () -> SignatureAlgorithm.fromWireName("MD5"));
+    }
+
+    @Test
+    void jca_names_are_stable() {
+        assertEquals("HmacSHA256", SignatureAlgorithm.HMAC_SHA256.jcaName());
+        assertEquals("HmacSHA512", SignatureAlgorithm.HMAC_SHA512.jcaName());
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/SignatureCanonicalizerTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/SignatureCanonicalizerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SignatureCanonicalizerTest {
+
+    @Test
+    void canonicalize_produces_stable_string_regardless_of_query_order() {
+        Map<String, String> orderA = new LinkedHashMap<>();
+        orderA.put("beta", "2");
+        orderA.put("alpha", "1");
+
+        Map<String, String> orderB = new LinkedHashMap<>();
+        orderB.put("alpha", "1");
+        orderB.put("beta", "2");
+
+        CanonicalRequest reqA = baseRequest().queryParams(orderA).build();
+        CanonicalRequest reqB = baseRequest().queryParams(orderB).build();
+
+        String a = SignatureCanonicalizer.canonicalize(reqA);
+        String b = SignatureCanonicalizer.canonicalize(reqB);
+
+        assertEquals(a, b, "same query set must produce identical canonical strings");
+        assertTrue(a.contains("alpha=1&beta=2"), "keys must appear in ascending order in the canonical query");
+    }
+
+    @Test
+    void canonicalize_body_change_changes_the_string() {
+        CanonicalRequest a = baseRequest().body("hello".getBytes()).build();
+        CanonicalRequest b = baseRequest().body("hellО".getBytes()).build();
+        assertNotEquals(
+                SignatureCanonicalizer.canonicalize(a),
+                SignatureCanonicalizer.canonicalize(b),
+                "any byte change in body must flip the SHA-256 tail");
+    }
+
+    @Test
+    void canonicalize_method_case_is_normalized_upper() {
+        CanonicalRequest lower = baseRequest().method("post").build();
+        CanonicalRequest upper = baseRequest().method("POST").build();
+        assertEquals(SignatureCanonicalizer.canonicalize(upper), SignatureCanonicalizer.canonicalize(lower));
+    }
+
+    @Test
+    void canonicalize_empty_query_and_body_still_produces_valid_string() {
+        CanonicalRequest req =
+                baseRequest().body(new byte[0]).queryParams(new HashMap<>()).build();
+        String s = SignatureCanonicalizer.canonicalize(req);
+        // 7 fixed segments split by \n. Body digest for empty input is a well-known constant.
+        assertTrue(
+                s.endsWith("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+                "empty body must hash to the well-known SHA-256 of empty input");
+    }
+
+    @Test
+    void canonical_query_url_encodes_special_characters() {
+        Map<String, String> params = new HashMap<>();
+        params.put("k", "a b/c=d&e");
+        String canonical = SignatureCanonicalizer.canonicalQuery(params);
+        // spaces become %20 (not '+'), slash '/' stays literal per URLEncoder,
+        // '=' inside value becomes %3D, '&' becomes %26.
+        assertEquals("k=a%20b%2Fc%3Dd%26e", canonical);
+    }
+
+    @Test
+    void canonical_query_handles_null_value_as_empty() {
+        Map<String, String> params = new HashMap<>();
+        params.put("k", null);
+        assertEquals("k=", SignatureCanonicalizer.canonicalQuery(params));
+    }
+
+    @Test
+    void sha256_hex_of_empty_matches_reference_vector() {
+        assertEquals(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                SignatureCanonicalizer.sha256Hex(new byte[0]));
+    }
+
+    @Test
+    void sha256_hex_of_abc_matches_reference_vector() {
+        // Standard NIST test vector for SHA-256("abc").
+        assertEquals(
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                SignatureCanonicalizer.sha256Hex("abc".getBytes()));
+    }
+
+    private static CanonicalRequest.Builder baseRequest() {
+        return CanonicalRequest.builder()
+                .method("POST")
+                .path("/naming/v1/register")
+                .clusterId("tenant-a")
+                .timestampMillis(1_700_000_000_000L)
+                .nonce("nonce-1")
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body("body".getBytes());
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/SignatureCanonicalizerTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/SignatureCanonicalizerTest.java
@@ -81,7 +81,8 @@ class SignatureCanonicalizerTest {
         Map<String, String> params = new HashMap<>();
         params.put("k", "a b/c=d&e");
         String canonical = SignatureCanonicalizer.canonicalQuery(params);
-        // spaces become %20 (not '+'), slash '/' stays literal per URLEncoder,
+        // spaces become %20 (canonicalizer rewrites the '+' produced by form-encoding),
+        // '/' becomes %2F because URLEncoder uses form-encoding semantics,
         // '=' inside value becomes %3D, '&' becomes %26.
         assertEquals("k=a%20b%2Fc%3Dd%26e", canonical);
     }

--- a/common/src/test/java/org/apache/seata/common/security/SignatureVerifierTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/SignatureVerifierTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SignatureVerifierTest {
+
+    private static final byte[] SECRET = new byte[] {
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+    };
+
+    private static final long NOW = 1_700_000_000_000L;
+
+    @Test
+    void happy_path_returns_ok() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        CanonicalRequest req = req(NOW).build();
+        String sig = HmacSigner.sign(req, SECRET);
+
+        VerificationResult result = verifier.verify(req, SECRET, sig);
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    void missing_signature_returns_missing_signature_error() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        VerificationResult r = verifier.verify(req(NOW).build(), SECRET, null);
+        assertFalse(r.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.MISSING_SIGNATURE, r.getErrorCode());
+    }
+
+    @Test
+    void missing_secret_returns_unknown_cluster_id_error() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        VerificationResult r = verifier.verify(req(NOW).build(), new byte[0], "sig");
+        assertFalse(r.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID, r.getErrorCode());
+    }
+
+    @Test
+    void timestamp_outside_window_returns_skew_error() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        long staleTs = NOW - (10 * 60 * 1000L); // 10 minutes in the past
+        CanonicalRequest req = req(staleTs).build();
+        String sig = HmacSigner.sign(req, SECRET);
+
+        VerificationResult r = verifier.verify(req, SECRET, sig);
+        assertFalse(r.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.TIMESTAMP_SKEW, r.getErrorCode());
+    }
+
+    @Test
+    void replay_of_valid_request_returns_replay_error() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        CanonicalRequest req = req(NOW).build();
+        String sig = HmacSigner.sign(req, SECRET);
+
+        assertTrue(verifier.verify(req, SECRET, sig).isSuccess());
+        VerificationResult replay = verifier.verify(req, SECRET, sig);
+        assertFalse(replay.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.REPLAY_DETECTED, replay.getErrorCode());
+    }
+
+    @Test
+    void tampered_body_returns_bad_signature() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        CanonicalRequest signed = req(NOW).body("clean".getBytes()).build();
+        String sig = HmacSigner.sign(signed, SECRET);
+
+        CanonicalRequest tampered =
+                req(NOW).nonce("nonce-2").body("dirty".getBytes()).build();
+        VerificationResult r = verifier.verify(tampered, SECRET, sig);
+        assertFalse(r.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.BAD_SIGNATURE, r.getErrorCode());
+    }
+
+    @Test
+    void constructor_rejects_null_cache_or_bad_window() {
+        NonceCache cache = new NonceCache.InMemory(1000L, () -> 0L);
+        assertThrows(NullPointerException.class, () -> new SignatureVerifier(null, 100L, () -> 0L));
+        assertThrows(IllegalArgumentException.class, () -> new SignatureVerifier(cache, 0L, () -> 0L));
+    }
+
+    @Test
+    void timestamp_ordering_is_symmetric_around_now() {
+        SignatureVerifier verifier = newVerifier(NOW);
+        // Timestamp 4 minutes ahead of "now" is inside the 5 minute window and must pass.
+        CanonicalRequest future = req(NOW + 4 * 60 * 1000L).build();
+        String sig = HmacSigner.sign(future, SECRET);
+        assertTrue(verifier.verify(future, SECRET, sig).isSuccess());
+    }
+
+    private SignatureVerifier newVerifier(long fixedNow) {
+        AtomicLong clock = new AtomicLong(fixedNow);
+        NonceCache cache = new NonceCache.InMemory(60_000L, clock::get);
+        return new SignatureVerifier(cache, 5 * 60 * 1000L, clock::get);
+    }
+
+    private CanonicalRequest.Builder req(long ts) {
+        return CanonicalRequest.builder()
+                .method("POST")
+                .path("/naming/v1/register")
+                .clusterId("tenant-a")
+                .timestampMillis(ts)
+                .nonce("nonce-" + ts)
+                .body("body".getBytes());
+    }
+}

--- a/common/src/test/java/org/apache/seata/common/security/VerificationResultTest.java
+++ b/common/src/test/java/org/apache/seata/common/security/VerificationResultTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.common.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VerificationResultTest {
+
+    @Test
+    void ok_returns_singleton() {
+        assertSame(
+                VerificationResult.ok(),
+                VerificationResult.ok(),
+                "success result should be shared to avoid allocation");
+        assertTrue(VerificationResult.ok().isSuccess());
+        assertNull(VerificationResult.ok().getErrorCode());
+        assertNull(VerificationResult.ok().getMessage());
+    }
+
+    @Test
+    void failure_captures_code_and_message() {
+        VerificationResult r = VerificationResult.failure(SecurityConstants.ErrorCode.BAD_SIGNATURE, "boom");
+        assertFalse(r.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.BAD_SIGNATURE, r.getErrorCode());
+        assertEquals("boom", r.getMessage());
+    }
+
+    @Test
+    void failure_allows_null_message() {
+        VerificationResult r = VerificationResult.failure(SecurityConstants.ErrorCode.FORBIDDEN, null);
+        assertFalse(r.isSuccess());
+        assertNull(r.getMessage());
+    }
+}

--- a/docs/SECURITY_AUTH_GUIDE.md
+++ b/docs/SECURITY_AUTH_GUIDE.md
@@ -1,3 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 # Seata NamingServer ↔ Seata Server 鉴权：完整配置与使用指南
 
 > 本文档针对基于方案 A（**HMAC-SHA256 预共享密钥签名**）的鉴权实现，覆盖：

--- a/docs/SECURITY_AUTH_GUIDE.md
+++ b/docs/SECURITY_AUTH_GUIDE.md
@@ -1,0 +1,873 @@
+# Seata NamingServer ↔ Seata Server 鉴权：完整配置与使用指南
+
+> 本文档针对基于方案 A（**HMAC-SHA256 预共享密钥签名**）的鉴权实现，覆盖：
+> - 架构总览与工作原理
+> - 完整配置项参考
+> - 分场景部署示例（单集群 / 多租户 / Raft）
+> - 密钥生成、轮换、销毁
+> - Client SDK 集成（可选）
+> - 灰度启用、监控告警、故障排查
+> - 兼容性、限制与常见问题
+>
+> 相关代码：
+> - 通用签名工具：`common/src/main/java/org/apache/seata/common/security/`
+> - NamingServer 侧鉴权：`namingserver/src/main/java/org/apache/seata/namingserver/security/`
+> - Seata Server 侧鉴权：`server/src/main/java/org/apache/seata/server/security/`
+> - 设计文档：[`NAMINGSERVER_ARCHITECTURE.md`](../NAMINGSERVER_ARCHITECTURE.md) §11
+
+---
+
+## 1. 架构总览
+
+### 1.1 核心概念
+
+| 概念 | 说明 | 生存周期 |
+|------|------|----------|
+| **cluster-id** | 集群身份标识，唯一标识一套 TC 集群或一台 NamingServer 实例 | 相对稳定，除非组织结构调整 |
+| **secret** | 32 字节共享密钥（Base64 编码），与 cluster-id 一一对应 | 建议 ≤ 90 天轮换 |
+| **timestamp** | 请求签名时的毫秒时间戳，用于防重放 | 单次请求有效 |
+| **nonce** | 随机 UUID，与 timestamp 联合防重放 | 10 分钟内不可复用 |
+| **signature** | HMAC-SHA256(secret, canonicalRequest) 的 Base64 编码 | 单次请求有效 |
+| **permissions** | 该 cluster-id 拥有的权限集合（REGISTER / VGROUP_WRITE / ...） | 相对稳定 |
+| **allowed-namespaces / clusters / vgroups** | 该 cluster-id 可访问的资源范围（NamingServer 侧） | 相对稳定 |
+
+### 1.2 请求签名流程
+
+```
+签名方（TC 或 NamingServer）                       验签方
+┌──────────────────────────────┐                 ┌──────────────────────────────┐
+│  1. 构造 CanonicalRequest    │                 │                              │
+│     (method+path+query       │                 │                              │
+│      +cluster-id+ts+nonce    │                 │                              │
+│      +sha256(body))          │                 │                              │
+│  2. HMAC-SHA256(secret, .)   │                 │                              │
+│  3. 附加 X-Seata-* 头        │───── HTTP ────►│  1. 检查时间戳 (±5min)      │
+│                              │                 │  2. 检查 nonce 是否已使用    │
+│                              │                 │  3. 用 secret 重算签名       │
+│                              │                 │  4. constant-time 比较       │
+│                              │                 │  5. 检查 permission 与资源   │
+│                              │                 │  6. 通过 → 转发到 Controller │
+│                              │                 │     失败 → 401/403 拒绝     │
+└──────────────────────────────┘                 └──────────────────────────────┘
+```
+
+### 1.3 HTTP 头字段规范
+
+| Header | 示例 | 说明 |
+|--------|------|------|
+| `X-Seata-Cluster-Id` | `tenant-a-prod` | 调用者身份，接收方据此查密钥 |
+| `X-Seata-Timestamp` | `1721995200123` | 毫秒时间戳 |
+| `X-Seata-Nonce` | `f7a3c9d2-8b4e-4a1c-9e5f-3d2a1b8c7e6f` | UUID 或其他不可猜测字符串 |
+| `X-Seata-Sign-Alg` | `HMAC-SHA256` | 可选，默认 `HMAC-SHA256`。支持 `HMAC-SHA512` |
+| `X-Seata-Sign` | `dGVzdHNpZ25hdHVyZXBheWxvYWRoZXJl...` | Base64 编码的签名值 |
+
+### 1.4 canonicalRequest 生成规则
+
+```
+signString = HTTP_METHOD          + "\n"
+           + URI_PATH             + "\n"
+           + CANONICAL_QUERY      + "\n"        # k1=v1&k2=v2 sorted by key, URL-encoded
+           + CLUSTER_ID           + "\n"
+           + TIMESTAMP            + "\n"
+           + NONCE                + "\n"
+           + SHA256_HEX(body)                   # empty body → e3b0c442...
+```
+
+**关键约束**：
+- `HTTP_METHOD` 必须大写
+- `CANONICAL_QUERY` 键名必须按字典序升序拼接
+- 空 body 使用 `SHA256("")` 的固定值
+- 所有字符串用 UTF-8 编码
+
+---
+
+## 2. 完整配置参考
+
+### 2.1 NamingServer 端配置（`seata.security.*`）
+
+配置类：`org.apache.seata.namingserver.security.SecurityProperties`
+
+```yaml
+seata:
+  security:
+    # ================== 开关 ==================
+    enabled: true                          # 是否加载鉴权层。false → 完全跳过（不注册 Filter Bean）
+    mode: ENFORCE                          # DISABLED | WARN | ENFORCE
+                                           #   DISABLED: 与 enabled=false 等价
+                                           #   WARN:     鉴权失败仅记录日志，不拒绝请求（用于灰度）
+                                           #   ENFORCE:  鉴权失败返回 401/403（生产模式）
+
+    # ================== 防重放参数 ==================
+    replay-window-seconds: 300             # 时间戳允许的最大偏差（前后），秒。默认 300
+    nonce-cache-minutes: 10                # Nonce 记忆时长，分钟。必须 > replay-window-seconds
+
+    # ================== 排除路径（Ant-style） ==================
+    exclude-paths:
+      - /naming/v1/health                  # 健康检查绕过
+      - /actuator/**                       # 若开启 Actuator
+
+    # ================== 允许的调用方（TC 集群） ==================
+    clusters:
+      - id: tenant-a-prod                  # cluster-id，请求头 X-Seata-Cluster-Id 用
+        secret-ref: env:TENANT_A_SECRET    # 密钥引用（详见 §3）
+        allowed-namespaces: [prod, staging]  # 空或含 "*" 表示不限
+        allowed-clusters: [cluster-A, cluster-B]
+        allowed-vgroups:                   # glob 通配，支持 * 和 ?
+          - "tenant_a_*"
+          - "shared_?"
+        permissions:                       # 该 cluster-id 拥有的权限
+          - REGISTER
+          - HEARTBEAT
+          - VGROUP_WRITE
+          - CONSOLE_READ
+          - CONSOLE_WRITE
+
+      - id: tenant-b-prod
+        secret-ref: vault:secret/seata/tenant-b
+        allowed-namespaces: [prod]
+        allowed-clusters: [cluster-B]
+        allowed-vgroups: ["tenant_b_*"]
+        permissions:
+          - REGISTER
+          - HEARTBEAT
+          - CONSOLE_READ                   # 只读租户，不允许写 vGroup
+
+    # ================== NamingServer 自身出站身份 ==================
+    # 当 NamingServer 需要主动调用 TC（vGroup 增/删、Console 转发、MCP）时使用
+    outbound:
+      cluster-id: naming-server-01         # NamingServer 自身在 TC 侧的 cluster-id
+      secret-ref: env:NAMING_SERVER_SECRET
+```
+
+**权限枚举**（`org.apache.seata.namingserver.security.Permission`）：
+
+| 权限 | 允许的操作 |
+|------|-----------|
+| `REGISTER` | `POST /naming/v1/register`, `/batchRegister`, `/unregister` |
+| `HEARTBEAT` | 同 REGISTER（心跳复用注册接口，此权限主要用于审计区分） |
+| `VGROUP_WRITE` | `POST /naming/v1/addGroup`, `/changeGroup` |
+| `CONSOLE_READ` | `GET /naming/v1/discovery`, `/clusters`, `/clusterData`, `/namespace`, `POST /naming/v1/watch`; console GET 请求 |
+| `CONSOLE_WRITE` | console POST/PUT/DELETE 请求（通过 `ConsoleRemotingFilter`） |
+| `MCP` | MCP 集成调用（`ConsoleLocalServiceImpl`） |
+
+### 2.2 Seata Server 端配置（`seata.registry.seata.security.inbound.*`）
+
+配置类：`org.apache.seata.server.security.ServerSecurityProperties`
+
+```yaml
+seata:
+  registry:
+    seata:
+      security:
+        inbound:
+          enabled: true
+          mode: ENFORCE                    # WARN | ENFORCE
+          replay-window-seconds: 300
+          nonce-cache-minutes: 10
+
+          exclude-paths:
+            - /actuator/health
+
+          # 允许的 NamingServer 身份（一般 1-2 个，用于密钥轮换共存期）
+          allowed-callers:
+            - id: naming-server-01
+              secret-ref: env:NAMING_SERVER_SECRET
+              permissions:
+                - VGROUP_WRITE             # 允许调用 /vgroup/v1/addVGroup, removeVGroup
+                - CONSOLE_PROXY            # 允许转发 /api/*/console/*
+                - MCP                      # 允许 MCP 集成
+            - id: naming-server-01-new     # 密钥轮换期间的新身份
+              secret-ref: env:NAMING_SERVER_SECRET_NEW
+              permissions:
+                - VGROUP_WRITE
+                - CONSOLE_PROXY
+                - MCP
+```
+
+**Server 侧权限枚举**（更小的集合，只覆盖 TC 实际接收的 3 类调用）：
+
+| 权限 | 允许的操作 |
+|------|-----------|
+| `VGROUP_WRITE` | `GET /vgroup/v1/addVGroup`, `/vgroup/v1/removeVGroup` |
+| `CONSOLE_PROXY` | 所有 `/api/*/console/*` 请求（由 NamingServer 反向代理） |
+| `MCP` | MCP 集成端点（预留） |
+
+---
+
+## 3. 密钥管理
+
+### 3.1 密钥引用格式（secretRef）
+
+```yaml
+# 从环境变量读取（推荐生产）
+secret-ref: env:MY_SECRET_ENV_VAR
+# 环境变量值应为 Base64 编码的原始密钥字节
+
+# 内联 Base64（仅本地开发）
+secret-ref: base64:dGhpc2lzYXNlY3JldGtleXRlc3RtaW5pbXVtdGhpcnR5dHdvYnl0ZXM=
+
+# 内联明文（仅本地开发；密钥长度必须 ≥ 32 字节 UTF-8 编码后）
+secret-ref: plain:this-is-a-secret-key-test-min-32-bytes-long-abc
+
+# 生产环境可扩展的方案（未内置，需自行实现 SecretResolver）:
+#   vault:secret/data/seata/tenant-a
+#   k8s-secret:seata-security/tenant-a-secret
+#   kms:arn:aws:kms:us-east-1:12345:key/abc
+```
+
+**约束**：
+- 密钥字节长度 **≥ 32**（256 bit），否则启动时报错拒绝
+- **禁止**明文密钥入代码库、日志、`/actuator/configprops` 输出
+
+### 3.2 生成密钥
+
+**方法 A：openssl**（推荐）
+```bash
+openssl rand -base64 32
+# 输出示例：
+# 5NPJlpsN9j2VhFsx3EhV0PQGH2LqBnwYm5DcMkAt+8w=
+```
+
+**方法 B：Java 一次性 CLI**
+```bash
+cat <<'EOF' | jshell -
+import java.security.SecureRandom;
+import java.util.Base64;
+byte[] k = new byte[32];
+new SecureRandom().nextBytes(k);
+System.out.println(Base64.getEncoder().encodeToString(k));
+EOF
+```
+
+**方法 C：Python**
+```bash
+python3 -c "import os,base64; print(base64.b64encode(os.urandom(32)).decode())"
+```
+
+### 3.3 分发密钥
+
+**Kubernetes：**
+```bash
+kubectl create secret generic seata-security-tenant-a \
+    --from-literal=TENANT_A_SECRET="5NPJlpsN9j2VhFsx3EhV0PQGH2LqBnwYm5DcMkAt+8w=" \
+    -n seata
+
+# 注入到 Deployment
+env:
+  - name: TENANT_A_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: seata-security-tenant-a
+        key: TENANT_A_SECRET
+```
+
+**Docker Compose：**
+```yaml
+services:
+  seata-server:
+    image: seataio/seata-server:latest
+    environment:
+      TENANT_A_SECRET: "5NPJlpsN9j2VhFsx3EhV0PQGH2LqBnwYm5DcMkAt+8w="
+      NAMING_SERVER_SECRET: "..."
+```
+
+**VM/物理机：**
+```bash
+# /etc/seata/seata-server.env
+TENANT_A_SECRET=5NPJlpsN9j2VhFsx3EhV0PQGH2LqBnwYm5DcMkAt+8w=
+NAMING_SERVER_SECRET=...
+
+# systemd
+[Service]
+EnvironmentFile=/etc/seata/seata-server.env
+```
+
+### 3.4 密钥轮换
+
+**推荐轮换周期：90 天**（可根据组织合规要求缩短）
+
+**零停机轮换步骤：**
+
+```
+【Phase 1】双密钥共存（几分钟内完成配置下发）
+  Step 1: 生成新密钥 SECRET_NEW
+  Step 2: 在 TC 端 allowed-callers 追加：
+    - id: naming-server-01-new
+      secret-ref: env:NAMING_SERVER_SECRET_NEW
+      permissions: [VGROUP_WRITE, CONSOLE_PROXY, MCP]
+  Step 3: 滚动重启 TC（每次一台，滚动更新）
+
+【Phase 2】切换到新密钥（NamingServer 端）
+  Step 4: 在 NamingServer 端更新 outbound.cluster-id = naming-server-01-new
+                                  outbound.secret-ref = env:NAMING_SERVER_SECRET_NEW
+  Step 5: 滚动重启 NamingServer
+
+【Phase 3】观察 24 小时
+  Step 6: 通过日志 / 指标确认没有请求使用旧 cluster-id
+  Step 7: 从 TC 端 allowed-callers 移除 naming-server-01
+  Step 8: 滚动重启 TC 完成收尾
+```
+
+**关键点**：
+- Phase 1 → Phase 3 之间，两个 cluster-id **同时有效**，任何一方使用哪套密钥都能通过
+- 密钥泄露时可直接跳过 Phase 3，从 TC 端立即摘除旧 cluster-id
+
+---
+
+## 4. 场景化部署示例
+
+### 4.1 场景 A：单集群（最简部署）
+
+```yaml
+# ==================== NamingServer 端 ====================
+# namingserver/application.yml
+seata:
+  security:
+    enabled: true
+    mode: ENFORCE
+    clusters:
+      - id: seata-prod
+        secret-ref: env:SEATA_PROD_SECRET
+        permissions: [REGISTER, HEARTBEAT, VGROUP_WRITE, CONSOLE_READ, CONSOLE_WRITE]
+    outbound:
+      cluster-id: naming-server
+      secret-ref: env:NAMING_SERVER_SECRET
+    exclude-paths:
+      - /naming/v1/health
+
+# ==================== Seata Server 端 ====================
+# server/application.yml
+seata:
+  registry:
+    type: seata
+    seata:
+      server-addr: naming-server:8081
+      security:
+        # 出站（TC → NamingServer）配置 —— 需要在 registry 层适配
+        outbound:
+          cluster-id: seata-prod
+          secret-ref: env:SEATA_PROD_SECRET
+        # 入站（NamingServer → TC）配置
+        inbound:
+          enabled: true
+          mode: ENFORCE
+          allowed-callers:
+            - id: naming-server
+              secret-ref: env:NAMING_SERVER_SECRET
+              permissions: [VGROUP_WRITE, CONSOLE_PROXY, MCP]
+```
+
+**分发密钥（.env）：**
+```bash
+SEATA_PROD_SECRET=$(openssl rand -base64 32)
+NAMING_SERVER_SECRET=$(openssl rand -base64 32)
+```
+
+### 4.2 场景 B：多租户（3 套 TC 集群共享 NamingServer）
+
+```yaml
+# ==================== NamingServer 端 ====================
+seata:
+  security:
+    enabled: true
+    mode: ENFORCE
+    clusters:
+      # 租户 A：只能访问 prod/staging 环境的自己的 cluster
+      - id: tenant-a
+        secret-ref: env:TENANT_A_SECRET
+        allowed-namespaces: [prod-a, staging-a]
+        allowed-clusters: [cluster-A-*]
+        allowed-vgroups: ["tenant_a_*"]
+        permissions: [REGISTER, HEARTBEAT, VGROUP_WRITE, CONSOLE_READ, CONSOLE_WRITE]
+
+      # 租户 B：只能访问 prod 环境
+      - id: tenant-b
+        secret-ref: env:TENANT_B_SECRET
+        allowed-namespaces: [prod-b]
+        allowed-clusters: [cluster-B-*]
+        allowed-vgroups: ["tenant_b_*"]
+        permissions: [REGISTER, HEARTBEAT, VGROUP_WRITE, CONSOLE_READ, CONSOLE_WRITE]
+
+      # 只读监控账号（例如运维观察其他租户）
+      - id: readonly-ops
+        secret-ref: env:READONLY_SECRET
+        allowed-namespaces: ["*"]
+        allowed-clusters: ["*"]
+        permissions: [CONSOLE_READ]         # 只有读权限
+
+    outbound:
+      cluster-id: naming-server-01
+      secret-ref: env:NAMING_SERVER_SECRET
+
+# ==================== TC 集群 A ====================
+seata:
+  registry:
+    seata:
+      security:
+        outbound:
+          cluster-id: tenant-a
+          secret-ref: env:TENANT_A_SECRET
+        inbound:
+          enabled: true
+          allowed-callers:
+            - id: naming-server-01
+              secret-ref: env:NAMING_SERVER_SECRET
+              permissions: [VGROUP_WRITE, CONSOLE_PROXY]
+
+# ==================== TC 集群 B ====================
+seata:
+  registry:
+    seata:
+      security:
+        outbound:
+          cluster-id: tenant-b
+          secret-ref: env:TENANT_B_SECRET
+        inbound:
+          enabled: true
+          allowed-callers:
+            - id: naming-server-01
+              secret-ref: env:NAMING_SERVER_SECRET
+              permissions: [VGROUP_WRITE, CONSOLE_PROXY]
+```
+
+**多租户隔离效果：**
+- 租户 A 用自己的密钥签名，试图注册到 `namespace=prod-b` → **403 FORBIDDEN**
+- 租户 A 伪造 `X-Seata-Cluster-Id=tenant-b`，但用自己的密钥签名 → **401 BAD_SIGNATURE**
+- 只读账号 `readonly-ops` 试图调用 `changeGroup` → **403 FORBIDDEN**（无 `VGROUP_WRITE`）
+
+### 4.3 场景 C：Raft 高可用集群
+
+```yaml
+# NamingServer 端（3 副本 HA）
+seata:
+  security:
+    enabled: true
+    mode: ENFORCE
+    clusters:
+      - id: raft-cluster
+        secret-ref: env:RAFT_CLUSTER_SECRET
+        allowed-namespaces: [prod]
+        allowed-clusters: [raft-1, raft-2, raft-3]  # 单集群 3 副本 → 3 个 unit
+        permissions: [REGISTER, HEARTBEAT, VGROUP_WRITE, CONSOLE_READ, CONSOLE_WRITE]
+    outbound:
+      cluster-id: naming-server-01
+      secret-ref: env:NAMING_SERVER_SECRET
+
+# 每个 TC 节点（3 副本）配置相同：
+seata:
+  registry:
+    seata:
+      security:
+        outbound:
+          cluster-id: raft-cluster
+          secret-ref: env:RAFT_CLUSTER_SECRET
+        inbound:
+          enabled: true
+          allowed-callers:
+            - id: naming-server-01
+              secret-ref: env:NAMING_SERVER_SECRET
+              permissions: [VGROUP_WRITE, CONSOLE_PROXY, MCP]
+```
+
+**Raft 特殊考虑：**
+- Leader 切换时新 Leader 用同一个 cluster-id 上报 → 无需额外配置
+- Follower 也会上报（角色不同但身份同），共用密钥
+- NonceCache 是单机的，多个 NamingServer 副本各自维护 → 客户端在多副本间切换时可能出现少量误判（详见 §7.4）
+
+---
+
+## 5. Client SDK 集成（TM/RM 端可选升级）
+
+**默认状态**：Client 端仍使用现有 JWT 机制（`NamingserverRegistryServiceImpl.refreshToken()`），本方案不影响它。
+
+**如需升级 Client 也走 HMAC 签名**（推荐生产环境）：
+
+```yaml
+# Client 应用配置
+seata:
+  tx-service-group: my_tx_group
+  registry:
+    type: seata
+    seata:
+      server-addr: naming-server-01:8081,naming-server-02:8081
+      namespace: prod
+      security:
+        cluster-id: business-app-x         # 该 Client 应用的身份
+        secret-ref: env:BUSINESS_APP_X_SECRET
+```
+
+**对应 NamingServer 端需注册 Client 身份：**
+```yaml
+seata:
+  security:
+    clusters:
+      - id: business-app-x
+        secret-ref: env:BUSINESS_APP_X_SECRET
+        allowed-namespaces: [prod]
+        permissions:
+          - CONSOLE_READ                   # discovery / watch 属于此权限
+```
+
+---
+
+## 6. 灰度启用与监控
+
+### 6.1 灰度三阶段
+
+```
+【Phase 1】WARN 模式（1-2 周）
+  - NamingServer & TC 端 mode: WARN
+  - 观察日志中出现的 [security][WARN] 记录
+  - 找出所有未升级的调用方（Client、旧版本 TC、遗留脚本）
+  - 逐个升级 / 修补
+
+【Phase 2】切换 ENFORCE（1 周）
+  - 保留 WARN 阶段发现的所有 allowed-callers
+  - mode: ENFORCE
+  - 滚动生效，观察 401/403 告警
+
+【Phase 3】清理
+  - 移除临时白名单
+  - 下线旧 JWT 端点（如决定完全弃用）
+```
+
+### 6.2 关键日志字段
+
+**成功请求**（DEBUG 级别，默认不打印）：
+```
+[security] cluster-id=tenant-a method=POST path=/naming/v1/register status=200
+```
+
+**失败请求**（WARN 级别）：
+```
+[security][ENFORCE] POST /naming/v1/register rejected status=401 code=BAD_SIGNATURE msg=signature does not match caller=tenant-a
+[security][ENFORCE] POST /naming/v1/register rejected status=403 code=FORBIDDEN msg=caller tenant-a lacks permission for POST /naming/v1/register caller=tenant-a
+[seata-server][security][ENFORCE] GET /vgroup/v1/addVGroup status=401 code=REPLAY_DETECTED msg=nonce already used for cluster-id naming-server-01 caller=naming-server-01
+```
+
+### 6.3 Prometheus 指标（建议自行接入）
+
+```
+# 需自行在 SecurityFilter 中埋点，建议指标：
+seata_auth_request_total{result="ok|denied", reason="MISSING_SIGNATURE|BAD_SIGNATURE|REPLAY_DETECTED|FORBIDDEN|TIMESTAMP_SKEW|UNKNOWN_CLUSTER_ID", src_cluster_id="..."}
+seata_auth_signature_verify_duration_seconds
+seata_auth_nonce_cache_size
+```
+
+### 6.4 关键告警规则
+
+```yaml
+# Prometheus alerting rules 示例
+- alert: SeataAuthBruteForce
+  expr: rate(seata_auth_request_total{result="denied", reason=~"BAD_SIGNATURE|UNKNOWN_CLUSTER_ID"}[5m]) > 10
+  for: 3m
+  annotations:
+    summary: "可疑暴力破解：{{ $labels.src_cluster_id }} 5min 内失败超过 10 次/s"
+
+- alert: SeataAuthReplayAttack
+  expr: increase(seata_auth_request_total{result="denied", reason="REPLAY_DETECTED"}[5m]) > 0
+  annotations:
+    summary: "疑似重放攻击：{{ $labels.src_cluster_id }}"
+
+- alert: SeataAuthCrossTenant
+  expr: increase(seata_auth_request_total{result="denied", reason="FORBIDDEN"}[1m]) > 5
+  annotations:
+    summary: "跨租户越权尝试或配置错误：{{ $labels.src_cluster_id }}"
+```
+
+---
+
+## 7. 故障排查
+
+### 7.1 快速定位表
+
+| 症状 | 响应头 `X-Seata-Auth-Error` | 可能原因 | 排查步骤 |
+|------|------------------------------|----------|----------|
+| 401 | `MISSING_SIGNATURE` | Client 未开启签名 / Header 被反向代理剥离 | 检查中间层 nginx 是否透传 `X-Seata-*`；确认 Client 配置 `outbound.cluster-id` 已设置 |
+| 401 | `UNKNOWN_CLUSTER_ID` | 接收方 `allowed-callers` 未包含此 cluster-id | 核对接收方配置 |
+| 401 | `TIMESTAMP_SKEW` | 时钟不同步 | 部署 chrony/ntpd，`chronyc tracking` 验证 |
+| 401 | `REPLAY_DETECTED` | Client 复用 nonce / Nonce 生成不够随机 | 用 UUID.randomUUID() 或 SecureRandom；不要用固定值/自增 |
+| 401 | `BAD_SIGNATURE` | 密钥不一致 / 签名算法实现 bug / query 参数编码差异 | 打开 Client 端 DEBUG 日志比对 signString |
+| 401 | `UNSUPPORTED_ALG` | `X-Seata-Sign-Alg` 值不认识 | 双方版本对齐，或省略此 header（默认 HMAC-SHA256） |
+| 403 | `FORBIDDEN` | Cluster-id 合法但没有对应权限 / 越权访问 namespace/cluster | 检查 `permissions` 和 `allowed-namespaces` 配置 |
+| 401 | `BAD_REQUEST` | Timestamp header 不是数字 / Nonce/Cluster-Id 为 null | 检查 Header 格式 |
+
+### 7.2 常见误配
+
+#### 问题 1：`BAD_SIGNATURE` 但双方密钥看起来相同
+
+**排查步骤：**
+```bash
+# 1. 打印双方密钥的字节数
+echo -n "$TENANT_A_SECRET" | base64 -d | wc -c    # 应输出 32
+
+# 2. 双方是否都是 Base64 解码后使用（而不是把 Base64 字符串当密钥）
+# 检查代码：SecretResolver.decodeBase64() 会自动解码 env:xxx
+
+# 3. Nonce 是否包含特殊字符？UUID 是安全的
+# 4. body 是否包含 CRLF 与 LF 差异？（例如 curl 在 Windows）
+```
+
+#### 问题 2：Client 端一直 `TIMESTAMP_SKEW`
+
+```bash
+# 检查双方时钟
+ssh naming-server-01 date +%s%3N
+ssh seata-server-01 date +%s%3N
+# 差异应 < 300000（5min）
+
+# NTP 状态
+chronyc tracking     # Linux
+w32tm /query /status # Windows
+```
+
+#### 问题 3：升级到 ENFORCE 后大量 `MISSING_SIGNATURE`
+
+```
+说明有调用方未升级到签名版本。回退到 WARN 模式，观察日志：
+grep "MISSING_SIGNATURE" logs/seata-server.log | awk '{print $NF}' | sort -u
+拿到未升级的 IP / 服务，逐个改造。
+```
+
+### 7.3 密钥损坏或泄露的应急预案
+
+```bash
+# 1. 立即生成新密钥
+NEW_SECRET=$(openssl rand -base64 32)
+
+# 2. 更新 K8s Secret（或 Vault / KMS）
+kubectl create secret generic seata-security-tenant-a \
+    --from-literal=TENANT_A_SECRET="$NEW_SECRET" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# 3. 立即从 NamingServer 端 clusters 列表移除旧 cluster-id
+#    （通过配置中心热更新，或滚动重启）
+
+# 4. 通知所有租户应用滚动重启，使用新密钥
+
+# 5. 事后：审计日志排查泄露期间的所有请求
+```
+
+### 7.4 NonceCache 单机限制
+
+**问题**：`NonceCache.InMemory` 只在**单节点**去重。多副本 NamingServer 部署时，攻击者理论上可以：
+```
+1. 拦截 Client 到 NS-A 的合法请求，拿到有效签名
+2. 立即向 NS-B 重放同一请求
+3. NS-B 的 Nonce cache 中没有此 nonce → 通过
+```
+
+**缓解方案：**
+
+**方案 1（推荐）**：让客户端始终固定到一个 NamingServer（sticky session）
+- 通过 LB 的 `ip_hash` 或 `cluster-id_hash`
+
+**方案 2**：分布式 NonceCache（需自行实现）
+```java
+// 实现 NonceCache 接口，用 Redis SETNX + TTL 存储 nonce
+public class RedisNonceCache implements NonceCache {
+    public boolean putIfAbsent(String clusterId, String nonce) {
+        String key = "seata:nonce:" + clusterId + ":" + nonce;
+        return jedis.set(key, "1", SetParams.setParams().nx().px(ttlMillis)) != null;
+    }
+    // ...
+}
+// 然后覆写自动装配的 Bean:
+@Bean
+public NonceCache nonceCache(JedisPool pool, SecurityProperties props) {
+    return new RedisNonceCache(pool, TimeUnit.MINUTES.toMillis(props.getNonceCacheMinutes()));
+}
+```
+
+**方案 3**：签名字符串中绑定接收方节点 ID
+- 需自定义 `CanonicalRequest` 扩展 —— 目前未内置
+
+---
+
+## 8. 兼容性说明
+
+### 8.1 与现有 JWT 认证的关系
+
+| 场景 | 现状 | 本方案 |
+|------|------|--------|
+| Client (TM/RM) → NamingServer | JWT | 保持不变，可选升级 HMAC |
+| Client (TM/RM) → TC (Netty) | `RegisterCheckAuthHandler` | 保持不变 |
+| TC → NamingServer | JWT（复用 Client 通道）| 保持不变，可选升级 HMAC |
+| **NamingServer → TC** | **无鉴权** | **本方案新增 HMAC** |
+| Console → NamingServer | 会话 | 保持不变 |
+
+### 8.2 版本兼容
+
+| 部署组合 | 是否兼容 |
+|----------|----------|
+| NamingServer 已升级 + TC 已升级 + `enabled=true` | ✅ 完全支持 |
+| NamingServer 已升级 + TC 未升级 | ✅ NamingServer 请求 TC 不带签名，TC 未开启验签 → 正常 |
+| NamingServer 未升级 + TC 已升级 + `mode=WARN` | ✅ TC 只记录警告不拒绝 |
+| NamingServer 未升级 + TC 已升级 + `mode=ENFORCE` | ⚠️ **TC 拒绝 NamingServer 请求** — 不要这样配置 |
+| 双方均未升级 | ✅ 与旧版本行为完全一致 |
+
+**升级顺序建议**：TC 端 → mode=WARN → NamingServer 端 → 观察 → 切 mode=ENFORCE。
+
+### 8.3 反向代理兼容
+
+如果 NamingServer 前有反向代理（Nginx、Traefik 等），确保透传自定义头：
+
+```nginx
+# Nginx 示例
+location /naming/ {
+    proxy_pass http://naming_upstream;
+    proxy_set_header X-Seata-Cluster-Id  $http_x_seata_cluster_id;
+    proxy_set_header X-Seata-Timestamp   $http_x_seata_timestamp;
+    proxy_set_header X-Seata-Nonce       $http_x_seata_nonce;
+    proxy_set_header X-Seata-Sign-Alg    $http_x_seata_sign_alg;
+    proxy_set_header X-Seata-Sign        $http_x_seata_sign;
+    # 保留原始 Host / URI 与 query（签名基于此计算）
+    proxy_set_header Host                $host;
+    proxy_http_version 1.1;
+}
+```
+
+---
+
+## 9. 限制与已知问题
+
+| 限制 | 说明 | 缓解 |
+|------|------|------|
+| **NonceCache 单机** | 多 NamingServer 副本部署时，节点间不共享 nonce | 见 §7.4 |
+| **时钟依赖** | 5min 时间窗容忍常规漂移，但极端场景仍需 NTP | 部署 chrony |
+| **未处理长轮询 watch** | Client → NamingServer 的 `/watch` 走原 JWT | 未来独立方案 |
+| **不含传输层安全** | 本方案只解决应用层身份，不涉及 TLS | 建议叠加 HTTPS |
+| **密钥硬存储** | 密钥落到 env / Vault，重启即可读 | 生产建议对接 KMS，密钥永不落盘 |
+| **不含 IP 白名单** | 完全信任签名 | 可通过 nginx allow/deny 前置约束 |
+| **单一算法** | 目前仅内置 HMAC-SHA256/512 | 通过 `SignatureAlgorithm` 枚举扩展 |
+
+---
+
+## 10. FAQ
+
+### Q1：可以不启用鉴权吗？
+可以。**默认 `enabled=false`**，不启用时行为与升级前完全一致，且不引入任何运行时开销。
+
+### Q2：Client 端也必须升级吗？
+不必须。TC ↔ NamingServer 之间的鉴权与 Client 完全独立。Client 可以继续用 JWT，或后续单独升级。
+
+### Q3：单机开发测试如何简化？
+```yaml
+seata:
+  security:
+    enabled: true
+    mode: WARN                             # 不拦截，避免调试受阻
+    clusters:
+      - id: dev
+        secret-ref: plain:local-dev-secret-min-32-bytes-abcdefghij
+        allowed-namespaces: ["*"]
+        allowed-clusters: ["*"]
+        permissions:
+          - REGISTER
+          - HEARTBEAT
+          - VGROUP_WRITE
+          - CONSOLE_READ
+          - CONSOLE_WRITE
+```
+
+### Q4：密钥长度必须 32 字节吗？可以更长吗？
+- **最小 32 字节（256 bit）** — 短于此值启动即失败
+- 更长完全没问题（HMAC 内部会 hash 到 block size）
+- 推荐固定 32 字节，简化管理
+
+### Q5：如何验证配置是否生效？
+```bash
+# 1. 启动后查看日志
+grep "loaded.*cluster identities" logs/naming-server.log
+# 期望: Loaded 2 cluster identities for NamingServer security
+
+# 2. 用 curl 手动构造签名请求测试
+export CID="tenant-a"
+export SECRET_B64="..."
+export TS=$(date +%s%3N)
+export NONCE=$(uuidgen)
+export METHOD="POST"
+export PATH_="/naming/v1/register"
+
+# 构造 signString（示例仅演示，实际需要按 canonicalizer 规则）
+BODY='{"test":"data"}'
+BODY_HASH=$(printf "$BODY" | shasum -a 256 | awk '{print $1}')
+SIGN_STRING="${METHOD}
+${PATH_}
+namespace=test
+${CID}
+${TS}
+${NONCE}
+${BODY_HASH}"
+
+SIGNATURE=$(printf "$SIGN_STRING" | \
+    openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(echo -n $SECRET_B64 | base64 -d | xxd -p -c 999)" \
+    -binary | base64)
+
+curl -X POST "http://localhost:8081/naming/v1/register?namespace=test&clusterName=c1&unit=u1" \
+     -H "Content-Type: application/json" \
+     -H "X-Seata-Cluster-Id: $CID" \
+     -H "X-Seata-Timestamp: $TS" \
+     -H "X-Seata-Nonce: $NONCE" \
+     -H "X-Seata-Sign-Alg: HMAC-SHA256" \
+     -H "X-Seata-Sign: $SIGNATURE" \
+     -d "$BODY" -v
+
+# 期望 200；若 401，查看响应头 X-Seata-Auth-Error 判断具体原因
+```
+
+### Q6：需要为每个 TC 节点分配独立 cluster-id 吗？
+**不需要**。一套 TC 集群（可能多个节点、多个 raft-group）应共享同一个 cluster-id 和密钥。这与 Seata 的"集群"语义一致。
+
+### Q7：现在支持 mTLS 吗？
+本方案（方案 A）**不含 mTLS**，但可以叠加。参考 [`NAMINGSERVER_ARCHITECTURE.md`](../NAMINGSERVER_ARCHITECTURE.md) §11.5 方案 B 的规划。
+
+---
+
+## 11. 附录：代码文件索引
+
+```
+common/src/main/java/org/apache/seata/common/security/
+├── SecurityConstants.java        # HTTP 头名与错误码枚举
+├── SignatureAlgorithm.java       # 支持的 MAC 算法（HMAC-SHA256/512）
+├── CanonicalRequest.java         # 可签名请求值对象（不可变）
+├── SignatureCanonicalizer.java   # 生成 signString（method+path+query+cluster-id+ts+nonce+body-hash）
+├── HmacSigner.java               # 签名与验签（constant-time compare）
+├── NonceCache.java               # 防重放缓存接口 + 单机内存实现
+├── SignatureVerifier.java        # 完整验签流水线（freshness → nonce → signature）
+└── VerificationResult.java       # 结构化验签结果
+
+namingserver/src/main/java/org/apache/seata/namingserver/security/
+├── Permission.java               # NamingServer 权限枚举
+├── ClusterIdentity.java          # 单个 cluster-id 的完整身份
+├── ClusterIdentityRegistry.java  # id → identity 内存表
+├── SecretResolver.java           # secretRef → 原始字节的解析器（env/base64/plain）
+├── SecurityProperties.java       # @ConfigurationProperties("seata.security")
+├── PermissionChecker.java        # 路径→权限映射与授权检查
+├── SecurityFilter.java           # 入站 Servlet Filter（完整流水线）
+├── OutboundSigner.java           # 生成出站请求的 X-Seata-* 头
+└── SecurityAutoConfiguration.java # Spring Boot 自动装配
+
+server/src/main/java/org/apache/seata/server/security/
+├── CallerPermission.java         # TC 侧权限枚举（VGROUP_WRITE/CONSOLE_PROXY/MCP）
+├── AllowedCaller.java            # 单个允许的调用者身份
+├── AllowedCallerRegistry.java    # id → caller 内存表
+├── ServerSecretResolver.java     # 同 SecretResolver（模块隔离）
+├── ServerSecurityProperties.java # @ConfigurationProperties("seata.registry.seata.security.inbound")
+├── RouteAuthorizer.java          # TC 路径→权限映射
+├── SeataServerAuthFilter.java    # 入站 Servlet Filter
+└── ServerSecurityAutoConfiguration.java # Spring Boot 自动装配
+
+# 单元测试（共 76 个测试，覆盖率 93%）
+common/src/test/java/org/apache/seata/common/security/       (48 tests)
+namingserver/src/test/java/org/apache/seata/namingserver/security/  (46 tests)
+server/src/test/java/org/apache/seata/server/security/       (28 tests)
+```
+
+---
+
+## 12. 变更历史
+
+| 日期 | 版本 | 变更 |
+|------|------|------|
+| 2026-07-27 | v1.0 | 首版：HMAC-SHA256 方案 A 落地，含完整单测 |

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentity.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentity.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * A registered caller identity. Every request the NamingServer receives is bound to at
+ * most one of these — the identity is looked up by the {@code X-Seata-Cluster-Id} header.
+ *
+ * <p>Fields are all immutable after construction; instances are cheap to share across threads.
+ */
+public final class ClusterIdentity {
+
+    private final String id;
+
+    private final byte[] secret;
+
+    private final Set<String> allowedNamespaces;
+
+    private final Set<String> allowedClusters;
+
+    private final List<Pattern> allowedVgroupPatterns;
+
+    private final Set<Permission> permissions;
+
+    public ClusterIdentity(String id,
+                           byte[] secret,
+                           Set<String> allowedNamespaces,
+                           Set<String> allowedClusters,
+                           List<Pattern> allowedVgroupPatterns,
+                           Set<Permission> permissions) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.secret = Objects.requireNonNull(secret, "secret").clone();
+        this.allowedNamespaces = allowedNamespaces == null
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(allowedNamespaces);
+        this.allowedClusters = allowedClusters == null
+                ? Collections.emptySet()
+                : Collections.unmodifiableSet(allowedClusters);
+        this.allowedVgroupPatterns = allowedVgroupPatterns == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(allowedVgroupPatterns);
+        this.permissions = permissions == null
+                ? EnumSet.noneOf(Permission.class)
+                : Collections.unmodifiableSet(EnumSet.copyOf(permissions));
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /** Defensive copy: never expose the underlying key material. */
+    public byte[] getSecret() {
+        return secret.clone();
+    }
+
+    public Set<String> getAllowedNamespaces() {
+        return allowedNamespaces;
+    }
+
+    public Set<String> getAllowedClusters() {
+        return allowedClusters;
+    }
+
+    public List<Pattern> getAllowedVgroupPatterns() {
+        return allowedVgroupPatterns;
+    }
+
+    public Set<Permission> getPermissions() {
+        return permissions;
+    }
+
+    /** Wildcard {@code *} in the allow-list means "no restriction". */
+    public boolean isNamespaceAllowed(String namespace) {
+        return allowedNamespaces.isEmpty()
+                || allowedNamespaces.contains("*")
+                || allowedNamespaces.contains(namespace);
+    }
+
+    public boolean isClusterAllowed(String cluster) {
+        return allowedClusters.isEmpty()
+                || allowedClusters.contains("*")
+                || allowedClusters.contains(cluster);
+    }
+
+    public boolean isVgroupAllowed(String vGroup) {
+        if (allowedVgroupPatterns.isEmpty()) {
+            return true;
+        }
+        if (vGroup == null) {
+            return false;
+        }
+        for (Pattern p : allowedVgroupPatterns) {
+            if (p.matcher(vGroup).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean hasPermission(Permission permission) {
+        return permissions.contains(permission);
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentity.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentity.java
@@ -43,20 +43,19 @@ public final class ClusterIdentity {
 
     private final Set<Permission> permissions;
 
-    public ClusterIdentity(String id,
-                           byte[] secret,
-                           Set<String> allowedNamespaces,
-                           Set<String> allowedClusters,
-                           List<Pattern> allowedVgroupPatterns,
-                           Set<Permission> permissions) {
+    public ClusterIdentity(
+            String id,
+            byte[] secret,
+            Set<String> allowedNamespaces,
+            Set<String> allowedClusters,
+            List<Pattern> allowedVgroupPatterns,
+            Set<Permission> permissions) {
         this.id = Objects.requireNonNull(id, "id");
         this.secret = Objects.requireNonNull(secret, "secret").clone();
-        this.allowedNamespaces = allowedNamespaces == null
-                ? Collections.emptySet()
-                : Collections.unmodifiableSet(allowedNamespaces);
-        this.allowedClusters = allowedClusters == null
-                ? Collections.emptySet()
-                : Collections.unmodifiableSet(allowedClusters);
+        this.allowedNamespaces =
+                allowedNamespaces == null ? Collections.emptySet() : Collections.unmodifiableSet(allowedNamespaces);
+        this.allowedClusters =
+                allowedClusters == null ? Collections.emptySet() : Collections.unmodifiableSet(allowedClusters);
         this.allowedVgroupPatterns = allowedVgroupPatterns == null
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(allowedVgroupPatterns);
@@ -92,15 +91,11 @@ public final class ClusterIdentity {
 
     /** Wildcard {@code *} in the allow-list means "no restriction". */
     public boolean isNamespaceAllowed(String namespace) {
-        return allowedNamespaces.isEmpty()
-                || allowedNamespaces.contains("*")
-                || allowedNamespaces.contains(namespace);
+        return allowedNamespaces.isEmpty() || allowedNamespaces.contains("*") || allowedNamespaces.contains(namespace);
     }
 
     public boolean isClusterAllowed(String cluster) {
-        return allowedClusters.isEmpty()
-                || allowedClusters.contains("*")
-                || allowedClusters.contains(cluster);
+        return allowedClusters.isEmpty() || allowedClusters.contains("*") || allowedClusters.contains(cluster);
     }
 
     public boolean isVgroupAllowed(String vGroup) {

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentityRegistry.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentityRegistry.java
@@ -18,13 +18,19 @@ package org.apache.seata.namingserver.security;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * In-memory table of {@link ClusterIdentity} keyed by cluster-id. Reads are lock-free; writes
  * only happen at startup or on config reload, so this is heavily biased for the read path.
+ *
+ * <p>The whole table is held as an immutable {@link Map} behind an {@link AtomicReference}.
+ * Register and reload publish a fresh snapshot via {@code compareAndSet} / {@code set}, so
+ * concurrent {@link #find(String)} calls always observe either the old table in full or the
+ * new table in full — never a transient empty/partial state during rotation.
  *
  * <p>Kept as a small stand-alone class (rather than a full-blown "IdentityService") so it can
  * be unit-tested without Spring context and shared between the inbound filter and the
@@ -32,34 +38,42 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class ClusterIdentityRegistry {
 
-    private final Map<String, ClusterIdentity> byId = new ConcurrentHashMap<>();
+    private final AtomicReference<Map<String, ClusterIdentity>> ref = new AtomicReference<>(Collections.emptyMap());
 
     /** Register (or replace) an identity. Callers must have already validated the secret length. */
     public void register(ClusterIdentity identity) {
-        byId.put(identity.getId(), identity);
+        while (true) {
+            Map<String, ClusterIdentity> current = ref.get();
+            Map<String, ClusterIdentity> next = new HashMap<>(current);
+            next.put(identity.getId(), identity);
+            if (ref.compareAndSet(current, Collections.unmodifiableMap(next))) {
+                return;
+            }
+        }
     }
 
-    /** Bulk-load, replacing everything atomically-ish (individual puts, not a swap). */
+    /** Bulk-load, atomically replacing the whole table via a single reference swap. */
     public void reload(Collection<ClusterIdentity> identities) {
-        byId.clear();
+        Map<String, ClusterIdentity> next = new HashMap<>();
         for (ClusterIdentity id : identities) {
-            byId.put(id.getId(), id);
+            next.put(id.getId(), id);
         }
+        ref.set(Collections.unmodifiableMap(next));
     }
 
     public Optional<ClusterIdentity> find(String clusterId) {
         if (clusterId == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(byId.get(clusterId));
+        return Optional.ofNullable(ref.get().get(clusterId));
     }
 
     /** Live, unmodifiable view — mainly for metrics / admin endpoints. */
     public Map<String, ClusterIdentity> asMap() {
-        return Collections.unmodifiableMap(byId);
+        return ref.get();
     }
 
     public int size() {
-        return byId.size();
+        return ref.get().size();
     }
 }

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentityRegistry.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/ClusterIdentityRegistry.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory table of {@link ClusterIdentity} keyed by cluster-id. Reads are lock-free; writes
+ * only happen at startup or on config reload, so this is heavily biased for the read path.
+ *
+ * <p>Kept as a small stand-alone class (rather than a full-blown "IdentityService") so it can
+ * be unit-tested without Spring context and shared between the inbound filter and the
+ * outbound signer.
+ */
+public final class ClusterIdentityRegistry {
+
+    private final Map<String, ClusterIdentity> byId = new ConcurrentHashMap<>();
+
+    /** Register (or replace) an identity. Callers must have already validated the secret length. */
+    public void register(ClusterIdentity identity) {
+        byId.put(identity.getId(), identity);
+    }
+
+    /** Bulk-load, replacing everything atomically-ish (individual puts, not a swap). */
+    public void reload(Collection<ClusterIdentity> identities) {
+        byId.clear();
+        for (ClusterIdentity id : identities) {
+            byId.put(id.getId(), id);
+        }
+    }
+
+    public Optional<ClusterIdentity> find(String clusterId) {
+        if (clusterId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(byId.get(clusterId));
+    }
+
+    /** Live, unmodifiable view — mainly for metrics / admin endpoints. */
+    public Map<String, ClusterIdentity> asMap() {
+        return Collections.unmodifiableMap(byId);
+    }
+
+    public int size() {
+        return byId.size();
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/OutboundSigner.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/OutboundSigner.java
@@ -16,16 +16,16 @@
  */
 package org.apache.seata.namingserver.security;
 
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Supplier;
-
-import org.apache.seata.common.security.CanonicalRequest;
-import org.apache.seata.common.security.HmacSigner;
-import org.apache.seata.common.security.SecurityConstants;
-import org.apache.seata.common.security.SignatureAlgorithm;
 
 /**
  * Produces the {@code X-Seata-*} headers that must accompany outgoing requests from
@@ -60,11 +60,12 @@ public final class OutboundSigner {
      * @param clock           supplies millisecond timestamps (defaults to system clock if null)
      * @param nonceSupplier   supplies unique nonces (defaults to random UUID if null)
      */
-    public OutboundSigner(String selfClusterId,
-                          byte[] secret,
-                          SignatureAlgorithm algorithm,
-                          Supplier<Long> clock,
-                          Supplier<String> nonceSupplier) {
+    public OutboundSigner(
+            String selfClusterId,
+            byte[] secret,
+            SignatureAlgorithm algorithm,
+            Supplier<Long> clock,
+            Supplier<String> nonceSupplier) {
         this.selfClusterId = Objects.requireNonNull(selfClusterId, "selfClusterId");
         this.secret = Objects.requireNonNull(secret, "secret").clone();
         this.algorithm = algorithm == null ? SignatureAlgorithm.HMAC_SHA256 : algorithm;
@@ -86,10 +87,7 @@ public final class OutboundSigner {
      * @param body         request body bytes (may be null/empty)
      * @return an ordered map ready to iterate onto the outbound request
      */
-    public Map<String, String> signHeaders(String method,
-                                           String path,
-                                           Map<String, String> queryParams,
-                                           byte[] body) {
+    public Map<String, String> signHeaders(String method, String path, Map<String, String> queryParams, byte[] body) {
         long ts = clock.get();
         String nonce = nonceSupplier.get();
         CanonicalRequest req = CanonicalRequest.builder()

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/OutboundSigner.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/OutboundSigner.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+
+/**
+ * Produces the {@code X-Seata-*} headers that must accompany outgoing requests from
+ * NamingServer to Seata Server (TC).
+ *
+ * <p>Two things justify the existence of this class:
+ * <ol>
+ *   <li>The signing convention (which headers, in what order, with what timestamp source) is
+ *       identical for every call site — vGroup add/remove, ConsoleRemotingFilter proxy,
+ *       MCP invocations. Centralising avoids drift.</li>
+ *   <li>The clock / nonce sources are injectable so tests can produce deterministic signatures.</li>
+ * </ol>
+ */
+public final class OutboundSigner {
+
+    private final String selfClusterId;
+
+    private final byte[] secret;
+
+    private final SignatureAlgorithm algorithm;
+
+    private final Supplier<Long> clock;
+
+    private final Supplier<String> nonceSupplier;
+
+    /**
+     * Full constructor. The two suppliers exist purely so tests can inject deterministic values.
+     *
+     * @param selfClusterId   value to place in {@code X-Seata-Cluster-Id} — the NamingServer's own id
+     * @param secret          shared secret paired with {@code selfClusterId} on the TC side
+     * @param algorithm       MAC algorithm; usually {@link SignatureAlgorithm#HMAC_SHA256}
+     * @param clock           supplies millisecond timestamps (defaults to system clock if null)
+     * @param nonceSupplier   supplies unique nonces (defaults to random UUID if null)
+     */
+    public OutboundSigner(String selfClusterId,
+                          byte[] secret,
+                          SignatureAlgorithm algorithm,
+                          Supplier<Long> clock,
+                          Supplier<String> nonceSupplier) {
+        this.selfClusterId = Objects.requireNonNull(selfClusterId, "selfClusterId");
+        this.secret = Objects.requireNonNull(secret, "secret").clone();
+        this.algorithm = algorithm == null ? SignatureAlgorithm.HMAC_SHA256 : algorithm;
+        this.clock = clock == null ? System::currentTimeMillis : clock;
+        this.nonceSupplier = nonceSupplier == null ? () -> UUID.randomUUID().toString() : nonceSupplier;
+    }
+
+    /** Convenience constructor for production wiring — uses default clock and UUID nonce. */
+    public OutboundSigner(String selfClusterId, byte[] secret) {
+        this(selfClusterId, secret, SignatureAlgorithm.HMAC_SHA256, null, null);
+    }
+
+    /**
+     * Build the header map for a request. Callers copy these into whichever HTTP client they use.
+     *
+     * @param method       HTTP method, e.g. {@code GET}, {@code POST}
+     * @param path         request path (no host, no query)
+     * @param queryParams  query parameters (may be empty)
+     * @param body         request body bytes (may be null/empty)
+     * @return an ordered map ready to iterate onto the outbound request
+     */
+    public Map<String, String> signHeaders(String method,
+                                           String path,
+                                           Map<String, String> queryParams,
+                                           byte[] body) {
+        long ts = clock.get();
+        String nonce = nonceSupplier.get();
+        CanonicalRequest req = CanonicalRequest.builder()
+                .method(method)
+                .path(path)
+                .queryParams(queryParams)
+                .clusterId(selfClusterId)
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(algorithm)
+                .body(body)
+                .build();
+        String signature = HmacSigner.sign(req, secret);
+
+        Map<String, String> headers = new LinkedHashMap<>(6);
+        headers.put(SecurityConstants.HEADER_CLUSTER_ID, selfClusterId);
+        headers.put(SecurityConstants.HEADER_TIMESTAMP, Long.toString(ts));
+        headers.put(SecurityConstants.HEADER_NONCE, nonce);
+        headers.put(SecurityConstants.HEADER_SIGN_ALG, algorithm.wireName());
+        headers.put(SecurityConstants.HEADER_SIGNATURE, signature);
+        return headers;
+    }
+
+    public String getSelfClusterId() {
+        return selfClusterId;
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/Permission.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/Permission.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+/**
+ * Discrete permissions a caller can hold. Kept as a small closed set so audit / config
+ * remains understandable — we deliberately do not model arbitrary RBAC here.
+ */
+public enum Permission {
+    /** Register a TC instance (initial admission). */
+    REGISTER,
+    /** Send heartbeat (re-register) for an already-registered TC. */
+    HEARTBEAT,
+    /** Modify the vGroup → cluster mapping via the console. */
+    VGROUP_WRITE,
+    /** Read cluster / namespace / vgroup data via the console. */
+    CONSOLE_READ,
+    /** Perform write operations (force commit/rollback etc.) via the console proxy. */
+    CONSOLE_WRITE,
+    /** Called from the MCP integration; grants API-level access without console UI context. */
+    MCP
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/PermissionChecker.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/PermissionChecker.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Objects;
+
+/**
+ * Maps an HTTP request path to the {@link Permission} needed to serve it, then verifies the
+ * caller identity holds that permission <em>and</em> that the requested namespace/cluster/vgroup
+ * fall within the identity's allow-lists.
+ *
+ * <p>Route → permission mapping is centralised here so operators can audit it at a glance
+ * without walking the controller layer.
+ */
+public final class PermissionChecker {
+
+    /**
+     * Decide whether the caller may perform the request.
+     *
+     * @param identity  authenticated caller (never null — this runs after signature verification)
+     * @param method    HTTP method, upper-case
+     * @param path      request path (no query string, no host)
+     * @param namespace target namespace as parsed from body/query (may be null for read-only endpoints)
+     * @param cluster   target cluster (may be null)
+     * @param vGroup    target vgroup (may be null)
+     * @return {@code true} iff the request is authorized
+     */
+    public boolean check(ClusterIdentity identity,
+                         String method,
+                         String path,
+                         String namespace,
+                         String cluster,
+                         String vGroup) {
+        Objects.requireNonNull(identity, "identity");
+        Objects.requireNonNull(method, "method");
+        Objects.requireNonNull(path, "path");
+
+        Permission required = requiredPermission(method, path);
+        if (required == null) {
+            // No route mapping = deny by default. Fail-closed is the correct posture here.
+            return false;
+        }
+        if (!identity.hasPermission(required)) {
+            return false;
+        }
+        if (namespace != null && !identity.isNamespaceAllowed(namespace)) {
+            return false;
+        }
+        if (cluster != null && !identity.isClusterAllowed(cluster)) {
+            return false;
+        }
+        if (vGroup != null && !identity.isVgroupAllowed(vGroup)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return the permission required to serve the given route, or {@code null} if the route
+     *         is not recognised (which the caller should treat as "forbidden")
+     */
+    public Permission requiredPermission(String method, String path) {
+        if ("POST".equals(method) && path.endsWith("/register")) {
+            return Permission.REGISTER;
+        }
+        if ("POST".equals(method) && path.endsWith("/batchRegister")) {
+            return Permission.REGISTER;
+        }
+        if ("POST".equals(method) && path.endsWith("/unregister")) {
+            return Permission.REGISTER;
+        }
+        if ("POST".equals(method) && (path.endsWith("/addGroup") || path.endsWith("/changeGroup"))) {
+            return Permission.VGROUP_WRITE;
+        }
+        if ("GET".equals(method) && (path.endsWith("/discovery")
+                || path.endsWith("/clusters")
+                || path.endsWith("/clusterData")
+                || path.endsWith("/namespace"))) {
+            return Permission.CONSOLE_READ;
+        }
+        if ("POST".equals(method) && path.endsWith("/watch")) {
+            // Watch is called by RM/TM at scale. Treat as a lightweight read.
+            return Permission.CONSOLE_READ;
+        }
+        if (path.contains("/console/")) {
+            return "GET".equals(method) ? Permission.CONSOLE_READ : Permission.CONSOLE_WRITE;
+        }
+        return null;
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/PermissionChecker.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/PermissionChecker.java
@@ -39,12 +39,8 @@ public final class PermissionChecker {
      * @param vGroup    target vgroup (may be null)
      * @return {@code true} iff the request is authorized
      */
-    public boolean check(ClusterIdentity identity,
-                         String method,
-                         String path,
-                         String namespace,
-                         String cluster,
-                         String vGroup) {
+    public boolean check(
+            ClusterIdentity identity, String method, String path, String namespace, String cluster, String vGroup) {
         Objects.requireNonNull(identity, "identity");
         Objects.requireNonNull(method, "method");
         Objects.requireNonNull(path, "path");
@@ -86,10 +82,11 @@ public final class PermissionChecker {
         if ("POST".equals(method) && (path.endsWith("/addGroup") || path.endsWith("/changeGroup"))) {
             return Permission.VGROUP_WRITE;
         }
-        if ("GET".equals(method) && (path.endsWith("/discovery")
-                || path.endsWith("/clusters")
-                || path.endsWith("/clusterData")
-                || path.endsWith("/namespace"))) {
+        if ("GET".equals(method)
+                && (path.endsWith("/discovery")
+                        || path.endsWith("/clusters")
+                        || path.endsWith("/clusterData")
+                        || path.endsWith("/namespace"))) {
             return Permission.CONSOLE_READ;
         }
         if ("POST".equals(method) && path.endsWith("/watch")) {

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecretResolver.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecretResolver.java
@@ -78,8 +78,8 @@ public final class SecretResolver {
         if (secretRef.startsWith(PLAIN_PREFIX)) {
             return secretRef.substring(PLAIN_PREFIX.length()).getBytes(java.nio.charset.StandardCharsets.UTF_8);
         }
-        throw new IllegalArgumentException("unsupported secretRef scheme: " + secretRef
-                + " (supported: env:, base64:, plain:)");
+        throw new IllegalArgumentException(
+                "unsupported secretRef scheme: " + secretRef + " (supported: env:, base64:, plain:)");
     }
 
     private static byte[] decodeBase64(String value) {

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecretResolver.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecretResolver.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Base64;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Resolves a {@code secretRef} string from configuration into raw key material.
+ *
+ * <p>Supported schemes:
+ * <ul>
+ *   <li>{@code env:VAR_NAME} — reads {@code System.getenv(VAR_NAME)} and Base64-decodes it.</li>
+ *   <li>{@code base64:...}   — inline Base64 (discouraged; only for local development).</li>
+ *   <li>{@code plain:...}    — inline UTF-8 bytes (discouraged; only for local development).</li>
+ * </ul>
+ *
+ * <p>The environment-lookup function is injected so tests can supply a fake env.
+ * Additional schemes (vault, k8s-secret, KMS) can be layered on by wrapping this class.
+ */
+public final class SecretResolver {
+
+    private static final String ENV_PREFIX = "env:";
+
+    private static final String BASE64_PREFIX = "base64:";
+
+    private static final String PLAIN_PREFIX = "plain:";
+
+    private final Function<String, String> envLookup;
+
+    public SecretResolver() {
+        this(System::getenv);
+    }
+
+    /** @param envLookup how to resolve {@code env:} references (defaults to {@link System#getenv(String)}). */
+    public SecretResolver(Function<String, String> envLookup) {
+        this.envLookup = Objects.requireNonNull(envLookup, "envLookup");
+    }
+
+    /**
+     * Resolve one reference.
+     *
+     * @param secretRef the string from configuration
+     * @return raw secret bytes
+     * @throws IllegalArgumentException if the ref is malformed, the env var is unset,
+     *                                  or the Base64 payload is invalid
+     */
+    public byte[] resolve(String secretRef) {
+        if (secretRef == null || secretRef.isEmpty()) {
+            throw new IllegalArgumentException("secretRef is blank");
+        }
+        if (secretRef.startsWith(ENV_PREFIX)) {
+            String envName = secretRef.substring(ENV_PREFIX.length());
+            String value = envLookup.apply(envName);
+            if (value == null || value.isEmpty()) {
+                throw new IllegalArgumentException("env var not set or empty: " + envName);
+            }
+            return decodeBase64(value);
+        }
+        if (secretRef.startsWith(BASE64_PREFIX)) {
+            return decodeBase64(secretRef.substring(BASE64_PREFIX.length()));
+        }
+        if (secretRef.startsWith(PLAIN_PREFIX)) {
+            return secretRef.substring(PLAIN_PREFIX.length()).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        }
+        throw new IllegalArgumentException("unsupported secretRef scheme: " + secretRef
+                + " (supported: env:, base64:, plain:)");
+    }
+
+    private static byte[] decodeBase64(String value) {
+        try {
+            return Base64.getDecoder().decode(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("invalid base64 in secretRef", e);
+        }
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityAutoConfiguration.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityAutoConfiguration.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import jakarta.servlet.Filter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.NonceCache;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * Wires up the security layer only when {@code seata.security.enabled=true}. When disabled
+ * the beans are not created and the request pipeline behaves exactly as before.
+ *
+ * <p>Ordering: the {@link SecurityFilter} sits at {@link Ordered#HIGHEST_PRECEDENCE} so it
+ * runs before {@link org.apache.seata.namingserver.filter.ConsoleRemotingFilter}. That way the
+ * proxy never dispatches an unauthenticated request to TC.
+ */
+@Configuration
+@EnableConfigurationProperties(SecurityProperties.class)
+@ConditionalOnProperty(prefix = "seata.security", name = "enabled", havingValue = "true")
+public class SecurityAutoConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityAutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SecretResolver secretResolver() {
+        return new SecretResolver();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ClusterIdentityRegistry clusterIdentityRegistry(SecurityProperties props,
+                                                           SecretResolver resolver) {
+        ClusterIdentityRegistry registry = new ClusterIdentityRegistry();
+        List<ClusterIdentity> loaded = new ArrayList<>();
+        for (SecurityProperties.ClusterConfig cfg : props.getClusters()) {
+            byte[] secret = resolver.resolve(cfg.getSecretRef());
+            if (secret.length < HmacSigner.MIN_KEY_LENGTH_BYTES) {
+                throw new IllegalStateException("secret for cluster-id '" + cfg.getId()
+                        + "' is shorter than " + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
+            }
+            List<Pattern> patterns = cfg.getAllowedVgroups() == null
+                    ? Collections.emptyList()
+                    : cfg.getAllowedVgroups().stream()
+                        .map(SecurityAutoConfiguration::globToRegex)
+                        .collect(Collectors.toList());
+            loaded.add(new ClusterIdentity(
+                    cfg.getId(),
+                    secret,
+                    cfg.getAllowedNamespaces() == null ? Collections.emptySet()
+                            : new java.util.HashSet<>(cfg.getAllowedNamespaces()),
+                    cfg.getAllowedClusters() == null ? Collections.emptySet()
+                            : new java.util.HashSet<>(cfg.getAllowedClusters()),
+                    patterns,
+                    cfg.getPermissions() == null ? java.util.EnumSet.noneOf(Permission.class)
+                            : java.util.EnumSet.copyOf(cfg.getPermissions())));
+        }
+        registry.reload(loaded);
+        LOGGER.info("Loaded {} cluster identities for NamingServer security", registry.size());
+        return registry;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public NonceCache nonceCache(SecurityProperties props) {
+        long ttlMillis = TimeUnit.MINUTES.toMillis(props.getNonceCacheMinutes());
+        return new NonceCache.InMemory(ttlMillis, System::currentTimeMillis);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SignatureVerifier signatureVerifier(NonceCache cache, SecurityProperties props) {
+        return new SignatureVerifier(cache,
+                TimeUnit.SECONDS.toMillis(props.getReplayWindowSeconds()),
+                System::currentTimeMillis);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PermissionChecker permissionChecker() {
+        return new PermissionChecker();
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> seataSecurityFilter(SecurityProperties props,
+                                                              ClusterIdentityRegistry registry,
+                                                              SignatureVerifier verifier,
+                                                              PermissionChecker checker) {
+        SecurityFilter filter = new SecurityFilter(props, registry, verifier, checker);
+        FilterRegistrationBean<Filter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(filter);
+        reg.addUrlPatterns("/*");
+        reg.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return reg;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "seata.security.outbound", name = "cluster-id")
+    public OutboundSigner outboundSigner(SecurityProperties props, SecretResolver resolver) {
+        SecurityProperties.OutboundConfig out = props.getOutbound();
+        byte[] secret = resolver.resolve(out.getSecretRef());
+        if (secret.length < HmacSigner.MIN_KEY_LENGTH_BYTES) {
+            throw new IllegalStateException("outbound secret is shorter than "
+                    + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
+        }
+        return new OutboundSigner(out.getClusterId(), secret);
+    }
+
+    /**
+     * Trivial glob → regex translator supporting {@code *} and {@code ?}. Handles nothing else,
+     * on purpose: complex regex belongs in a dedicated pattern language, not a config file.
+     */
+    static Pattern globToRegex(String glob) {
+        StringBuilder sb = new StringBuilder(glob.length() + 4);
+        sb.append('^');
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            switch (c) {
+                case '*':
+                    sb.append(".*");
+                    break;
+                case '?':
+                    sb.append('.');
+                    break;
+                case '.': case '\\': case '+': case '(': case ')':
+                case '[': case ']': case '{': case '}': case '^':
+                case '$': case '|':
+                    sb.append('\\').append(c);
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        sb.append('$');
+        return Pattern.compile(sb.toString());
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityAutoConfiguration.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityAutoConfiguration.java
@@ -17,13 +17,6 @@
 package org.apache.seata.namingserver.security;
 
 import jakarta.servlet.Filter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import org.apache.seata.common.security.HmacSigner;
 import org.apache.seata.common.security.NonceCache;
 import org.apache.seata.common.security.SignatureVerifier;
@@ -36,6 +29,13 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Wires up the security layer only when {@code seata.security.enabled=true}. When disabled
@@ -60,30 +60,32 @@ public class SecurityAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ClusterIdentityRegistry clusterIdentityRegistry(SecurityProperties props,
-                                                           SecretResolver resolver) {
+    public ClusterIdentityRegistry clusterIdentityRegistry(SecurityProperties props, SecretResolver resolver) {
         ClusterIdentityRegistry registry = new ClusterIdentityRegistry();
         List<ClusterIdentity> loaded = new ArrayList<>();
         for (SecurityProperties.ClusterConfig cfg : props.getClusters()) {
             byte[] secret = resolver.resolve(cfg.getSecretRef());
             if (secret.length < HmacSigner.MIN_KEY_LENGTH_BYTES) {
-                throw new IllegalStateException("secret for cluster-id '" + cfg.getId()
-                        + "' is shorter than " + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
+                throw new IllegalStateException("secret for cluster-id '" + cfg.getId() + "' is shorter than "
+                        + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
             }
             List<Pattern> patterns = cfg.getAllowedVgroups() == null
                     ? Collections.emptyList()
                     : cfg.getAllowedVgroups().stream()
-                        .map(SecurityAutoConfiguration::globToRegex)
-                        .collect(Collectors.toList());
+                            .map(SecurityAutoConfiguration::globToRegex)
+                            .collect(Collectors.toList());
             loaded.add(new ClusterIdentity(
                     cfg.getId(),
                     secret,
-                    cfg.getAllowedNamespaces() == null ? Collections.emptySet()
+                    cfg.getAllowedNamespaces() == null
+                            ? Collections.emptySet()
                             : new java.util.HashSet<>(cfg.getAllowedNamespaces()),
-                    cfg.getAllowedClusters() == null ? Collections.emptySet()
+                    cfg.getAllowedClusters() == null
+                            ? Collections.emptySet()
                             : new java.util.HashSet<>(cfg.getAllowedClusters()),
                     patterns,
-                    cfg.getPermissions() == null ? java.util.EnumSet.noneOf(Permission.class)
+                    cfg.getPermissions() == null
+                            ? java.util.EnumSet.noneOf(Permission.class)
                             : java.util.EnumSet.copyOf(cfg.getPermissions())));
         }
         registry.reload(loaded);
@@ -101,9 +103,8 @@ public class SecurityAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public SignatureVerifier signatureVerifier(NonceCache cache, SecurityProperties props) {
-        return new SignatureVerifier(cache,
-                TimeUnit.SECONDS.toMillis(props.getReplayWindowSeconds()),
-                System::currentTimeMillis);
+        return new SignatureVerifier(
+                cache, TimeUnit.SECONDS.toMillis(props.getReplayWindowSeconds()), System::currentTimeMillis);
     }
 
     @Bean
@@ -113,10 +114,11 @@ public class SecurityAutoConfiguration {
     }
 
     @Bean
-    public FilterRegistrationBean<Filter> seataSecurityFilter(SecurityProperties props,
-                                                              ClusterIdentityRegistry registry,
-                                                              SignatureVerifier verifier,
-                                                              PermissionChecker checker) {
+    public FilterRegistrationBean<Filter> seataSecurityFilter(
+            SecurityProperties props,
+            ClusterIdentityRegistry registry,
+            SignatureVerifier verifier,
+            PermissionChecker checker) {
         SecurityFilter filter = new SecurityFilter(props, registry, verifier, checker);
         FilterRegistrationBean<Filter> reg = new FilterRegistrationBean<>();
         reg.setFilter(filter);
@@ -132,8 +134,8 @@ public class SecurityAutoConfiguration {
         SecurityProperties.OutboundConfig out = props.getOutbound();
         byte[] secret = resolver.resolve(out.getSecretRef());
         if (secret.length < HmacSigner.MIN_KEY_LENGTH_BYTES) {
-            throw new IllegalStateException("outbound secret is shorter than "
-                    + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
+            throw new IllegalStateException(
+                    "outbound secret is shorter than " + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
         }
         return new OutboundSigner(out.getClusterId(), secret);
     }
@@ -154,9 +156,18 @@ public class SecurityAutoConfiguration {
                 case '?':
                     sb.append('.');
                     break;
-                case '.': case '\\': case '+': case '(': case ')':
-                case '[': case ']': case '{': case '}': case '^':
-                case '$': case '|':
+                case '.':
+                case '\\':
+                case '+':
+                case '(':
+                case ')':
+                case '[':
+                case ']':
+                case '{':
+                case '}':
+                case '^':
+                case '$':
+                case '|':
                     sb.append('\\').append(c);
                     break;
                 default:

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityFilter.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityFilter.java
@@ -18,11 +18,22 @@ package org.apache.seata.namingserver.security;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.apache.seata.common.security.VerificationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -34,17 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import jakarta.servlet.ReadListener;
-import jakarta.servlet.ServletInputStream;
-import jakarta.servlet.http.HttpServletRequestWrapper;
-import org.apache.seata.common.security.CanonicalRequest;
-import org.apache.seata.common.security.SecurityConstants;
-import org.apache.seata.common.security.SignatureAlgorithm;
-import org.apache.seata.common.security.SignatureVerifier;
-import org.apache.seata.common.security.VerificationResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Servlet filter that authenticates every inbound HTTP request against a shared secret and
@@ -87,10 +87,11 @@ public class SecurityFilter implements Filter {
 
     private final PermissionChecker permissionChecker;
 
-    public SecurityFilter(SecurityProperties properties,
-                          ClusterIdentityRegistry registry,
-                          SignatureVerifier verifier,
-                          PermissionChecker permissionChecker) {
+    public SecurityFilter(
+            SecurityProperties properties,
+            ClusterIdentityRegistry registry,
+            SignatureVerifier verifier,
+            PermissionChecker permissionChecker) {
         this.properties = Objects.requireNonNull(properties, "properties");
         this.registry = Objects.requireNonNull(registry, "registry");
         this.verifier = Objects.requireNonNull(verifier, "verifier");
@@ -121,9 +122,13 @@ public class SecurityFilter implements Filter {
 
         // ---- Missing headers ----
         if (isBlank(clusterId) || isBlank(timestamp) || isBlank(nonce) || isBlank(signature)) {
-            handleFailure(httpReq, httpResp, chain,
+            handleFailure(
+                    httpReq,
+                    httpResp,
+                    chain,
                     SecurityConstants.ErrorCode.MISSING_SIGNATURE,
-                    "one or more required security headers are missing", null);
+                    "one or more required security headers are missing",
+                    null);
             return;
         }
 
@@ -132,25 +137,33 @@ public class SecurityFilter implements Filter {
         try {
             ts = Long.parseLong(timestamp);
         } catch (NumberFormatException e) {
-            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.BAD_REQUEST,
-                    "timestamp header is not a valid long", null);
+            handleFailure(
+                    httpReq,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.BAD_REQUEST,
+                    "timestamp header is not a valid long",
+                    null);
             return;
         }
         SignatureAlgorithm algorithm;
         try {
-            algorithm = algName == null ? SignatureAlgorithm.HMAC_SHA256
-                    : SignatureAlgorithm.fromWireName(algName);
+            algorithm = algName == null ? SignatureAlgorithm.HMAC_SHA256 : SignatureAlgorithm.fromWireName(algName);
         } catch (IllegalArgumentException e) {
-            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.UNSUPPORTED_ALG,
-                    e.getMessage(), null);
+            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.UNSUPPORTED_ALG, e.getMessage(), null);
             return;
         }
 
         // ---- Identity lookup ----
         Optional<ClusterIdentity> identityOpt = registry.find(clusterId);
         if (!identityOpt.isPresent()) {
-            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID,
-                    "no identity registered for cluster-id: " + clusterId, null);
+            handleFailure(
+                    httpReq,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID,
+                    "no identity registered for cluster-id: " + clusterId,
+                    null);
             return;
         }
         ClusterIdentity identity = identityOpt.get();
@@ -181,12 +194,17 @@ public class SecurityFilter implements Filter {
         String namespace = httpReq.getParameter("namespace");
         String cluster = httpReq.getParameter("clusterName");
         String vgroup = httpReq.getParameter("vGroup");
-        boolean allowed = permissionChecker.check(identity, httpReq.getMethod(),
-                httpReq.getRequestURI(), namespace, cluster, vgroup);
+        boolean allowed = permissionChecker.check(
+                identity, httpReq.getMethod(), httpReq.getRequestURI(), namespace, cluster, vgroup);
         if (!allowed) {
-            handleFailure(wrapper, httpResp, chain, SecurityConstants.ErrorCode.FORBIDDEN,
-                    "caller " + clusterId + " lacks permission for " + httpReq.getMethod()
-                            + " " + httpReq.getRequestURI(), identity);
+            handleFailure(
+                    wrapper,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.FORBIDDEN,
+                    "caller " + clusterId + " lacks permission for " + httpReq.getMethod() + " "
+                            + httpReq.getRequestURI(),
+                    identity);
             return;
         }
 
@@ -214,8 +232,12 @@ public class SecurityFilter implements Filter {
             return false;
         }
         if (pattern.endsWith("/**")) {
+            // Trim the trailing "/**" and require an exact match of the parent segment
+            // or a proper descendant. Using a naked startsWith(prefix) would incorrectly
+            // match sibling paths that merely share the same prefix string
+            // (e.g. "/actuator/**" would otherwise match "/actuatorX").
             String prefix = pattern.substring(0, pattern.length() - 3);
-            return uri.startsWith(prefix);
+            return uri.equals(prefix) || uri.startsWith(prefix + "/");
         }
         return pattern.equals(uri);
     }
@@ -230,16 +252,22 @@ public class SecurityFilter implements Filter {
         return params;
     }
 
-    private void handleFailure(HttpServletRequest req,
-                               HttpServletResponse resp,
-                               FilterChain chain,
-                               SecurityConstants.ErrorCode code,
-                               String message,
-                               ClusterIdentity identity) throws IOException, ServletException {
+    private void handleFailure(
+            HttpServletRequest req,
+            HttpServletResponse resp,
+            FilterChain chain,
+            SecurityConstants.ErrorCode code,
+            String message,
+            ClusterIdentity identity)
+            throws IOException, ServletException {
         SecurityProperties.Mode mode = properties.getMode();
         if (mode == SecurityProperties.Mode.WARN) {
-            LOGGER.warn("[security][WARN] {} {} rejected: code={} msg={} caller={}",
-                    req.getMethod(), req.getRequestURI(), code, message,
+            LOGGER.warn(
+                    "[security][WARN] {} {} rejected: code={} msg={} caller={}",
+                    req.getMethod(),
+                    req.getRequestURI(),
+                    code,
+                    message,
                     identity == null ? "unknown" : identity.getId());
             if (identity != null) {
                 req.setAttribute(ATTR_IDENTITY, identity);
@@ -251,21 +279,58 @@ public class SecurityFilter implements Filter {
         int status = (code == SecurityConstants.ErrorCode.FORBIDDEN)
                 ? HttpServletResponse.SC_FORBIDDEN
                 : HttpServletResponse.SC_UNAUTHORIZED;
-        LOGGER.warn("[security][ENFORCE] {} {} rejected status={} code={} msg={} caller={}",
-                req.getMethod(), req.getRequestURI(), status, code, message,
+        LOGGER.warn(
+                "[security][ENFORCE] {} {} rejected status={} code={} msg={} caller={}",
+                req.getMethod(),
+                req.getRequestURI(),
+                status,
+                code,
+                message,
                 identity == null ? "unknown" : identity.getId());
         resp.setHeader(RESP_HEADER_ERROR, code.name());
         resp.setContentType("application/json;charset=UTF-8");
         resp.setStatus(status);
-        resp.getWriter().write("{\"code\":\"" + code.name() + "\",\"message\":\""
-                + escapeJson(message) + "\"}");
+        resp.getWriter().write("{\"code\":\"" + code.name() + "\",\"message\":\"" + escapeJson(message) + "\"}");
     }
 
     private static String escapeJson(String v) {
         if (v == null) {
             return "";
         }
-        return v.replace("\\", "\\\\").replace("\"", "\\\"");
+        StringBuilder sb = new StringBuilder(v.length() + 8);
+        for (int i = 0; i < v.length(); i++) {
+            char c = v.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
     }
 
     private static boolean isBlank(String s) {
@@ -293,13 +358,24 @@ public class SecurityFilter implements Filter {
             ByteArrayInputStream stream = new ByteArrayInputStream(body);
             return new ServletInputStream() {
                 @Override
-                public boolean isFinished() { return stream.available() == 0; }
+                public boolean isFinished() {
+                    return stream.available() == 0;
+                }
+
                 @Override
-                public boolean isReady() { return true; }
+                public boolean isReady() {
+                    return true;
+                }
+
                 @Override
-                public void setReadListener(ReadListener listener) { /* not used */ }
+                public void setReadListener(ReadListener listener) {
+                    /* not used */
+                }
+
                 @Override
-                public int read() { return stream.read(); }
+                public int read() {
+                    return stream.read();
+                }
             };
         }
 

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityFilter.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityFilter.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.apache.seata.common.security.VerificationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Servlet filter that authenticates every inbound HTTP request against a shared secret and
+ * a per-caller permission set.
+ *
+ * <p>Life-cycle of a single request:
+ * <ol>
+ *   <li>Path is compared against {@link SecurityProperties#getExcludePaths()}; matches are
+ *       passed straight through (e.g. {@code /naming/v1/health}).</li>
+ *   <li>Extract security headers. If missing:
+ *       <ul>
+ *         <li>{@code WARN} mode → log and pass through.</li>
+ *         <li>{@code ENFORCE} mode → reject with 401.</li>
+ *       </ul>
+ *   </li>
+ *   <li>Look up {@link ClusterIdentity} by {@code X-Seata-Cluster-Id}. Unknown → 401.</li>
+ *   <li>Buffer the request body so both the signature verifier and downstream controllers can
+ *       read it — {@code ServletInputStream} is single-shot by default.</li>
+ *   <li>Run {@link SignatureVerifier} — freshness, nonce, HMAC.</li>
+ *   <li>Run {@link PermissionChecker} — route → permission and allow-list scoping.</li>
+ *   <li>On success, expose the identity in the request attribute {@link #ATTR_IDENTITY} for
+ *       downstream code (e.g. {@code ConsoleRemotingFilter} choosing the target TC) and pass on.</li>
+ * </ol>
+ */
+public class SecurityFilter implements Filter {
+
+    /** Request attribute name under which the authenticated identity is exposed. */
+    public static final String ATTR_IDENTITY = "seata.security.identity";
+
+    /** Response header used to surface the error code for machine consumers. */
+    public static final String RESP_HEADER_ERROR = "X-Seata-Auth-Error";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityFilter.class);
+
+    private final SecurityProperties properties;
+
+    private final ClusterIdentityRegistry registry;
+
+    private final SignatureVerifier verifier;
+
+    private final PermissionChecker permissionChecker;
+
+    public SecurityFilter(SecurityProperties properties,
+                          ClusterIdentityRegistry registry,
+                          SignatureVerifier verifier,
+                          PermissionChecker permissionChecker) {
+        this.properties = Objects.requireNonNull(properties, "properties");
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.verifier = Objects.requireNonNull(verifier, "verifier");
+        this.permissionChecker = Objects.requireNonNull(permissionChecker, "permissionChecker");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        HttpServletRequest httpReq = (HttpServletRequest) request;
+        HttpServletResponse httpResp = (HttpServletResponse) response;
+
+        // Fast-path bypass: health checks and any other whitelisted path.
+        if (isExcluded(httpReq.getRequestURI())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String clusterId = httpReq.getHeader(SecurityConstants.HEADER_CLUSTER_ID);
+        String timestamp = httpReq.getHeader(SecurityConstants.HEADER_TIMESTAMP);
+        String nonce = httpReq.getHeader(SecurityConstants.HEADER_NONCE);
+        String algName = httpReq.getHeader(SecurityConstants.HEADER_SIGN_ALG);
+        String signature = httpReq.getHeader(SecurityConstants.HEADER_SIGNATURE);
+
+        // ---- Missing headers ----
+        if (isBlank(clusterId) || isBlank(timestamp) || isBlank(nonce) || isBlank(signature)) {
+            handleFailure(httpReq, httpResp, chain,
+                    SecurityConstants.ErrorCode.MISSING_SIGNATURE,
+                    "one or more required security headers are missing", null);
+            return;
+        }
+
+        // ---- Parse timestamp / algorithm ----
+        long ts;
+        try {
+            ts = Long.parseLong(timestamp);
+        } catch (NumberFormatException e) {
+            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.BAD_REQUEST,
+                    "timestamp header is not a valid long", null);
+            return;
+        }
+        SignatureAlgorithm algorithm;
+        try {
+            algorithm = algName == null ? SignatureAlgorithm.HMAC_SHA256
+                    : SignatureAlgorithm.fromWireName(algName);
+        } catch (IllegalArgumentException e) {
+            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.UNSUPPORTED_ALG,
+                    e.getMessage(), null);
+            return;
+        }
+
+        // ---- Identity lookup ----
+        Optional<ClusterIdentity> identityOpt = registry.find(clusterId);
+        if (!identityOpt.isPresent()) {
+            handleFailure(httpReq, httpResp, chain, SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID,
+                    "no identity registered for cluster-id: " + clusterId, null);
+            return;
+        }
+        ClusterIdentity identity = identityOpt.get();
+
+        // ---- Buffer body so the verifier and the downstream controller can both read it. ----
+        CachedBodyRequestWrapper wrapper = new CachedBodyRequestWrapper(httpReq);
+        byte[] body = wrapper.getCachedBody();
+
+        // ---- Verify signature ----
+        CanonicalRequest canonical = CanonicalRequest.builder()
+                .method(httpReq.getMethod())
+                .path(httpReq.getRequestURI())
+                .queryParams(parseQuery(httpReq))
+                .clusterId(clusterId)
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(algorithm)
+                .body(body)
+                .build();
+
+        VerificationResult result = verifier.verify(canonical, identity.getSecret(), signature);
+        if (!result.isSuccess()) {
+            handleFailure(wrapper, httpResp, chain, result.getErrorCode(), result.getMessage(), identity);
+            return;
+        }
+
+        // ---- Permission check ----
+        String namespace = httpReq.getParameter("namespace");
+        String cluster = httpReq.getParameter("clusterName");
+        String vgroup = httpReq.getParameter("vGroup");
+        boolean allowed = permissionChecker.check(identity, httpReq.getMethod(),
+                httpReq.getRequestURI(), namespace, cluster, vgroup);
+        if (!allowed) {
+            handleFailure(wrapper, httpResp, chain, SecurityConstants.ErrorCode.FORBIDDEN,
+                    "caller " + clusterId + " lacks permission for " + httpReq.getMethod()
+                            + " " + httpReq.getRequestURI(), identity);
+            return;
+        }
+
+        // ---- Success: hand off to the rest of the chain ----
+        wrapper.setAttribute(ATTR_IDENTITY, identity);
+        chain.doFilter(wrapper, httpResp);
+    }
+
+    private boolean isExcluded(String uri) {
+        List<String> excluded = properties.getExcludePaths();
+        if (excluded == null || excluded.isEmpty()) {
+            return false;
+        }
+        for (String pattern : excluded) {
+            if (matches(pattern, uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Minimal Ant-style matcher: supports trailing {@code /**} and exact match. */
+    static boolean matches(String pattern, String uri) {
+        if (pattern == null || uri == null) {
+            return false;
+        }
+        if (pattern.endsWith("/**")) {
+            String prefix = pattern.substring(0, pattern.length() - 3);
+            return uri.startsWith(prefix);
+        }
+        return pattern.equals(uri);
+    }
+
+    private Map<String, String> parseQuery(HttpServletRequest req) {
+        Map<String, String> params = new LinkedHashMap<>();
+        Enumeration<String> names = req.getParameterNames();
+        while (names.hasMoreElements()) {
+            String name = names.nextElement();
+            params.put(name, req.getParameter(name));
+        }
+        return params;
+    }
+
+    private void handleFailure(HttpServletRequest req,
+                               HttpServletResponse resp,
+                               FilterChain chain,
+                               SecurityConstants.ErrorCode code,
+                               String message,
+                               ClusterIdentity identity) throws IOException, ServletException {
+        SecurityProperties.Mode mode = properties.getMode();
+        if (mode == SecurityProperties.Mode.WARN) {
+            LOGGER.warn("[security][WARN] {} {} rejected: code={} msg={} caller={}",
+                    req.getMethod(), req.getRequestURI(), code, message,
+                    identity == null ? "unknown" : identity.getId());
+            if (identity != null) {
+                req.setAttribute(ATTR_IDENTITY, identity);
+            }
+            chain.doFilter(req, resp);
+            return;
+        }
+        // ENFORCE
+        int status = (code == SecurityConstants.ErrorCode.FORBIDDEN)
+                ? HttpServletResponse.SC_FORBIDDEN
+                : HttpServletResponse.SC_UNAUTHORIZED;
+        LOGGER.warn("[security][ENFORCE] {} {} rejected status={} code={} msg={} caller={}",
+                req.getMethod(), req.getRequestURI(), status, code, message,
+                identity == null ? "unknown" : identity.getId());
+        resp.setHeader(RESP_HEADER_ERROR, code.name());
+        resp.setContentType("application/json;charset=UTF-8");
+        resp.setStatus(status);
+        resp.getWriter().write("{\"code\":\"" + code.name() + "\",\"message\":\""
+                + escapeJson(message) + "\"}");
+    }
+
+    private static String escapeJson(String v) {
+        if (v == null) {
+            return "";
+        }
+        return v.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isEmpty();
+    }
+
+    /**
+     * Wraps a request so its body can be read multiple times: once here for signing, once again
+     * by Spring MVC when it binds the {@code @RequestBody}.
+     */
+    static final class CachedBodyRequestWrapper extends HttpServletRequestWrapper {
+        private final byte[] body;
+
+        CachedBodyRequestWrapper(HttpServletRequest request) throws IOException {
+            super(request);
+            this.body = readAll(request);
+        }
+
+        byte[] getCachedBody() {
+            return body;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            ByteArrayInputStream stream = new ByteArrayInputStream(body);
+            return new ServletInputStream() {
+                @Override
+                public boolean isFinished() { return stream.available() == 0; }
+                @Override
+                public boolean isReady() { return true; }
+                @Override
+                public void setReadListener(ReadListener listener) { /* not used */ }
+                @Override
+                public int read() { return stream.read(); }
+            };
+        }
+
+        @Override
+        public BufferedReader getReader() {
+            return new BufferedReader(new InputStreamReader(getInputStream(), StandardCharsets.UTF_8));
+        }
+
+        private static byte[] readAll(HttpServletRequest request) throws IOException {
+            try (ServletInputStream in = request.getInputStream()) {
+                java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+                byte[] buf = new byte[4096];
+                int n;
+                while ((n = in.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
+                return out.toByteArray();
+            }
+        }
+    }
+}

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityProperties.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityProperties.java
@@ -16,11 +16,11 @@
  */
 package org.apache.seata.namingserver.security;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.seata.common.security.SecurityConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Configuration mapped from {@code seata.security.*} in {@code application.yml}.
@@ -133,27 +133,73 @@ public class SecurityProperties {
         private List<String> allowedVgroups = new ArrayList<>();
         private List<Permission> permissions = new ArrayList<>();
 
-        public String getId() { return id; }
-        public void setId(String id) { this.id = id; }
-        public String getSecretRef() { return secretRef; }
-        public void setSecretRef(String secretRef) { this.secretRef = secretRef; }
-        public List<String> getAllowedNamespaces() { return allowedNamespaces; }
-        public void setAllowedNamespaces(List<String> allowedNamespaces) { this.allowedNamespaces = allowedNamespaces; }
-        public List<String> getAllowedClusters() { return allowedClusters; }
-        public void setAllowedClusters(List<String> allowedClusters) { this.allowedClusters = allowedClusters; }
-        public List<String> getAllowedVgroups() { return allowedVgroups; }
-        public void setAllowedVgroups(List<String> allowedVgroups) { this.allowedVgroups = allowedVgroups; }
-        public List<Permission> getPermissions() { return permissions; }
-        public void setPermissions(List<Permission> permissions) { this.permissions = permissions; }
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getSecretRef() {
+            return secretRef;
+        }
+
+        public void setSecretRef(String secretRef) {
+            this.secretRef = secretRef;
+        }
+
+        public List<String> getAllowedNamespaces() {
+            return allowedNamespaces;
+        }
+
+        public void setAllowedNamespaces(List<String> allowedNamespaces) {
+            this.allowedNamespaces = allowedNamespaces;
+        }
+
+        public List<String> getAllowedClusters() {
+            return allowedClusters;
+        }
+
+        public void setAllowedClusters(List<String> allowedClusters) {
+            this.allowedClusters = allowedClusters;
+        }
+
+        public List<String> getAllowedVgroups() {
+            return allowedVgroups;
+        }
+
+        public void setAllowedVgroups(List<String> allowedVgroups) {
+            this.allowedVgroups = allowedVgroups;
+        }
+
+        public List<Permission> getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(List<Permission> permissions) {
+            this.permissions = permissions;
+        }
     }
 
     public static class OutboundConfig {
         private String clusterId;
         private String secretRef;
 
-        public String getClusterId() { return clusterId; }
-        public void setClusterId(String clusterId) { this.clusterId = clusterId; }
-        public String getSecretRef() { return secretRef; }
-        public void setSecretRef(String secretRef) { this.secretRef = secretRef; }
+        public String getClusterId() {
+            return clusterId;
+        }
+
+        public void setClusterId(String clusterId) {
+            this.clusterId = clusterId;
+        }
+
+        public String getSecretRef() {
+            return secretRef;
+        }
+
+        public void setSecretRef(String secretRef) {
+            this.secretRef = secretRef;
+        }
     }
 }

--- a/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityProperties.java
+++ b/namingserver/src/main/java/org/apache/seata/namingserver/security/SecurityProperties.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.seata.common.security.SecurityConstants;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration mapped from {@code seata.security.*} in {@code application.yml}.
+ *
+ * <p>Design decisions:
+ * <ul>
+ *   <li><b>Secret indirection</b>: each cluster carries a {@code secret-ref} string (e.g.
+ *       {@code env:MY_VAR}, {@code vault:secret/foo}) instead of an inline value. The
+ *       {@code SecretResolver} resolves it at boot time. This keeps plaintext keys out of
+ *       config files and out of {@code /actuator/configprops} dumps.</li>
+ *   <li><b>Mode enum</b> ({@code DISABLED / WARN / ENFORCE}) gives operators a safe two-step
+ *       rollout: deploy in {@code WARN} to observe, then flip to {@code ENFORCE}.</li>
+ * </ul>
+ */
+@ConfigurationProperties(prefix = "seata.security")
+public class SecurityProperties {
+
+    /** Whether the security layer is loaded at all. When false, no filter is registered. */
+    private boolean enabled = false;
+
+    /** {@link Mode#ENFORCE} rejects unsigned or invalid requests. {@link Mode#WARN} only logs. */
+    private Mode mode = Mode.ENFORCE;
+
+    /** Clock-skew tolerance for {@code X-Seata-Timestamp}, in seconds. */
+    private long replayWindowSeconds = SecurityConstants.DEFAULT_REPLAY_WINDOW_SECONDS;
+
+    /** How long a nonce lives in the anti-replay cache, in minutes. */
+    private long nonceCacheMinutes = SecurityConstants.DEFAULT_NONCE_CACHE_MINUTES;
+
+    /** URL paths (Ant-style) that bypass the filter entirely, e.g. the health endpoint. */
+    private List<String> excludePaths = new ArrayList<>();
+
+    /** Identities the NamingServer will trust on the inbound path. */
+    private List<ClusterConfig> clusters = new ArrayList<>();
+
+    /** Identity the NamingServer uses when reaching out to TC (self-identification). */
+    private OutboundConfig outbound = new OutboundConfig();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
+    }
+
+    public long getReplayWindowSeconds() {
+        return replayWindowSeconds;
+    }
+
+    public void setReplayWindowSeconds(long replayWindowSeconds) {
+        this.replayWindowSeconds = replayWindowSeconds;
+    }
+
+    public long getNonceCacheMinutes() {
+        return nonceCacheMinutes;
+    }
+
+    public void setNonceCacheMinutes(long nonceCacheMinutes) {
+        this.nonceCacheMinutes = nonceCacheMinutes;
+    }
+
+    public List<String> getExcludePaths() {
+        return excludePaths;
+    }
+
+    public void setExcludePaths(List<String> excludePaths) {
+        this.excludePaths = excludePaths;
+    }
+
+    public List<ClusterConfig> getClusters() {
+        return clusters;
+    }
+
+    public void setClusters(List<ClusterConfig> clusters) {
+        this.clusters = clusters;
+    }
+
+    public OutboundConfig getOutbound() {
+        return outbound;
+    }
+
+    public void setOutbound(OutboundConfig outbound) {
+        this.outbound = outbound;
+    }
+
+    public enum Mode {
+        /** Skip all auth logic. */
+        DISABLED,
+        /** Log unauthorized requests but do not reject them. */
+        WARN,
+        /** Reject unauthorized requests with 401/403. */
+        ENFORCE
+    }
+
+    /** Per-caller config binding. See {@link ClusterIdentity} for the runtime shape. */
+    public static class ClusterConfig {
+        private String id;
+        private String secretRef;
+        private List<String> allowedNamespaces = new ArrayList<>();
+        private List<String> allowedClusters = new ArrayList<>();
+        private List<String> allowedVgroups = new ArrayList<>();
+        private List<Permission> permissions = new ArrayList<>();
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+        public String getSecretRef() { return secretRef; }
+        public void setSecretRef(String secretRef) { this.secretRef = secretRef; }
+        public List<String> getAllowedNamespaces() { return allowedNamespaces; }
+        public void setAllowedNamespaces(List<String> allowedNamespaces) { this.allowedNamespaces = allowedNamespaces; }
+        public List<String> getAllowedClusters() { return allowedClusters; }
+        public void setAllowedClusters(List<String> allowedClusters) { this.allowedClusters = allowedClusters; }
+        public List<String> getAllowedVgroups() { return allowedVgroups; }
+        public void setAllowedVgroups(List<String> allowedVgroups) { this.allowedVgroups = allowedVgroups; }
+        public List<Permission> getPermissions() { return permissions; }
+        public void setPermissions(List<Permission> permissions) { this.permissions = permissions; }
+    }
+
+    public static class OutboundConfig {
+        private String clusterId;
+        private String secretRef;
+
+        public String getClusterId() { return clusterId; }
+        public void setClusterId(String clusterId) { this.clusterId = clusterId; }
+        public String getSecretRef() { return secretRef; }
+        public void setSecretRef(String secretRef) { this.secretRef = secretRef; }
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityRegistryTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityRegistryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClusterIdentityRegistryTest {
+
+    private static ClusterIdentity id(String name) {
+        return new ClusterIdentity(name, new byte[32],
+                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER));
+    }
+
+    @Test
+    void find_returns_registered_identity() {
+        ClusterIdentityRegistry reg = new ClusterIdentityRegistry();
+        reg.register(id("tenant-a"));
+        assertTrue(reg.find("tenant-a").isPresent());
+        assertFalse(reg.find("tenant-b").isPresent());
+    }
+
+    @Test
+    void find_null_returns_empty() {
+        ClusterIdentityRegistry reg = new ClusterIdentityRegistry();
+        assertFalse(reg.find(null).isPresent());
+    }
+
+    @Test
+    void reload_replaces_previous_content() {
+        ClusterIdentityRegistry reg = new ClusterIdentityRegistry();
+        reg.register(id("tenant-a"));
+        reg.register(id("tenant-b"));
+        reg.reload(Arrays.asList(id("tenant-c")));
+        assertEquals(1, reg.size());
+        assertFalse(reg.find("tenant-a").isPresent());
+        assertTrue(reg.find("tenant-c").isPresent());
+    }
+
+    @Test
+    void as_map_is_unmodifiable() {
+        ClusterIdentityRegistry reg = new ClusterIdentityRegistry();
+        reg.register(id("tenant-a"));
+        assertThrows(UnsupportedOperationException.class, () -> reg.asMap().clear());
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityRegistryTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityRegistryTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.seata.namingserver.security;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -30,8 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ClusterIdentityRegistryTest {
 
     private static ClusterIdentity id(String name) {
-        return new ClusterIdentity(name, new byte[32],
-                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+        return new ClusterIdentity(
+                name,
+                new byte[32],
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptyList(),
                 EnumSet.of(Permission.REGISTER));
     }
 

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.seata.namingserver.security;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.regex.Pattern;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -35,8 +35,12 @@ class ClusterIdentityTest {
     @Test
     void empty_allow_lists_default_to_permissive_for_ns_and_cluster() {
         // No allow-list configured → treat as no restriction (matches production defaults).
-        ClusterIdentity id = new ClusterIdentity("t", SECRET,
-                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                SECRET,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptyList(),
                 EnumSet.of(Permission.REGISTER));
         assertTrue(id.isNamespaceAllowed("anything"));
         assertTrue(id.isClusterAllowed("anything"));
@@ -45,7 +49,9 @@ class ClusterIdentityTest {
 
     @Test
     void wildcard_star_in_allow_list_matches_all() {
-        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                SECRET,
                 new HashSet<>(Collections.singletonList("*")),
                 new HashSet<>(Collections.singletonList("*")),
                 Collections.emptyList(),
@@ -56,7 +62,9 @@ class ClusterIdentityTest {
 
     @Test
     void explicit_allow_list_is_strict() {
-        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                SECRET,
                 new HashSet<>(Arrays.asList("prod", "staging")),
                 new HashSet<>(Arrays.asList("cluster-A")),
                 Collections.emptyList(),
@@ -70,8 +78,11 @@ class ClusterIdentityTest {
     @Test
     void vgroup_pattern_matches_glob_regex() {
         Pattern p = Pattern.compile("^tenant_a_.*$");
-        ClusterIdentity id = new ClusterIdentity("t", SECRET,
-                Collections.emptySet(), Collections.emptySet(),
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                SECRET,
+                Collections.emptySet(),
+                Collections.emptySet(),
                 Collections.singletonList(p),
                 EnumSet.of(Permission.VGROUP_WRITE));
         assertTrue(id.isVgroupAllowed("tenant_a_group"));
@@ -81,8 +92,12 @@ class ClusterIdentityTest {
 
     @Test
     void get_secret_returns_defensive_copy() {
-        ClusterIdentity id = new ClusterIdentity("t", SECRET,
-                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                SECRET,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptyList(),
                 EnumSet.noneOf(Permission.class));
         byte[] first = id.getSecret();
         byte[] second = id.getSecret();
@@ -91,8 +106,12 @@ class ClusterIdentityTest {
 
     @Test
     void has_permission_reflects_configured_set() {
-        ClusterIdentity id = new ClusterIdentity("t", SECRET,
-                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                SECRET,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptyList(),
                 EnumSet.of(Permission.REGISTER, Permission.HEARTBEAT));
         assertTrue(id.hasPermission(Permission.REGISTER));
         assertFalse(id.hasPermission(Permission.CONSOLE_WRITE));

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/ClusterIdentityTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClusterIdentityTest {
+
+    private static final byte[] SECRET = new byte[32];
+
+    @Test
+    void empty_allow_lists_default_to_permissive_for_ns_and_cluster() {
+        // No allow-list configured → treat as no restriction (matches production defaults).
+        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER));
+        assertTrue(id.isNamespaceAllowed("anything"));
+        assertTrue(id.isClusterAllowed("anything"));
+        assertTrue(id.isVgroupAllowed("anything"));
+    }
+
+    @Test
+    void wildcard_star_in_allow_list_matches_all() {
+        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+                new HashSet<>(Collections.singletonList("*")),
+                new HashSet<>(Collections.singletonList("*")),
+                Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER));
+        assertTrue(id.isNamespaceAllowed("prod"));
+        assertTrue(id.isClusterAllowed("cluster-XYZ"));
+    }
+
+    @Test
+    void explicit_allow_list_is_strict() {
+        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+                new HashSet<>(Arrays.asList("prod", "staging")),
+                new HashSet<>(Arrays.asList("cluster-A")),
+                Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER));
+        assertTrue(id.isNamespaceAllowed("prod"));
+        assertFalse(id.isNamespaceAllowed("dev"));
+        assertTrue(id.isClusterAllowed("cluster-A"));
+        assertFalse(id.isClusterAllowed("cluster-B"));
+    }
+
+    @Test
+    void vgroup_pattern_matches_glob_regex() {
+        Pattern p = Pattern.compile("^tenant_a_.*$");
+        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+                Collections.emptySet(), Collections.emptySet(),
+                Collections.singletonList(p),
+                EnumSet.of(Permission.VGROUP_WRITE));
+        assertTrue(id.isVgroupAllowed("tenant_a_group"));
+        assertFalse(id.isVgroupAllowed("tenant_b_group"));
+        assertFalse(id.isVgroupAllowed(null));
+    }
+
+    @Test
+    void get_secret_returns_defensive_copy() {
+        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+                EnumSet.noneOf(Permission.class));
+        byte[] first = id.getSecret();
+        byte[] second = id.getSecret();
+        assertNotSame(first, second, "each call must return a fresh copy");
+    }
+
+    @Test
+    void has_permission_reflects_configured_set() {
+        ClusterIdentity id = new ClusterIdentity("t", SECRET,
+                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER, Permission.HEARTBEAT));
+        assertTrue(id.hasPermission(Permission.REGISTER));
+        assertFalse(id.hasPermission(Permission.CONSOLE_WRITE));
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/OutboundSignerTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/OutboundSignerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OutboundSignerTest {
+
+    private static final byte[] SECRET = new byte[32];
+    static {
+        for (int i = 0; i < 32; i++) {
+            SECRET[i] = (byte) i;
+        }
+    }
+
+    @Test
+    void produces_all_required_headers() {
+        OutboundSigner signer = new OutboundSigner(
+                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 1234L, () -> "fixed");
+        Map<String, String> headers = signer.signHeaders("POST", "/vgroup/v1/addVGroup",
+                singletonQuery("vGroup", "g1"), null);
+
+        assertEquals("naming-01", headers.get(SecurityConstants.HEADER_CLUSTER_ID));
+        assertEquals("1234", headers.get(SecurityConstants.HEADER_TIMESTAMP));
+        assertEquals("fixed", headers.get(SecurityConstants.HEADER_NONCE));
+        assertEquals("HMAC-SHA256", headers.get(SecurityConstants.HEADER_SIGN_ALG));
+        assertTrue(headers.get(SecurityConstants.HEADER_SIGNATURE).length() > 0);
+    }
+
+    @Test
+    void signature_verifies_with_same_secret() {
+        OutboundSigner signer = new OutboundSigner(
+                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 5000L, () -> "n-1");
+        byte[] body = "{\"a\":1}".getBytes();
+        Map<String, String> headers = signer.signHeaders("POST", "/vgroup/v1/addVGroup",
+                singletonQuery("vGroup", "g1"), body);
+
+        CanonicalRequest req = CanonicalRequest.builder()
+                .method("POST")
+                .path("/vgroup/v1/addVGroup")
+                .queryParams(singletonQuery("vGroup", "g1"))
+                .clusterId("naming-01")
+                .timestampMillis(5000L)
+                .nonce("n-1")
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(body)
+                .build();
+
+        assertTrue(HmacSigner.verify(req, SECRET, headers.get(SecurityConstants.HEADER_SIGNATURE)));
+    }
+
+    @Test
+    void nonce_supplier_is_called_per_request() {
+        AtomicLong counter = new AtomicLong();
+        OutboundSigner signer = new OutboundSigner(
+                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256,
+                () -> 0L, () -> "n-" + counter.incrementAndGet());
+
+        Map<String, String> h1 = signer.signHeaders("GET", "/a", null, null);
+        Map<String, String> h2 = signer.signHeaders("GET", "/a", null, null);
+        assertEquals("n-1", h1.get(SecurityConstants.HEADER_NONCE));
+        assertEquals("n-2", h2.get(SecurityConstants.HEADER_NONCE));
+    }
+
+    private static Map<String, String> singletonQuery(String k, String v) {
+        Map<String, String> m = new HashMap<>();
+        m.put(k, v);
+        return m;
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/OutboundSignerTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/OutboundSignerTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.seata.namingserver.security;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.seata.common.security.CanonicalRequest;
 import org.apache.seata.common.security.HmacSigner;
 import org.apache.seata.common.security.SecurityConstants;
 import org.apache.seata.common.security.SignatureAlgorithm;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class OutboundSignerTest {
 
     private static final byte[] SECRET = new byte[32];
+
     static {
         for (int i = 0; i < 32; i++) {
             SECRET[i] = (byte) i;
@@ -40,10 +41,10 @@ class OutboundSignerTest {
 
     @Test
     void produces_all_required_headers() {
-        OutboundSigner signer = new OutboundSigner(
-                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 1234L, () -> "fixed");
-        Map<String, String> headers = signer.signHeaders("POST", "/vgroup/v1/addVGroup",
-                singletonQuery("vGroup", "g1"), null);
+        OutboundSigner signer =
+                new OutboundSigner("naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 1234L, () -> "fixed");
+        Map<String, String> headers =
+                signer.signHeaders("POST", "/vgroup/v1/addVGroup", singletonQuery("vGroup", "g1"), null);
 
         assertEquals("naming-01", headers.get(SecurityConstants.HEADER_CLUSTER_ID));
         assertEquals("1234", headers.get(SecurityConstants.HEADER_TIMESTAMP));
@@ -54,11 +55,11 @@ class OutboundSignerTest {
 
     @Test
     void signature_verifies_with_same_secret() {
-        OutboundSigner signer = new OutboundSigner(
-                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 5000L, () -> "n-1");
+        OutboundSigner signer =
+                new OutboundSigner("naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 5000L, () -> "n-1");
         byte[] body = "{\"a\":1}".getBytes();
-        Map<String, String> headers = signer.signHeaders("POST", "/vgroup/v1/addVGroup",
-                singletonQuery("vGroup", "g1"), body);
+        Map<String, String> headers =
+                signer.signHeaders("POST", "/vgroup/v1/addVGroup", singletonQuery("vGroup", "g1"), body);
 
         CanonicalRequest req = CanonicalRequest.builder()
                 .method("POST")
@@ -78,8 +79,7 @@ class OutboundSignerTest {
     void nonce_supplier_is_called_per_request() {
         AtomicLong counter = new AtomicLong();
         OutboundSigner signer = new OutboundSigner(
-                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256,
-                () -> 0L, () -> "n-" + counter.incrementAndGet());
+                "naming-01", SECRET, SignatureAlgorithm.HMAC_SHA256, () -> 0L, () -> "n-" + counter.incrementAndGet());
 
         Map<String, String> h1 = signer.signHeaders("GET", "/a", null, null);
         Map<String, String> h2 = signer.signHeaders("GET", "/a", null, null);

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/PermissionCheckerTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/PermissionCheckerTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.seata.namingserver.security;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,10 +36,8 @@ class PermissionCheckerTest {
 
     @Test
     void register_route_requires_register_permission() {
-        assertEquals(Permission.REGISTER,
-                checker.requiredPermission("POST", "/naming/v1/register"));
-        assertEquals(Permission.REGISTER,
-                checker.requiredPermission("POST", "/naming/v1/batchRegister"));
+        assertEquals(Permission.REGISTER, checker.requiredPermission("POST", "/naming/v1/register"));
+        assertEquals(Permission.REGISTER, checker.requiredPermission("POST", "/naming/v1/batchRegister"));
     }
 
     @Test
@@ -57,9 +55,9 @@ class PermissionCheckerTest {
 
     @Test
     void console_proxy_uses_method_to_pick_read_or_write() {
-        assertEquals(Permission.CONSOLE_READ,
-                checker.requiredPermission("GET", "/api/v1/console/globalSession/query"));
-        assertEquals(Permission.CONSOLE_WRITE,
+        assertEquals(Permission.CONSOLE_READ, checker.requiredPermission("GET", "/api/v1/console/globalSession/query"));
+        assertEquals(
+                Permission.CONSOLE_WRITE,
                 checker.requiredPermission("POST", "/api/v1/console/globalSession/forceCommit"));
     }
 
@@ -82,16 +80,21 @@ class PermissionCheckerTest {
 
     @Test
     void check_denies_namespace_outside_allow_list() {
-        ClusterIdentity id = new ClusterIdentity("t", new byte[32],
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                new byte[32],
                 new HashSet<>(Collections.singletonList("staging")),
-                Collections.emptySet(), Collections.emptyList(),
+                Collections.emptySet(),
+                Collections.emptyList(),
                 EnumSet.of(Permission.REGISTER));
         assertFalse(checker.check(id, "POST", "/naming/v1/register", "prod", "cluster-A", null));
     }
 
     @Test
     void check_denies_cluster_outside_allow_list() {
-        ClusterIdentity id = new ClusterIdentity("t", new byte[32],
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                new byte[32],
                 Collections.emptySet(),
                 new HashSet<>(Arrays.asList("cluster-A")),
                 Collections.emptyList(),
@@ -102,25 +105,25 @@ class PermissionCheckerTest {
     @Test
     void check_denies_vgroup_outside_pattern() {
         List<Pattern> patterns = Collections.singletonList(Pattern.compile("^tenant_a_.*$"));
-        ClusterIdentity id = new ClusterIdentity("t", new byte[32],
-                Collections.emptySet(), Collections.emptySet(), patterns,
+        ClusterIdentity id = new ClusterIdentity(
+                "t",
+                new byte[32],
+                Collections.emptySet(),
+                Collections.emptySet(),
+                patterns,
                 EnumSet.of(Permission.VGROUP_WRITE));
-        assertFalse(checker.check(id, "POST", "/naming/v1/addGroup",
-                "prod", "cluster-A", "tenant_b_group"));
-        assertTrue(checker.check(id, "POST", "/naming/v1/addGroup",
-                "prod", "cluster-A", "tenant_a_group"));
+        assertFalse(checker.check(id, "POST", "/naming/v1/addGroup", "prod", "cluster-A", "tenant_b_group"));
+        assertTrue(checker.check(id, "POST", "/naming/v1/addGroup", "prod", "cluster-A", "tenant_a_group"));
     }
 
     @Test
     void check_denies_unknown_route_by_default() {
         ClusterIdentity id = identity(EnumSet.allOf(Permission.class));
-        assertFalse(checker.check(id, "GET", "/random", null, null, null),
-                "unknown routes must fail closed");
+        assertFalse(checker.check(id, "GET", "/random", null, null, null), "unknown routes must fail closed");
     }
 
     private static ClusterIdentity identity(java.util.Set<Permission> perms) {
-        return new ClusterIdentity("t", new byte[32],
-                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
-                perms);
+        return new ClusterIdentity(
+                "t", new byte[32], Collections.emptySet(), Collections.emptySet(), Collections.emptyList(), perms);
     }
 }

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/PermissionCheckerTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/PermissionCheckerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PermissionCheckerTest {
+
+    private final PermissionChecker checker = new PermissionChecker();
+
+    @Test
+    void register_route_requires_register_permission() {
+        assertEquals(Permission.REGISTER,
+                checker.requiredPermission("POST", "/naming/v1/register"));
+        assertEquals(Permission.REGISTER,
+                checker.requiredPermission("POST", "/naming/v1/batchRegister"));
+    }
+
+    @Test
+    void vgroup_routes_require_vgroup_write() {
+        assertEquals(Permission.VGROUP_WRITE, checker.requiredPermission("POST", "/naming/v1/addGroup"));
+        assertEquals(Permission.VGROUP_WRITE, checker.requiredPermission("POST", "/naming/v1/changeGroup"));
+    }
+
+    @Test
+    void discovery_routes_require_console_read() {
+        assertEquals(Permission.CONSOLE_READ, checker.requiredPermission("GET", "/naming/v1/discovery"));
+        assertEquals(Permission.CONSOLE_READ, checker.requiredPermission("GET", "/naming/v1/namespace"));
+        assertEquals(Permission.CONSOLE_READ, checker.requiredPermission("POST", "/naming/v1/watch"));
+    }
+
+    @Test
+    void console_proxy_uses_method_to_pick_read_or_write() {
+        assertEquals(Permission.CONSOLE_READ,
+                checker.requiredPermission("GET", "/api/v1/console/globalSession/query"));
+        assertEquals(Permission.CONSOLE_WRITE,
+                checker.requiredPermission("POST", "/api/v1/console/globalSession/forceCommit"));
+    }
+
+    @Test
+    void unknown_route_returns_null() {
+        assertNull(checker.requiredPermission("GET", "/random/path"));
+    }
+
+    @Test
+    void check_denies_when_permission_missing() {
+        ClusterIdentity id = identity(EnumSet.of(Permission.CONSOLE_READ));
+        assertFalse(checker.check(id, "POST", "/naming/v1/register", "prod", "cluster-A", null));
+    }
+
+    @Test
+    void check_allows_when_all_conditions_met() {
+        ClusterIdentity id = identity(EnumSet.of(Permission.REGISTER));
+        assertTrue(checker.check(id, "POST", "/naming/v1/register", "prod", "cluster-A", null));
+    }
+
+    @Test
+    void check_denies_namespace_outside_allow_list() {
+        ClusterIdentity id = new ClusterIdentity("t", new byte[32],
+                new HashSet<>(Collections.singletonList("staging")),
+                Collections.emptySet(), Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER));
+        assertFalse(checker.check(id, "POST", "/naming/v1/register", "prod", "cluster-A", null));
+    }
+
+    @Test
+    void check_denies_cluster_outside_allow_list() {
+        ClusterIdentity id = new ClusterIdentity("t", new byte[32],
+                Collections.emptySet(),
+                new HashSet<>(Arrays.asList("cluster-A")),
+                Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER));
+        assertFalse(checker.check(id, "POST", "/naming/v1/register", "prod", "cluster-B", null));
+    }
+
+    @Test
+    void check_denies_vgroup_outside_pattern() {
+        List<Pattern> patterns = Collections.singletonList(Pattern.compile("^tenant_a_.*$"));
+        ClusterIdentity id = new ClusterIdentity("t", new byte[32],
+                Collections.emptySet(), Collections.emptySet(), patterns,
+                EnumSet.of(Permission.VGROUP_WRITE));
+        assertFalse(checker.check(id, "POST", "/naming/v1/addGroup",
+                "prod", "cluster-A", "tenant_b_group"));
+        assertTrue(checker.check(id, "POST", "/naming/v1/addGroup",
+                "prod", "cluster-A", "tenant_a_group"));
+    }
+
+    @Test
+    void check_denies_unknown_route_by_default() {
+        ClusterIdentity id = identity(EnumSet.allOf(Permission.class));
+        assertFalse(checker.check(id, "GET", "/random", null, null, null),
+                "unknown routes must fail closed");
+    }
+
+    private static ClusterIdentity identity(java.util.Set<Permission> perms) {
+        return new ClusterIdentity("t", new byte[32],
+                Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
+                perms);
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/SecretResolverTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/SecretResolverTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SecretResolverTest {
+
+    @Test
+    void resolves_env_reference() {
+        Map<String, String> env = new HashMap<>();
+        String encoded = Base64.getEncoder().encodeToString("hello-world".getBytes(StandardCharsets.UTF_8));
+        env.put("MY_KEY", encoded);
+        SecretResolver resolver = new SecretResolver(env::get);
+        assertArrayEquals("hello-world".getBytes(StandardCharsets.UTF_8), resolver.resolve("env:MY_KEY"));
+    }
+
+    @Test
+    void resolves_inline_base64() {
+        SecretResolver resolver = new SecretResolver(Collections.<String, String>emptyMap()::get);
+        String encoded = Base64.getEncoder().encodeToString("abc".getBytes(StandardCharsets.UTF_8));
+        assertArrayEquals("abc".getBytes(StandardCharsets.UTF_8), resolver.resolve("base64:" + encoded));
+    }
+
+    @Test
+    void resolves_plain_scheme() {
+        SecretResolver resolver = new SecretResolver(Collections.<String, String>emptyMap()::get);
+        assertArrayEquals("abc".getBytes(StandardCharsets.UTF_8), resolver.resolve("plain:abc"));
+    }
+
+    @Test
+    void rejects_unset_env_var() {
+        SecretResolver resolver = new SecretResolver(Collections.<String, String>emptyMap()::get);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve("env:NOT_SET"));
+    }
+
+    @Test
+    void rejects_blank_ref() {
+        SecretResolver resolver = new SecretResolver(Collections.<String, String>emptyMap()::get);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(null));
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(""));
+    }
+
+    @Test
+    void rejects_unknown_scheme() {
+        SecretResolver resolver = new SecretResolver(Collections.<String, String>emptyMap()::get);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve("kms:my-key"));
+    }
+
+    @Test
+    void rejects_invalid_base64() {
+        SecretResolver resolver = new SecretResolver(Collections.<String, String>emptyMap()::get);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve("base64:not!base64"));
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/SecretResolverTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/SecretResolverTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.seata.namingserver.security;
 
+import org.junit.jupiter.api.Test;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityAutoConfigurationTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityAutoConfigurationTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.seata.namingserver.security;
 
-import java.util.regex.Pattern;
-
 import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,8 +45,7 @@ class SecurityAutoConfigurationTest {
         // A literal '.' in a glob must not match arbitrary characters.
         Pattern p = SecurityAutoConfiguration.globToRegex("group.a");
         assertTrue(p.matcher("group.a").matches());
-        assertFalse(p.matcher("groupXa").matches(),
-                "'.' must be treated literally, not as regex any-char");
+        assertFalse(p.matcher("groupXa").matches(), "'.' must be treated literally, not as regex any-char");
     }
 
     @Test

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityAutoConfigurationTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityAutoConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SecurityAutoConfigurationTest {
+
+    @Test
+    void glob_to_regex_translates_star() {
+        Pattern p = SecurityAutoConfiguration.globToRegex("tenant_a_*");
+        assertTrue(p.matcher("tenant_a_group").matches());
+        assertTrue(p.matcher("tenant_a_").matches());
+        assertFalse(p.matcher("tenant_b_group").matches());
+    }
+
+    @Test
+    void glob_to_regex_translates_question_mark() {
+        Pattern p = SecurityAutoConfiguration.globToRegex("g?");
+        assertTrue(p.matcher("g1").matches());
+        assertFalse(p.matcher("g12").matches());
+    }
+
+    @Test
+    void glob_to_regex_escapes_regex_special_chars() {
+        // A literal '.' in a glob must not match arbitrary characters.
+        Pattern p = SecurityAutoConfiguration.globToRegex("group.a");
+        assertTrue(p.matcher("group.a").matches());
+        assertFalse(p.matcher("groupXa").matches(),
+                "'.' must be treated literally, not as regex any-char");
+    }
+
+    @Test
+    void glob_to_regex_supports_leading_wildcard() {
+        Pattern p = SecurityAutoConfiguration.globToRegex("*_prod");
+        assertTrue(p.matcher("a_prod").matches());
+        assertTrue(p.matcher("_prod").matches());
+        assertFalse(p.matcher("prod").matches());
+    }
+}

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityFilterTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityFilterTest.java
@@ -16,15 +16,6 @@
  */
 package org.apache.seata.namingserver.security;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -40,15 +31,24 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SecurityFilterTest {
 
     private static final byte[] SECRET = new byte[32];
+
     static {
         for (int i = 0; i < 32; i++) {
             SECRET[i] = (byte) (i + 1);
@@ -106,9 +106,13 @@ class SecurityFilterTest {
 
     @Test
     void valid_signed_request_passes_and_exposes_identity() throws Exception {
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+        MockHttpServletRequest req = signedRequest(
+                "POST",
+                "/naming/v1/register",
                 singletonQuery("namespace", "prod", "clusterName", "cluster-A"),
-                "{}".getBytes(), clock.get(), "n-1");
+                "{}".getBytes(),
+                clock.get(),
+                "n-1");
         MockHttpServletResponse resp = new MockHttpServletResponse();
         RecordingChain chain = new RecordingChain();
 
@@ -116,8 +120,8 @@ class SecurityFilterTest {
 
         assertTrue(chain.called.get(), "valid request must reach the chain");
         assertNotNull(chain.capturedRequest.get());
-        ClusterIdentity injected = (ClusterIdentity)
-                chain.capturedRequest.get().getAttribute(SecurityFilter.ATTR_IDENTITY);
+        ClusterIdentity injected =
+                (ClusterIdentity) chain.capturedRequest.get().getAttribute(SecurityFilter.ATTR_IDENTITY);
         assertNotNull(injected, "authenticated identity should be exposed on the request");
         assertEquals(CLUSTER_ID, injected.getId());
     }
@@ -135,8 +139,8 @@ class SecurityFilterTest {
 
         assertFalse(chain.called.get());
         assertEquals(401, resp.getStatus());
-        assertEquals(SecurityConstants.ErrorCode.MISSING_SIGNATURE.name(),
-                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+        assertEquals(
+                SecurityConstants.ErrorCode.MISSING_SIGNATURE.name(), resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
     }
 
     @Test
@@ -157,8 +161,13 @@ class SecurityFilterTest {
 
     @Test
     void unknown_cluster_id_is_rejected() throws Exception {
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "n-2");
+        MockHttpServletRequest req = signedRequest(
+                "POST",
+                "/naming/v1/register",
+                singletonQuery("namespace", "prod"),
+                "{}".getBytes(),
+                clock.get(),
+                "n-2");
         req.removeHeader(SecurityConstants.HEADER_CLUSTER_ID);
         req.addHeader(SecurityConstants.HEADER_CLUSTER_ID, "someone-else");
         MockHttpServletResponse resp = new MockHttpServletResponse();
@@ -168,7 +177,8 @@ class SecurityFilterTest {
 
         assertFalse(chain.called.get());
         assertEquals(401, resp.getStatus());
-        assertEquals(SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID.name(),
+        assertEquals(
+                SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID.name(),
                 resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
     }
 
@@ -177,23 +187,28 @@ class SecurityFilterTest {
     @Test
     void stale_timestamp_is_rejected() throws Exception {
         long stale = clock.get() - 10 * 60 * 1000L;
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{}".getBytes(), stale, "n-3");
+        MockHttpServletRequest req = signedRequest(
+                "POST", "/naming/v1/register", singletonQuery("namespace", "prod"), "{}".getBytes(), stale, "n-3");
         MockHttpServletResponse resp = new MockHttpServletResponse();
         RecordingChain chain = new RecordingChain();
 
         filter.doFilter(req, resp, chain);
 
         assertFalse(chain.called.get());
-        assertEquals(SecurityConstants.ErrorCode.TIMESTAMP_SKEW.name(),
-                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+        assertEquals(
+                SecurityConstants.ErrorCode.TIMESTAMP_SKEW.name(), resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
     }
 
     @Test
     void tampered_body_produces_bad_signature() throws Exception {
         // Sign with body-A, then swap in body-B without re-signing.
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{\"a\":1}".getBytes(), clock.get(), "n-4");
+        MockHttpServletRequest req = signedRequest(
+                "POST",
+                "/naming/v1/register",
+                singletonQuery("namespace", "prod"),
+                "{\"a\":1}".getBytes(),
+                clock.get(),
+                "n-4");
         req.setContent("{\"a\":2}".getBytes());
         MockHttpServletResponse resp = new MockHttpServletResponse();
         RecordingChain chain = new RecordingChain();
@@ -201,26 +216,36 @@ class SecurityFilterTest {
         filter.doFilter(req, resp, chain);
 
         assertFalse(chain.called.get());
-        assertEquals(SecurityConstants.ErrorCode.BAD_SIGNATURE.name(),
-                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+        assertEquals(
+                SecurityConstants.ErrorCode.BAD_SIGNATURE.name(), resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
     }
 
     @Test
     void replay_of_valid_request_is_rejected() throws Exception {
-        MockHttpServletRequest req1 = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "same-nonce");
+        MockHttpServletRequest req1 = signedRequest(
+                "POST",
+                "/naming/v1/register",
+                singletonQuery("namespace", "prod"),
+                "{}".getBytes(),
+                clock.get(),
+                "same-nonce");
         MockHttpServletResponse resp1 = new MockHttpServletResponse();
         filter.doFilter(req1, resp1, new RecordingChain());
         assertEquals(200, resp1.getStatus());
 
-        MockHttpServletRequest req2 = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "same-nonce");
+        MockHttpServletRequest req2 = signedRequest(
+                "POST",
+                "/naming/v1/register",
+                singletonQuery("namespace", "prod"),
+                "{}".getBytes(),
+                clock.get(),
+                "same-nonce");
         MockHttpServletResponse resp2 = new MockHttpServletResponse();
         RecordingChain chain2 = new RecordingChain();
         filter.doFilter(req2, resp2, chain2);
         assertFalse(chain2.called.get());
-        assertEquals(SecurityConstants.ErrorCode.REPLAY_DETECTED.name(),
-                resp2.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+        assertEquals(
+                SecurityConstants.ErrorCode.REPLAY_DETECTED.name(), resp2.getHeader(SecurityFilter.RESP_HEADER_ERROR));
     }
 
     // ------------------------------------------------------------------ authorization
@@ -229,11 +254,20 @@ class SecurityFilterTest {
     void caller_without_required_permission_is_forbidden() throws Exception {
         // Reload with an identity that only holds CONSOLE_READ.
         registry.reload(Collections.singletonList(new ClusterIdentity(
-                CLUSTER_ID, SECRET, Collections.emptySet(), Collections.emptySet(),
-                Collections.emptyList(), EnumSet.of(Permission.CONSOLE_READ))));
+                CLUSTER_ID,
+                SECRET,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptyList(),
+                EnumSet.of(Permission.CONSOLE_READ))));
 
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "n-5");
+        MockHttpServletRequest req = signedRequest(
+                "POST",
+                "/naming/v1/register",
+                singletonQuery("namespace", "prod"),
+                "{}".getBytes(),
+                clock.get(),
+                "n-5");
         MockHttpServletResponse resp = new MockHttpServletResponse();
         RecordingChain chain = new RecordingChain();
 
@@ -241,21 +275,26 @@ class SecurityFilterTest {
 
         assertFalse(chain.called.get());
         assertEquals(403, resp.getStatus());
-        assertEquals(SecurityConstants.ErrorCode.FORBIDDEN.name(),
-                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+        assertEquals(SecurityConstants.ErrorCode.FORBIDDEN.name(), resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
     }
 
     @Test
     void namespace_outside_allow_list_is_forbidden() throws Exception {
         registry.reload(Collections.singletonList(new ClusterIdentity(
-                CLUSTER_ID, SECRET,
+                CLUSTER_ID,
+                SECRET,
                 Collections.singleton("staging"),
                 Collections.emptySet(),
                 Collections.emptyList(),
                 EnumSet.of(Permission.REGISTER))));
 
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "n-6");
+        MockHttpServletRequest req = signedRequest(
+                "POST",
+                "/naming/v1/register",
+                singletonQuery("namespace", "prod"),
+                "{}".getBytes(),
+                clock.get(),
+                "n-6");
         MockHttpServletResponse resp = new MockHttpServletResponse();
         RecordingChain chain = new RecordingChain();
 
@@ -270,20 +309,21 @@ class SecurityFilterTest {
     @Test
     void body_is_readable_by_downstream_after_filter() throws Exception {
         byte[] body = "{\"a\":42}".getBytes();
-        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
-                singletonQuery("namespace", "prod"), body, clock.get(), "n-7");
+        MockHttpServletRequest req = signedRequest(
+                "POST", "/naming/v1/register", singletonQuery("namespace", "prod"), body, clock.get(), "n-7");
         MockHttpServletResponse resp = new MockHttpServletResponse();
 
         AtomicReference<String> downstreamBody = new AtomicReference<>();
         FilterChain chain = (r, rp) -> {
-            byte[] read = ((jakarta.servlet.http.HttpServletRequest) r).getInputStream().readAllBytes();
+            byte[] read = ((jakarta.servlet.http.HttpServletRequest) r)
+                    .getInputStream()
+                    .readAllBytes();
             downstreamBody.set(new String(read));
         };
 
         filter.doFilter(req, resp, chain);
 
-        assertEquals("{\"a\":42}", downstreamBody.get(),
-                "wrapper must let controllers still read the original body");
+        assertEquals("{\"a\":42}", downstreamBody.get(), "wrapper must let controllers still read the original body");
     }
 
     // ------------------------------------------------------------------ matches() helper
@@ -301,9 +341,8 @@ class SecurityFilterTest {
 
     // ------------------------------------------------------------------ helpers
 
-    private MockHttpServletRequest signedRequest(String method, String path,
-                                                 Map<String, String> query, byte[] body,
-                                                 long ts, String nonce) {
+    private MockHttpServletRequest signedRequest(
+            String method, String path, Map<String, String> query, byte[] body, long ts, String nonce) {
         MockHttpServletRequest req = new MockHttpServletRequest(method, path);
         req.setContent(body == null ? new byte[0] : body);
         for (Map.Entry<String, String> e : query.entrySet()) {
@@ -347,8 +386,7 @@ class SecurityFilterTest {
         final AtomicReference<ServletRequest> capturedRequest = new AtomicReference<>();
 
         @Override
-        public void doFilter(ServletRequest request, ServletResponse response)
-                throws IOException, ServletException {
+        public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
             called.set(true);
             capturedRequest.set(request);
         }

--- a/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityFilterTest.java
+++ b/namingserver/src/test/java/org/apache/seata/namingserver/security/SecurityFilterTest.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.namingserver.security;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.NonceCache;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SecurityFilterTest {
+
+    private static final byte[] SECRET = new byte[32];
+    static {
+        for (int i = 0; i < 32; i++) {
+            SECRET[i] = (byte) (i + 1);
+        }
+    }
+
+    private static final String CLUSTER_ID = "tenant-a";
+
+    private ClusterIdentityRegistry registry;
+    private SecurityProperties props;
+    private AtomicLong clock;
+    private NonceCache nonceCache;
+    private SignatureVerifier verifier;
+    private PermissionChecker permissionChecker;
+    private SecurityFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        registry = new ClusterIdentityRegistry();
+        registry.register(new ClusterIdentity(
+                CLUSTER_ID,
+                SECRET,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptyList(),
+                EnumSet.allOf(Permission.class)));
+
+        props = new SecurityProperties();
+        props.setEnabled(true);
+        props.setMode(SecurityProperties.Mode.ENFORCE);
+        props.setExcludePaths(Collections.singletonList("/naming/v1/health"));
+
+        clock = new AtomicLong(1_700_000_000_000L);
+        nonceCache = new NonceCache.InMemory(60_000L, clock::get);
+        verifier = new SignatureVerifier(nonceCache, 5 * 60 * 1000L, clock::get);
+        permissionChecker = new PermissionChecker();
+        filter = new SecurityFilter(props, registry, verifier, permissionChecker);
+    }
+
+    // ------------------------------------------------------------------ excluded paths
+
+    @Test
+    void health_endpoint_bypasses_filter() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/naming/v1/health");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called.get(), "excluded path should pass through");
+        assertEquals(200, resp.getStatus(), "no rejection expected");
+    }
+
+    // ------------------------------------------------------------------ happy path
+
+    @Test
+    void valid_signed_request_passes_and_exposes_identity() throws Exception {
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod", "clusterName", "cluster-A"),
+                "{}".getBytes(), clock.get(), "n-1");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called.get(), "valid request must reach the chain");
+        assertNotNull(chain.capturedRequest.get());
+        ClusterIdentity injected = (ClusterIdentity)
+                chain.capturedRequest.get().getAttribute(SecurityFilter.ATTR_IDENTITY);
+        assertNotNull(injected, "authenticated identity should be exposed on the request");
+        assertEquals(CLUSTER_ID, injected.getId());
+    }
+
+    // ------------------------------------------------------------------ missing headers
+
+    @Test
+    void missing_signature_headers_are_rejected_in_enforce_mode() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/naming/v1/register");
+        req.setContent("{}".getBytes());
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(401, resp.getStatus());
+        assertEquals(SecurityConstants.ErrorCode.MISSING_SIGNATURE.name(),
+                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void missing_headers_pass_through_in_warn_mode() throws Exception {
+        props.setMode(SecurityProperties.Mode.WARN);
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/naming/v1/register");
+        req.setContent("{}".getBytes());
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called.get(), "WARN mode must not block");
+        assertEquals(200, resp.getStatus());
+    }
+
+    // ------------------------------------------------------------------ unknown cluster
+
+    @Test
+    void unknown_cluster_id_is_rejected() throws Exception {
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "n-2");
+        req.removeHeader(SecurityConstants.HEADER_CLUSTER_ID);
+        req.addHeader(SecurityConstants.HEADER_CLUSTER_ID, "someone-else");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(401, resp.getStatus());
+        assertEquals(SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID.name(),
+                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+    }
+
+    // ------------------------------------------------------------------ bad timestamp / signature
+
+    @Test
+    void stale_timestamp_is_rejected() throws Exception {
+        long stale = clock.get() - 10 * 60 * 1000L;
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{}".getBytes(), stale, "n-3");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(SecurityConstants.ErrorCode.TIMESTAMP_SKEW.name(),
+                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void tampered_body_produces_bad_signature() throws Exception {
+        // Sign with body-A, then swap in body-B without re-signing.
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{\"a\":1}".getBytes(), clock.get(), "n-4");
+        req.setContent("{\"a\":2}".getBytes());
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(SecurityConstants.ErrorCode.BAD_SIGNATURE.name(),
+                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void replay_of_valid_request_is_rejected() throws Exception {
+        MockHttpServletRequest req1 = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "same-nonce");
+        MockHttpServletResponse resp1 = new MockHttpServletResponse();
+        filter.doFilter(req1, resp1, new RecordingChain());
+        assertEquals(200, resp1.getStatus());
+
+        MockHttpServletRequest req2 = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "same-nonce");
+        MockHttpServletResponse resp2 = new MockHttpServletResponse();
+        RecordingChain chain2 = new RecordingChain();
+        filter.doFilter(req2, resp2, chain2);
+        assertFalse(chain2.called.get());
+        assertEquals(SecurityConstants.ErrorCode.REPLAY_DETECTED.name(),
+                resp2.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+    }
+
+    // ------------------------------------------------------------------ authorization
+
+    @Test
+    void caller_without_required_permission_is_forbidden() throws Exception {
+        // Reload with an identity that only holds CONSOLE_READ.
+        registry.reload(Collections.singletonList(new ClusterIdentity(
+                CLUSTER_ID, SECRET, Collections.emptySet(), Collections.emptySet(),
+                Collections.emptyList(), EnumSet.of(Permission.CONSOLE_READ))));
+
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "n-5");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(403, resp.getStatus());
+        assertEquals(SecurityConstants.ErrorCode.FORBIDDEN.name(),
+                resp.getHeader(SecurityFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void namespace_outside_allow_list_is_forbidden() throws Exception {
+        registry.reload(Collections.singletonList(new ClusterIdentity(
+                CLUSTER_ID, SECRET,
+                Collections.singleton("staging"),
+                Collections.emptySet(),
+                Collections.emptyList(),
+                EnumSet.of(Permission.REGISTER))));
+
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), "{}".getBytes(), clock.get(), "n-6");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(403, resp.getStatus());
+    }
+
+    // ------------------------------------------------------------------ body readable downstream
+
+    @Test
+    void body_is_readable_by_downstream_after_filter() throws Exception {
+        byte[] body = "{\"a\":42}".getBytes();
+        MockHttpServletRequest req = signedRequest("POST", "/naming/v1/register",
+                singletonQuery("namespace", "prod"), body, clock.get(), "n-7");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+
+        AtomicReference<String> downstreamBody = new AtomicReference<>();
+        FilterChain chain = (r, rp) -> {
+            byte[] read = ((jakarta.servlet.http.HttpServletRequest) r).getInputStream().readAllBytes();
+            downstreamBody.set(new String(read));
+        };
+
+        filter.doFilter(req, resp, chain);
+
+        assertEquals("{\"a\":42}", downstreamBody.get(),
+                "wrapper must let controllers still read the original body");
+    }
+
+    // ------------------------------------------------------------------ matches() helper
+
+    @Test
+    void matches_helper_supports_exact_and_wildcard() {
+        assertTrue(SecurityFilter.matches("/naming/v1/health", "/naming/v1/health"));
+        assertFalse(SecurityFilter.matches("/naming/v1/health", "/naming/v1/health/x"));
+        assertTrue(SecurityFilter.matches("/naming/v1/**", "/naming/v1/health"));
+        assertTrue(SecurityFilter.matches("/naming/v1/**", "/naming/v1/anything/deep"));
+        assertFalse(SecurityFilter.matches("/naming/v1/**", "/other"));
+        assertFalse(SecurityFilter.matches(null, "/x"));
+        assertFalse(SecurityFilter.matches("/x", null));
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private MockHttpServletRequest signedRequest(String method, String path,
+                                                 Map<String, String> query, byte[] body,
+                                                 long ts, String nonce) {
+        MockHttpServletRequest req = new MockHttpServletRequest(method, path);
+        req.setContent(body == null ? new byte[0] : body);
+        for (Map.Entry<String, String> e : query.entrySet()) {
+            req.addParameter(e.getKey(), e.getValue());
+        }
+
+        CanonicalRequest canonical = CanonicalRequest.builder()
+                .method(method)
+                .path(path)
+                .queryParams(query)
+                .clusterId(CLUSTER_ID)
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(body)
+                .build();
+        String sig = HmacSigner.sign(canonical, SECRET);
+
+        req.addHeader(SecurityConstants.HEADER_CLUSTER_ID, CLUSTER_ID);
+        req.addHeader(SecurityConstants.HEADER_TIMESTAMP, String.valueOf(ts));
+        req.addHeader(SecurityConstants.HEADER_NONCE, nonce);
+        req.addHeader(SecurityConstants.HEADER_SIGN_ALG, SignatureAlgorithm.HMAC_SHA256.wireName());
+        req.addHeader(SecurityConstants.HEADER_SIGNATURE, sig);
+        return req;
+    }
+
+    private static Map<String, String> singletonQuery(String... kv) {
+        if ((kv.length & 1) != 0) {
+            throw new IllegalArgumentException("kv must be pairs");
+        }
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            map.put(kv[i], kv[i + 1]);
+        }
+        return map;
+    }
+
+    /** Captures whether the chain was invoked and the request that was passed. */
+    private static final class RecordingChain implements FilterChain {
+        final AtomicBoolean called = new AtomicBoolean();
+        final AtomicReference<ServletRequest> capturedRequest = new AtomicReference<>();
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response)
+                throws IOException, ServletException {
+            called.set(true);
+            capturedRequest.set(request);
+        }
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -135,6 +135,12 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
+        <!-- Jakarta Servlet API required by the security auth filter, aligned with Spring Boot 4.x. -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>seata-core</artifactId>

--- a/server/src/main/java/org/apache/seata/server/security/AllowedCaller.java
+++ b/server/src/main/java/org/apache/seata/server/security/AllowedCaller.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A NamingServer identity that TC is willing to accept inbound calls from.
+ *
+ * <p>Note this is the mirror of {@code ClusterIdentity} on the NamingServer side, but with a
+ * different permission vocabulary. TC doesn't care about namespaces / cluster allow-lists
+ * (that's NamingServer's concern) — TC only cares "do you have the right to call me for X?".
+ */
+public final class AllowedCaller {
+
+    private final String id;
+
+    private final byte[] secret;
+
+    private final Set<CallerPermission> permissions;
+
+    public AllowedCaller(String id, byte[] secret, Set<CallerPermission> permissions) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.secret = Objects.requireNonNull(secret, "secret").clone();
+        this.permissions = permissions == null
+                ? EnumSet.noneOf(CallerPermission.class)
+                : Collections.unmodifiableSet(EnumSet.copyOf(permissions));
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    /** Defensive copy — key material never leaves this object. */
+    public byte[] getSecret() {
+        return secret.clone();
+    }
+
+    public Set<CallerPermission> getPermissions() {
+        return permissions;
+    }
+
+    public boolean hasPermission(CallerPermission permission) {
+        return permissions.contains(permission);
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/security/AllowedCallerRegistry.java
+++ b/server/src/main/java/org/apache/seata/server/security/AllowedCallerRegistry.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory table of NamingServer identities that TC trusts. Supports online replacement so
+ * operators can hot-swap secrets during rotation without a restart.
+ */
+public final class AllowedCallerRegistry {
+
+    private final ConcurrentHashMap<String, AllowedCaller> byId = new ConcurrentHashMap<>();
+
+    public void register(AllowedCaller caller) {
+        byId.put(caller.getId(), caller);
+    }
+
+    /**
+     * Swap the whole set. During a rotation the new secret and the old secret can coexist
+     * — the caller passes both entries in and this method installs them atomically.
+     */
+    public void reload(Collection<AllowedCaller> callers) {
+        byId.clear();
+        for (AllowedCaller c : callers) {
+            byId.put(c.getId(), c);
+        }
+    }
+
+    public Optional<AllowedCaller> find(String id) {
+        return id == null ? Optional.empty() : Optional.ofNullable(byId.get(id));
+    }
+
+    public int size() {
+        return byId.size();
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/security/AllowedCallerRegistry.java
+++ b/server/src/main/java/org/apache/seata/server/security/AllowedCallerRegistry.java
@@ -17,19 +17,34 @@
 package org.apache.seata.server.security;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * In-memory table of NamingServer identities that TC trusts. Supports online replacement so
  * operators can hot-swap secrets during rotation without a restart.
+ *
+ * <p>The whole table is kept as an immutable {@link Map} behind an {@link AtomicReference}.
+ * Register and reload publish a fresh snapshot via {@code compareAndSet} / {@code set}, so
+ * concurrent {@link #find(String)} calls always observe either the old table in full or the
+ * new table in full — never a transient empty/partial state during rotation.
  */
 public final class AllowedCallerRegistry {
 
-    private final ConcurrentHashMap<String, AllowedCaller> byId = new ConcurrentHashMap<>();
+    private final AtomicReference<Map<String, AllowedCaller>> ref = new AtomicReference<>(Collections.emptyMap());
 
     public void register(AllowedCaller caller) {
-        byId.put(caller.getId(), caller);
+        while (true) {
+            Map<String, AllowedCaller> current = ref.get();
+            Map<String, AllowedCaller> next = new HashMap<>(current);
+            next.put(caller.getId(), caller);
+            if (ref.compareAndSet(current, Collections.unmodifiableMap(next))) {
+                return;
+            }
+        }
     }
 
     /**
@@ -37,17 +52,18 @@ public final class AllowedCallerRegistry {
      * — the caller passes both entries in and this method installs them atomically.
      */
     public void reload(Collection<AllowedCaller> callers) {
-        byId.clear();
+        Map<String, AllowedCaller> next = new HashMap<>();
         for (AllowedCaller c : callers) {
-            byId.put(c.getId(), c);
+            next.put(c.getId(), c);
         }
+        ref.set(Collections.unmodifiableMap(next));
     }
 
     public Optional<AllowedCaller> find(String id) {
-        return id == null ? Optional.empty() : Optional.ofNullable(byId.get(id));
+        return id == null ? Optional.empty() : Optional.ofNullable(ref.get().get(id));
     }
 
     public int size() {
-        return byId.size();
+        return ref.get().size();
     }
 }

--- a/server/src/main/java/org/apache/seata/server/security/CallerPermission.java
+++ b/server/src/main/java/org/apache/seata/server/security/CallerPermission.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+/**
+ * Permissions accepted by the Seata Server inbound auth filter. Smaller vocabulary than the
+ * NamingServer side because TC only ever receives three <em>categories</em> of inbound calls
+ * from NamingServer: vGroup writes, console proxy pass-through, and MCP integration calls.
+ */
+public enum CallerPermission {
+    /** May call {@code /vgroup/v1/addVGroup} and {@code /vgroup/v1/removeVGroup}. */
+    VGROUP_WRITE,
+    /** May call any {@code /api/*} console-facing endpoint (proxied by NamingServer). */
+    CONSOLE_PROXY,
+    /** Reserved for MCP-driven admin integrations. */
+    MCP
+}

--- a/server/src/main/java/org/apache/seata/server/security/RouteAuthorizer.java
+++ b/server/src/main/java/org/apache/seata/server/security/RouteAuthorizer.java
@@ -17,9 +17,9 @@
 package org.apache.seata.server.security;
 
 /**
- * Maps TC's inbound HTTP routes to a required {@link CallerPermission}. Deny-by-default:
- * any path that isn't matched here returns {@code null} and the filter treats that as
- * forbidden.
+ * Maps TC's inbound HTTP routes to a required {@link CallerPermission}. Any path that
+ * isn't matched here returns {@code null}, which the filter treats as "not part of the
+ * NamingServer control-plane surface" and passes through untouched.
  *
  * <p>Kept intentionally small — only paths that could conceivably be reached by
  * NamingServer or by an operator's console proxy need protection here. Netty ports and

--- a/server/src/main/java/org/apache/seata/server/security/RouteAuthorizer.java
+++ b/server/src/main/java/org/apache/seata/server/security/RouteAuthorizer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+/**
+ * Maps TC's inbound HTTP routes to a required {@link CallerPermission}. Deny-by-default:
+ * any path that isn't matched here returns {@code null} and the filter treats that as
+ * forbidden.
+ *
+ * <p>Kept intentionally small — only paths that could conceivably be reached by
+ * NamingServer or by an operator's console proxy need protection here. Netty ports and
+ * anything auto-served by Spring Boot infrastructure (actuator, static files) are
+ * expected to be either excluded up-front or protected by other means.
+ */
+public final class RouteAuthorizer {
+
+    /** @return required permission or {@code null} if the route is not recognised */
+    public CallerPermission requiredPermission(String method, String path) {
+        if (path == null || method == null) {
+            return null;
+        }
+        // vGroup mapping write is the highest-privilege pathway from NamingServer to TC.
+        if ("GET".equals(method)
+                && (path.endsWith("/vgroup/v1/addVGroup") || path.endsWith("/vgroup/v1/removeVGroup"))) {
+            return CallerPermission.VGROUP_WRITE;
+        }
+        // Console proxy — everything under /api/*/console/*
+        if (path.contains("/console/")) {
+            return CallerPermission.CONSOLE_PROXY;
+        }
+        // MCP integration endpoints (if any) can be added here.
+        return null;
+    }
+
+    /** Convenience: returns true iff the caller may serve the request. */
+    public boolean isAuthorized(AllowedCaller caller, String method, String path) {
+        CallerPermission required = requiredPermission(method, path);
+        if (required == null) {
+            return false;
+        }
+        return caller.hasPermission(required);
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/security/SeataServerAuthFilter.java
+++ b/server/src/main/java/org/apache/seata/server/security/SeataServerAuthFilter.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.apache.seata.common.security.VerificationResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * TC-side inbound filter that authenticates requests coming from NamingServer.
+ *
+ * <p>Structure mirrors {@code namingserver.security.SecurityFilter} — same pipeline:
+ * exclude → parse headers → identity lookup → buffer body → verify signature → authorise route.
+ * The two live in separate modules because they have different dependency footprints, but a
+ * mismatch in behaviour will show up in the shared integration tests.
+ *
+ * <p>The filter registers at {@link org.springframework.core.Ordered#HIGHEST_PRECEDENCE} in
+ * the auto-configuration so it runs before any of the existing TC filters
+ * (e.g. {@code XSSHttpRequestFilter}, {@code RaftRequestFilter}).
+ */
+public class SeataServerAuthFilter implements Filter {
+
+    /** Exposes the authenticated caller on the request attributes. */
+    public static final String ATTR_CALLER = "seata.server.security.caller";
+
+    /** Machine-readable error code on the response, mirroring the NamingServer side. */
+    public static final String RESP_HEADER_ERROR = "X-Seata-Auth-Error";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeataServerAuthFilter.class);
+
+    private final ServerSecurityProperties properties;
+
+    private final AllowedCallerRegistry registry;
+
+    private final SignatureVerifier verifier;
+
+    private final RouteAuthorizer routeAuthorizer;
+
+    public SeataServerAuthFilter(
+            ServerSecurityProperties properties,
+            AllowedCallerRegistry registry,
+            SignatureVerifier verifier,
+            RouteAuthorizer routeAuthorizer) {
+        this.properties = Objects.requireNonNull(properties, "properties");
+        this.registry = Objects.requireNonNull(registry, "registry");
+        this.verifier = Objects.requireNonNull(verifier, "verifier");
+        this.routeAuthorizer = Objects.requireNonNull(routeAuthorizer, "routeAuthorizer");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        HttpServletRequest httpReq = (HttpServletRequest) request;
+        HttpServletResponse httpResp = (HttpServletResponse) response;
+
+        String path = httpReq.getRequestURI();
+        String method = httpReq.getMethod();
+
+        // 1. Route filter: only intercept paths TC deems sensitive. If the route is not
+        //    on the protected list, pass through untouched — TC has other filters for the
+        //    Netty side, static assets, etc.
+        CallerPermission required = routeAuthorizer.requiredPermission(method, path);
+        if (required == null || isExcluded(path)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 2. Extract security headers.
+        String clusterId = httpReq.getHeader(SecurityConstants.HEADER_CLUSTER_ID);
+        String tsStr = httpReq.getHeader(SecurityConstants.HEADER_TIMESTAMP);
+        String nonce = httpReq.getHeader(SecurityConstants.HEADER_NONCE);
+        String algName = httpReq.getHeader(SecurityConstants.HEADER_SIGN_ALG);
+        String sig = httpReq.getHeader(SecurityConstants.HEADER_SIGNATURE);
+
+        if (isBlank(clusterId) || isBlank(tsStr) || isBlank(nonce) || isBlank(sig)) {
+            reject(
+                    httpReq,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.MISSING_SIGNATURE,
+                    "one or more required security headers are missing",
+                    null);
+            return;
+        }
+
+        long ts;
+        try {
+            ts = Long.parseLong(tsStr);
+        } catch (NumberFormatException e) {
+            reject(
+                    httpReq,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.BAD_REQUEST,
+                    "timestamp header is not a valid long",
+                    null);
+            return;
+        }
+        SignatureAlgorithm alg;
+        try {
+            alg = algName == null ? SignatureAlgorithm.HMAC_SHA256 : SignatureAlgorithm.fromWireName(algName);
+        } catch (IllegalArgumentException e) {
+            reject(httpReq, httpResp, chain, SecurityConstants.ErrorCode.UNSUPPORTED_ALG, e.getMessage(), null);
+            return;
+        }
+
+        // 3. Identity lookup.
+        Optional<AllowedCaller> callerOpt = registry.find(clusterId);
+        if (!callerOpt.isPresent()) {
+            reject(
+                    httpReq,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID,
+                    "cluster-id not in allowed-callers: " + clusterId,
+                    null);
+            return;
+        }
+        AllowedCaller caller = callerOpt.get();
+
+        // 4. Buffer body — needed so the verifier + controller can both read it.
+        CachedBodyRequestWrapper wrapper = new CachedBodyRequestWrapper(httpReq);
+
+        // 5. Verify signature.
+        CanonicalRequest canonical = CanonicalRequest.builder()
+                .method(method)
+                .path(path)
+                .queryParams(collectQuery(httpReq))
+                .clusterId(clusterId)
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(alg)
+                .body(wrapper.getCachedBody())
+                .build();
+
+        VerificationResult verdict = verifier.verify(canonical, caller.getSecret(), sig);
+        if (!verdict.isSuccess()) {
+            reject(wrapper, httpResp, chain, verdict.getErrorCode(), verdict.getMessage(), caller);
+            return;
+        }
+
+        // 6. Route-level permission — signature verified, but does the caller hold the right?
+        if (!caller.hasPermission(required)) {
+            reject(
+                    wrapper,
+                    httpResp,
+                    chain,
+                    SecurityConstants.ErrorCode.FORBIDDEN,
+                    "caller " + clusterId + " lacks permission " + required,
+                    caller);
+            return;
+        }
+
+        // 7. Success.
+        wrapper.setAttribute(ATTR_CALLER, caller);
+        chain.doFilter(wrapper, httpResp);
+    }
+
+    private boolean isExcluded(String path) {
+        List<String> excluded = properties.getExcludePaths();
+        if (excluded == null || excluded.isEmpty()) {
+            return false;
+        }
+        for (String pattern : excluded) {
+            if (matches(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean matches(String pattern, String path) {
+        if (pattern == null || path == null) {
+            return false;
+        }
+        if (pattern.endsWith("/**")) {
+            return path.startsWith(pattern.substring(0, pattern.length() - 3));
+        }
+        return pattern.equals(path);
+    }
+
+    private void reject(
+            HttpServletRequest req,
+            HttpServletResponse resp,
+            FilterChain chain,
+            SecurityConstants.ErrorCode code,
+            String message,
+            AllowedCaller caller)
+            throws IOException, ServletException {
+        ServerSecurityProperties.Mode mode = properties.getMode();
+        if (mode == ServerSecurityProperties.Mode.WARN) {
+            LOGGER.warn(
+                    "[seata-server][security][WARN] {} {} rejected code={} msg={} caller={}",
+                    req.getMethod(),
+                    req.getRequestURI(),
+                    code,
+                    message,
+                    caller == null ? "unknown" : caller.getId());
+            if (caller != null) {
+                req.setAttribute(ATTR_CALLER, caller);
+            }
+            chain.doFilter(req, resp);
+            return;
+        }
+        int status = (code == SecurityConstants.ErrorCode.FORBIDDEN)
+                ? HttpServletResponse.SC_FORBIDDEN
+                : HttpServletResponse.SC_UNAUTHORIZED;
+        LOGGER.warn(
+                "[seata-server][security][ENFORCE] {} {} status={} code={} msg={} caller={}",
+                req.getMethod(),
+                req.getRequestURI(),
+                status,
+                code,
+                message,
+                caller == null ? "unknown" : caller.getId());
+        resp.setHeader(RESP_HEADER_ERROR, code.name());
+        resp.setContentType("application/json;charset=UTF-8");
+        resp.setStatus(status);
+        resp.getWriter().write("{\"code\":\"" + code.name() + "\",\"message\":\"" + escapeJson(message) + "\"}");
+    }
+
+    private static Map<String, String> collectQuery(HttpServletRequest req) {
+        Map<String, String> params = new LinkedHashMap<>();
+        Enumeration<String> names = req.getParameterNames();
+        while (names.hasMoreElements()) {
+            String name = names.nextElement();
+            params.put(name, req.getParameter(name));
+        }
+        return params;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isEmpty();
+    }
+
+    private static String escapeJson(String v) {
+        if (v == null) {
+            return "";
+        }
+        return v.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    /** Same wrapper idea as on the NamingServer side. See that class for design notes. */
+    static final class CachedBodyRequestWrapper extends HttpServletRequestWrapper {
+        private final byte[] body;
+
+        CachedBodyRequestWrapper(HttpServletRequest request) throws IOException {
+            super(request);
+            this.body = readAll(request);
+        }
+
+        byte[] getCachedBody() {
+            return body;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            ByteArrayInputStream stream = new ByteArrayInputStream(body);
+            return new ServletInputStream() {
+                @Override
+                public boolean isFinished() {
+                    return stream.available() == 0;
+                }
+
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setReadListener(ReadListener l) {
+                    /* no-op */
+                }
+
+                @Override
+                public int read() {
+                    return stream.read();
+                }
+            };
+        }
+
+        @Override
+        public BufferedReader getReader() {
+            return new BufferedReader(new InputStreamReader(getInputStream(), StandardCharsets.UTF_8));
+        }
+
+        private static byte[] readAll(HttpServletRequest request) throws IOException {
+            try (ServletInputStream in = request.getInputStream()) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buf = new byte[4096];
+                int n;
+                while ((n = in.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
+                return out.toByteArray();
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/security/SeataServerAuthFilter.java
+++ b/server/src/main/java/org/apache/seata/server/security/SeataServerAuthFilter.java
@@ -219,7 +219,12 @@ public class SeataServerAuthFilter implements Filter {
             return false;
         }
         if (pattern.endsWith("/**")) {
-            return path.startsWith(pattern.substring(0, pattern.length() - 3));
+            // Trim the trailing "/**" and require an exact match of the parent segment
+            // or a proper descendant. Using a naked startsWith(prefix) would incorrectly
+            // match sibling paths that merely share the same prefix string
+            // (e.g. "/actuator/**" would otherwise match "/actuatorX").
+            String prefix = pattern.substring(0, pattern.length() - 3);
+            return path.equals(prefix) || path.startsWith(prefix + "/");
         }
         return pattern.equals(path);
     }
@@ -282,7 +287,40 @@ public class SeataServerAuthFilter implements Filter {
         if (v == null) {
             return "";
         }
-        return v.replace("\\", "\\\\").replace("\"", "\\\"");
+        StringBuilder sb = new StringBuilder(v.length() + 8);
+        for (int i = 0; i < v.length(); i++) {
+            char c = v.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
     }
 
     /** Same wrapper idea as on the NamingServer side. See that class for design notes. */

--- a/server/src/main/java/org/apache/seata/server/security/ServerSecretResolver.java
+++ b/server/src/main/java/org/apache/seata/server/security/ServerSecretResolver.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Same three-scheme resolver as {@code namingserver.security.SecretResolver}, duplicated here
+ * so the two modules do not need a shared runtime dependency beyond {@code seata-common}.
+ * If the two files ever drift, the tests in each module will catch it.
+ */
+public final class ServerSecretResolver {
+
+    private static final String ENV_PREFIX = "env:";
+    private static final String BASE64_PREFIX = "base64:";
+    private static final String PLAIN_PREFIX = "plain:";
+
+    private final Function<String, String> envLookup;
+
+    public ServerSecretResolver() {
+        this(System::getenv);
+    }
+
+    public ServerSecretResolver(Function<String, String> envLookup) {
+        this.envLookup = Objects.requireNonNull(envLookup, "envLookup");
+    }
+
+    public byte[] resolve(String secretRef) {
+        if (secretRef == null || secretRef.isEmpty()) {
+            throw new IllegalArgumentException("secretRef is blank");
+        }
+        if (secretRef.startsWith(ENV_PREFIX)) {
+            String envName = secretRef.substring(ENV_PREFIX.length());
+            String value = envLookup.apply(envName);
+            if (value == null || value.isEmpty()) {
+                throw new IllegalArgumentException("env var not set or empty: " + envName);
+            }
+            return decodeBase64(value);
+        }
+        if (secretRef.startsWith(BASE64_PREFIX)) {
+            return decodeBase64(secretRef.substring(BASE64_PREFIX.length()));
+        }
+        if (secretRef.startsWith(PLAIN_PREFIX)) {
+            return secretRef.substring(PLAIN_PREFIX.length()).getBytes(StandardCharsets.UTF_8);
+        }
+        throw new IllegalArgumentException("unsupported secretRef scheme: " + secretRef);
+    }
+
+    private static byte[] decodeBase64(String v) {
+        try {
+            return Base64.getDecoder().decode(v);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("invalid base64 in secretRef", e);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/security/ServerSecurityAutoConfiguration.java
+++ b/server/src/main/java/org/apache/seata/server/security/ServerSecurityAutoConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import jakarta.servlet.Filter;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.NonceCache;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Loads the TC-side inbound auth pipeline when
+ * {@code seata.registry.seata.security.inbound.enabled=true}. Kept as a separate
+ * {@code @Configuration} so operators can strip it out entirely by leaving the property unset.
+ */
+@Configuration
+@EnableConfigurationProperties(ServerSecurityProperties.class)
+@ConditionalOnProperty(prefix = "seata.registry.seata.security.inbound", name = "enabled", havingValue = "true")
+public class ServerSecurityAutoConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServerSecurityAutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ServerSecretResolver serverSecretResolver() {
+        return new ServerSecretResolver();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AllowedCallerRegistry allowedCallerRegistry(ServerSecurityProperties props, ServerSecretResolver resolver) {
+        AllowedCallerRegistry registry = new AllowedCallerRegistry();
+        List<AllowedCaller> loaded = new ArrayList<>();
+        for (ServerSecurityProperties.CallerConfig cfg : props.getAllowedCallers()) {
+            byte[] secret = resolver.resolve(cfg.getSecretRef());
+            if (secret.length < HmacSigner.MIN_KEY_LENGTH_BYTES) {
+                throw new IllegalStateException("secret for caller '" + cfg.getId() + "' shorter than "
+                        + HmacSigner.MIN_KEY_LENGTH_BYTES + " bytes");
+            }
+            loaded.add(new AllowedCaller(
+                    cfg.getId(),
+                    secret,
+                    cfg.getPermissions() == null
+                            ? EnumSet.noneOf(CallerPermission.class)
+                            : EnumSet.copyOf(cfg.getPermissions())));
+        }
+        registry.reload(loaded);
+        LOGGER.info("[seata-server][security] loaded {} allowed caller(s)", registry.size());
+        return registry;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public NonceCache serverNonceCache(ServerSecurityProperties props) {
+        return new NonceCache.InMemory(
+                TimeUnit.MINUTES.toMillis(props.getNonceCacheMinutes()), System::currentTimeMillis);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SignatureVerifier serverSignatureVerifier(NonceCache serverNonceCache, ServerSecurityProperties props) {
+        return new SignatureVerifier(
+                serverNonceCache, TimeUnit.SECONDS.toMillis(props.getReplayWindowSeconds()), System::currentTimeMillis);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public RouteAuthorizer routeAuthorizer() {
+        return new RouteAuthorizer();
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> seataServerAuthFilter(
+            ServerSecurityProperties props,
+            AllowedCallerRegistry registry,
+            SignatureVerifier serverSignatureVerifier,
+            RouteAuthorizer authorizer) {
+        SeataServerAuthFilter filter = new SeataServerAuthFilter(props, registry, serverSignatureVerifier, authorizer);
+        FilterRegistrationBean<Filter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(filter);
+        // Only the paths TC actually needs to protect — /vgroup/v1/*, /api/*/console/*.
+        // Broader match is fine because the filter itself pass-throughs unknown routes.
+        reg.addUrlPatterns("/vgroup/v1/*", "/api/*");
+        reg.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return reg;
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/security/ServerSecurityProperties.java
+++ b/server/src/main/java/org/apache/seata/server/security/ServerSecurityProperties.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import org.apache.seata.common.security.SecurityConstants;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for TC's inbound auth pipeline. Bound to
+ * {@code seata.registry.seata.security.inbound.*} to keep the namespace close to the
+ * existing {@code seata.registry.seata.*} settings that TC already uses.
+ *
+ * <p>Outbound (TC → NamingServer) auth continues to be handled by the existing
+ * {@code NamingserverRegistryServiceImpl} — this class only wires the inbound side.
+ */
+@ConfigurationProperties(prefix = "seata.registry.seata.security.inbound")
+public class ServerSecurityProperties {
+
+    private boolean enabled = false;
+
+    private Mode mode = Mode.ENFORCE;
+
+    private long replayWindowSeconds = SecurityConstants.DEFAULT_REPLAY_WINDOW_SECONDS;
+
+    private long nonceCacheMinutes = SecurityConstants.DEFAULT_NONCE_CACHE_MINUTES;
+
+    /** Paths the filter must not touch (e.g. actuator health). Ant-style, supports trailing {@code /**}. */
+    private List<String> excludePaths = new ArrayList<>();
+
+    /** Accepted NamingServer identities. Multiple entries let operators rotate secrets safely. */
+    private List<CallerConfig> allowedCallers = new ArrayList<>();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
+    }
+
+    public long getReplayWindowSeconds() {
+        return replayWindowSeconds;
+    }
+
+    public void setReplayWindowSeconds(long s) {
+        this.replayWindowSeconds = s;
+    }
+
+    public long getNonceCacheMinutes() {
+        return nonceCacheMinutes;
+    }
+
+    public void setNonceCacheMinutes(long m) {
+        this.nonceCacheMinutes = m;
+    }
+
+    public List<String> getExcludePaths() {
+        return excludePaths;
+    }
+
+    public void setExcludePaths(List<String> p) {
+        this.excludePaths = p;
+    }
+
+    public List<CallerConfig> getAllowedCallers() {
+        return allowedCallers;
+    }
+
+    public void setAllowedCallers(List<CallerConfig> c) {
+        this.allowedCallers = c;
+    }
+
+    public enum Mode {
+        /** Auth pipeline runs but only logs violations. */
+        WARN,
+        /** Auth pipeline runs and rejects violations with 401/403. */
+        ENFORCE
+    }
+
+    public static class CallerConfig {
+        private String id;
+        private String secretRef;
+        private List<CallerPermission> permissions = new ArrayList<>();
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getSecretRef() {
+            return secretRef;
+        }
+
+        public void setSecretRef(String secretRef) {
+            this.secretRef = secretRef;
+        }
+
+        public List<CallerPermission> getPermissions() {
+            return permissions;
+        }
+
+        public void setPermissions(List<CallerPermission> p) {
+            this.permissions = p;
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/security/AllowedCallerRegistryTest.java
+++ b/server/src/test/java/org/apache/seata/server/security/AllowedCallerRegistryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AllowedCallerRegistryTest {
+
+    @Test
+    void find_returns_registered_caller() {
+        AllowedCallerRegistry reg = new AllowedCallerRegistry();
+        reg.register(caller("naming-01"));
+        assertTrue(reg.find("naming-01").isPresent());
+        assertFalse(reg.find("unknown").isPresent());
+        assertFalse(reg.find(null).isPresent());
+    }
+
+    @Test
+    void reload_supports_key_rotation_with_two_active_secrets() {
+        AllowedCallerRegistry reg = new AllowedCallerRegistry();
+        AllowedCaller oldSecret = caller("naming-01");
+        reg.register(oldSecret);
+        // Rotation: install both entries so requests signed with either succeed.
+        reg.reload(Arrays.asList(oldSecret, caller("naming-01-new")));
+        assertEquals(2, reg.size());
+    }
+
+    @Test
+    void secret_is_defensively_copied_by_caller() {
+        byte[] key = new byte[32];
+        AllowedCaller caller = new AllowedCaller("x", key, EnumSet.noneOf(CallerPermission.class));
+        assertNotSame(caller.getSecret(), caller.getSecret());
+    }
+
+    @Test
+    void permissions_default_to_empty_when_null() {
+        AllowedCaller c = new AllowedCaller("x", new byte[32], null);
+        assertTrue(c.getPermissions().isEmpty());
+        assertFalse(c.hasPermission(CallerPermission.VGROUP_WRITE));
+    }
+
+    private static AllowedCaller caller(String id) {
+        return new AllowedCaller(id, new byte[32], Collections.singleton(CallerPermission.VGROUP_WRITE));
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/security/InteropIntegrationTest.java
+++ b/server/src/test/java/org/apache/seata/server/security/InteropIntegrationTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.NonceCache;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.apache.seata.common.security.VerificationResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end proof that the code an operator would deploy on the two sides actually
+ * interoperates. The NamingServer side uses raw HmacSigner (mimicking what OutboundSigner
+ * emits) and the TC side runs the full verifier pipeline.
+ *
+ * <p>Guards against silent drift between the two sides — if either party changes the wire
+ * format, this test breaks even when the individual unit tests still pass.
+ */
+class InteropIntegrationTest {
+
+    private static final byte[] SHARED_SECRET = new byte[32];
+
+    static {
+        for (int i = 0; i < 32; i++) {
+            SHARED_SECRET[i] = (byte) (0x30 + i);
+        }
+    }
+
+    @Test
+    void naming_server_add_vgroup_call_verifies_on_tc() {
+        // 1) NamingServer side: build the request as NamingManager.executeControlRequest would
+        //    (GET /vgroup/v1/addVGroup?vGroup=g1&unit=u1, empty body).
+        String method = "GET";
+        String path = "/vgroup/v1/addVGroup";
+        Map<String, String> query = new HashMap<>();
+        query.put("vGroup", "g1");
+        query.put("unit", "u1");
+        long ts = 5_000L;
+        String nonce = "abc-123";
+
+        CanonicalRequest namingSide = CanonicalRequest.builder()
+                .method(method)
+                .path(path)
+                .queryParams(query)
+                .clusterId("naming-server-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(new byte[0])
+                .build();
+        String signature = HmacSigner.sign(namingSide, SHARED_SECRET);
+
+        // 2) Wire: {clusterId, ts, nonce, alg, signature} + body travel over HTTP.
+        //         The TC receives them as headers/query/body and rebuilds a canonical.
+
+        // 3) TC side: rebuild the canonical from the "received" headers/query/body and verify.
+        CanonicalRequest tcSide = CanonicalRequest.builder()
+                .method(method)
+                .path(path)
+                .queryParams(query)
+                .clusterId("naming-server-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(new byte[0])
+                .build();
+
+        NonceCache cache = new NonceCache.InMemory(60_000L, () -> ts);
+        SignatureVerifier verifier = new SignatureVerifier(cache, 300_000L, () -> ts);
+        AllowedCaller caller =
+                new AllowedCaller("naming-server-01", SHARED_SECRET, EnumSet.of(CallerPermission.VGROUP_WRITE));
+        RouteAuthorizer routes = new RouteAuthorizer();
+
+        VerificationResult verdict = verifier.verify(tcSide, caller.getSecret(), signature);
+        assertTrue(verdict.isSuccess(), "handshake must succeed end-to-end");
+
+        assertTrue(routes.isAuthorized(caller, method, path), "signature ok + right permission → allowed");
+    }
+
+    @Test
+    void wrong_secret_on_tc_side_produces_bad_signature() {
+        Map<String, String> query = new HashMap<>();
+        query.put("vGroup", "g1");
+        String nonce = "x-1";
+        long ts = 6_000L;
+        CanonicalRequest signed = CanonicalRequest.builder()
+                .method("GET")
+                .path("/vgroup/v1/addVGroup")
+                .queryParams(query)
+                .clusterId("naming-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(new byte[0])
+                .build();
+        String signature = HmacSigner.sign(signed, SHARED_SECRET);
+
+        // TC has a different secret for the same cluster-id (e.g. rotation gone wrong).
+        byte[] wrongSecret = SHARED_SECRET.clone();
+        wrongSecret[15] ^= 0x55;
+
+        NonceCache cache = new NonceCache.InMemory(60_000L, () -> ts);
+        SignatureVerifier verifier = new SignatureVerifier(cache, 300_000L, () -> ts);
+        VerificationResult verdict = verifier.verify(signed, wrongSecret, signature);
+
+        assertFalse(verdict.isSuccess());
+        assertEquals(SecurityConstants.ErrorCode.BAD_SIGNATURE, verdict.getErrorCode());
+    }
+
+    @Test
+    void query_parameter_reorder_on_wire_does_not_break_verification() {
+        // NamingServer sends ?vGroup=g1&unit=u1
+        // TC receives them but iterates in a different order internally.
+        // Because canonicalization sorts, both sides produce identical signStrings.
+        Map<String, String> senderOrder = new java.util.LinkedHashMap<>();
+        senderOrder.put("vGroup", "g1");
+        senderOrder.put("unit", "u1");
+
+        Map<String, String> receiverOrder = new java.util.LinkedHashMap<>();
+        receiverOrder.put("unit", "u1");
+        receiverOrder.put("vGroup", "g1");
+
+        long ts = 7_000L;
+        String nonce = "reorder-1";
+        CanonicalRequest sent = CanonicalRequest.builder()
+                .method("GET")
+                .path("/vgroup/v1/addVGroup")
+                .queryParams(senderOrder)
+                .clusterId("naming-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(new byte[0])
+                .build();
+        String signature = HmacSigner.sign(sent, SHARED_SECRET);
+
+        CanonicalRequest received = CanonicalRequest.builder()
+                .method("GET")
+                .path("/vgroup/v1/addVGroup")
+                .queryParams(receiverOrder)
+                .clusterId("naming-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(new byte[0])
+                .build();
+
+        NonceCache cache = new NonceCache.InMemory(60_000L, () -> ts);
+        SignatureVerifier verifier = new SignatureVerifier(cache, 300_000L, () -> ts);
+        assertTrue(verifier.verify(received, SHARED_SECRET, signature).isSuccess());
+    }
+
+    @Test
+    void console_proxy_body_forwarding_survives_signature_check() {
+        // Console POSTs a body-carrying request; NamingServer proxies it verbatim.
+        byte[] body = "{\"xid\":\"1.2.3\",\"branchId\":42}".getBytes();
+        long ts = 8_000L;
+        String nonce = "console-1";
+
+        CanonicalRequest sent = CanonicalRequest.builder()
+                .method("POST")
+                .path("/api/v1/console/globalSession/forceCommit")
+                .queryParams(Collections.<String, String>emptyMap())
+                .clusterId("naming-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(body)
+                .build();
+        String signature = HmacSigner.sign(sent, SHARED_SECRET);
+
+        // The body byte-for-byte must appear on the TC side.
+        CanonicalRequest received = CanonicalRequest.builder()
+                .method("POST")
+                .path("/api/v1/console/globalSession/forceCommit")
+                .queryParams(Collections.<String, String>emptyMap())
+                .clusterId("naming-01")
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(body)
+                .build();
+
+        NonceCache cache = new NonceCache.InMemory(60_000L, () -> ts);
+        SignatureVerifier verifier = new SignatureVerifier(cache, 300_000L, () -> ts);
+        assertTrue(
+                verifier.verify(received, SHARED_SECRET, signature).isSuccess(),
+                "unchanged proxied body must still verify");
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/security/RouteAuthorizerTest.java
+++ b/server/src/test/java/org/apache/seata/server/security/RouteAuthorizerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RouteAuthorizerTest {
+
+    private final RouteAuthorizer authorizer = new RouteAuthorizer();
+
+    @Test
+    void vgroup_write_route_requires_vgroup_write() {
+        assertEquals(CallerPermission.VGROUP_WRITE, authorizer.requiredPermission("GET", "/vgroup/v1/addVGroup"));
+        assertEquals(CallerPermission.VGROUP_WRITE, authorizer.requiredPermission("GET", "/vgroup/v1/removeVGroup"));
+    }
+
+    @Test
+    void console_paths_require_console_proxy() {
+        assertEquals(
+                CallerPermission.CONSOLE_PROXY,
+                authorizer.requiredPermission("GET", "/api/v1/console/globalSession/query"));
+        assertEquals(
+                CallerPermission.CONSOLE_PROXY,
+                authorizer.requiredPermission("POST", "/api/v1/console/globalSession/forceCommit"));
+    }
+
+    @Test
+    void unknown_route_returns_null() {
+        assertNull(authorizer.requiredPermission("GET", "/random"));
+        assertNull(authorizer.requiredPermission(null, "/x"));
+        assertNull(authorizer.requiredPermission("GET", null));
+    }
+
+    @Test
+    void isAuthorized_true_when_caller_holds_permission() {
+        AllowedCaller c = new AllowedCaller("n", new byte[32], EnumSet.of(CallerPermission.VGROUP_WRITE));
+        assertTrue(authorizer.isAuthorized(c, "GET", "/vgroup/v1/addVGroup"));
+    }
+
+    @Test
+    void isAuthorized_false_when_permission_missing() {
+        AllowedCaller c = new AllowedCaller("n", new byte[32], EnumSet.of(CallerPermission.CONSOLE_PROXY));
+        assertFalse(authorizer.isAuthorized(c, "GET", "/vgroup/v1/addVGroup"));
+    }
+
+    @Test
+    void isAuthorized_false_for_unknown_route_even_if_all_permissions_held() {
+        AllowedCaller c = new AllowedCaller("n", new byte[32], EnumSet.allOf(CallerPermission.class));
+        assertFalse(authorizer.isAuthorized(c, "GET", "/random"));
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/security/SeataServerAuthFilterTest.java
+++ b/server/src/test/java/org/apache/seata/server/security/SeataServerAuthFilterTest.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.apache.seata.common.security.CanonicalRequest;
+import org.apache.seata.common.security.HmacSigner;
+import org.apache.seata.common.security.NonceCache;
+import org.apache.seata.common.security.SecurityConstants;
+import org.apache.seata.common.security.SignatureAlgorithm;
+import org.apache.seata.common.security.SignatureVerifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SeataServerAuthFilterTest {
+
+    private static final byte[] SECRET = new byte[32];
+
+    static {
+        for (int i = 0; i < 32; i++) {
+            SECRET[i] = (byte) (i + 7);
+        }
+    }
+
+    private static final String CALLER_ID = "naming-server-01";
+
+    private ServerSecurityProperties props;
+    private AllowedCallerRegistry registry;
+    private AtomicLong clock;
+    private SignatureVerifier verifier;
+    private RouteAuthorizer authorizer;
+    private SeataServerAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        props = new ServerSecurityProperties();
+        props.setEnabled(true);
+        props.setMode(ServerSecurityProperties.Mode.ENFORCE);
+
+        registry = new AllowedCallerRegistry();
+        registry.register(new AllowedCaller(CALLER_ID, SECRET, EnumSet.allOf(CallerPermission.class)));
+
+        clock = new AtomicLong(1_700_000_000_000L);
+        NonceCache cache = new NonceCache.InMemory(60_000L, clock::get);
+        verifier = new SignatureVerifier(cache, 5 * 60 * 1000L, clock::get);
+        authorizer = new RouteAuthorizer();
+        filter = new SeataServerAuthFilter(props, registry, verifier, authorizer);
+    }
+
+    @Test
+    void unprotected_route_bypasses_signature_check() throws Exception {
+        // /health is not on the RouteAuthorizer list → filter passes through.
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/health");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called.get());
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    void protected_route_with_valid_signature_passes() throws Exception {
+        MockHttpServletRequest req = signed(
+                "GET", "/vgroup/v1/addVGroup", map("vGroup", "g1", "unit", "u1"), new byte[0], clock.get(), "n-1");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called.get(), "valid request must pass");
+        AllowedCaller injected =
+                (AllowedCaller) chain.capturedRequest.get().getAttribute(SeataServerAuthFilter.ATTR_CALLER);
+        assertNotNull(injected);
+        assertEquals(CALLER_ID, injected.getId());
+    }
+
+    @Test
+    void protected_route_without_headers_is_rejected() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/vgroup/v1/addVGroup");
+        req.addParameter("vGroup", "g1");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(401, resp.getStatus());
+        assertEquals(
+                SecurityConstants.ErrorCode.MISSING_SIGNATURE.name(),
+                resp.getHeader(SeataServerAuthFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void warn_mode_lets_unsigned_request_pass_through_but_logs() throws Exception {
+        props.setMode(ServerSecurityProperties.Mode.WARN);
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/vgroup/v1/addVGroup");
+        req.addParameter("vGroup", "g1");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertTrue(chain.called.get());
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    void unknown_caller_is_rejected() throws Exception {
+        MockHttpServletRequest req =
+                signed("GET", "/vgroup/v1/addVGroup", map("vGroup", "g1"), new byte[0], clock.get(), "n-2");
+        req.removeHeader(SecurityConstants.HEADER_CLUSTER_ID);
+        req.addHeader(SecurityConstants.HEADER_CLUSTER_ID, "stranger");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(
+                SecurityConstants.ErrorCode.UNKNOWN_CLUSTER_ID.name(),
+                resp.getHeader(SeataServerAuthFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void caller_missing_permission_is_forbidden() throws Exception {
+        // Reload with a caller that only holds CONSOLE_PROXY.
+        registry.reload(Collections.singletonList(
+                new AllowedCaller(CALLER_ID, SECRET, EnumSet.of(CallerPermission.CONSOLE_PROXY))));
+
+        MockHttpServletRequest req =
+                signed("GET", "/vgroup/v1/addVGroup", map("vGroup", "g1"), new byte[0], clock.get(), "n-3");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(403, resp.getStatus());
+        assertEquals(
+                SecurityConstants.ErrorCode.FORBIDDEN.name(), resp.getHeader(SeataServerAuthFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void replay_of_valid_request_is_rejected() throws Exception {
+        MockHttpServletRequest req1 =
+                signed("GET", "/vgroup/v1/addVGroup", map("vGroup", "g1"), new byte[0], clock.get(), "dup");
+        filter.doFilter(req1, new MockHttpServletResponse(), new RecordingChain());
+
+        MockHttpServletRequest req2 =
+                signed("GET", "/vgroup/v1/addVGroup", map("vGroup", "g1"), new byte[0], clock.get(), "dup");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+        filter.doFilter(req2, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(
+                SecurityConstants.ErrorCode.REPLAY_DETECTED.name(),
+                resp.getHeader(SeataServerAuthFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void tampered_query_is_detected() throws Exception {
+        // Sign for vGroup=g1, then flip to vGroup=g2 without re-signing.
+        MockHttpServletRequest req =
+                signed("GET", "/vgroup/v1/addVGroup", map("vGroup", "g1"), new byte[0], clock.get(), "n-4");
+        req.removeParameter("vGroup");
+        req.addParameter("vGroup", "g2");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        RecordingChain chain = new RecordingChain();
+
+        filter.doFilter(req, resp, chain);
+
+        assertFalse(chain.called.get());
+        assertEquals(
+                SecurityConstants.ErrorCode.BAD_SIGNATURE.name(),
+                resp.getHeader(SeataServerAuthFilter.RESP_HEADER_ERROR));
+    }
+
+    @Test
+    void matches_helper_handles_exact_and_wildcard() {
+        assertTrue(SeataServerAuthFilter.matches("/health", "/health"));
+        assertFalse(SeataServerAuthFilter.matches("/health", "/health/x"));
+        assertTrue(SeataServerAuthFilter.matches("/actuator/**", "/actuator/env"));
+        assertFalse(SeataServerAuthFilter.matches("/actuator/**", "/other"));
+        assertFalse(SeataServerAuthFilter.matches(null, "/x"));
+    }
+
+    // -------------------------------------------------- helpers
+
+    private MockHttpServletRequest signed(
+            String method, String path, Map<String, String> query, byte[] body, long ts, String nonce) {
+        MockHttpServletRequest req = new MockHttpServletRequest(method, path);
+        req.setContent(body == null ? new byte[0] : body);
+        for (Map.Entry<String, String> e : query.entrySet()) {
+            req.addParameter(e.getKey(), e.getValue());
+        }
+        CanonicalRequest canonical = CanonicalRequest.builder()
+                .method(method)
+                .path(path)
+                .queryParams(query)
+                .clusterId(CALLER_ID)
+                .timestampMillis(ts)
+                .nonce(nonce)
+                .algorithm(SignatureAlgorithm.HMAC_SHA256)
+                .body(body)
+                .build();
+        String sig = HmacSigner.sign(canonical, SECRET);
+
+        req.addHeader(SecurityConstants.HEADER_CLUSTER_ID, CALLER_ID);
+        req.addHeader(SecurityConstants.HEADER_TIMESTAMP, Long.toString(ts));
+        req.addHeader(SecurityConstants.HEADER_NONCE, nonce);
+        req.addHeader(SecurityConstants.HEADER_SIGN_ALG, SignatureAlgorithm.HMAC_SHA256.wireName());
+        req.addHeader(SecurityConstants.HEADER_SIGNATURE, sig);
+        return req;
+    }
+
+    private static Map<String, String> map(String... kv) {
+        if ((kv.length & 1) != 0) {
+            throw new IllegalArgumentException("kv must be pairs");
+        }
+        Map<String, String> m = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put(kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    private static final class RecordingChain implements FilterChain {
+        final AtomicBoolean called = new AtomicBoolean();
+        final AtomicReference<ServletRequest> capturedRequest = new AtomicReference<>();
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+            called.set(true);
+            capturedRequest.set(request);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/security/ServerSecretResolverTest.java
+++ b/server/src/test/java/org/apache/seata/server/security/ServerSecretResolverTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServerSecretResolverTest {
+
+    @Test
+    void env_scheme_reads_base64_from_env() {
+        Map<String, String> env = new HashMap<>();
+        String v = Base64.getEncoder().encodeToString("hi".getBytes(StandardCharsets.UTF_8));
+        env.put("MY_KEY", v);
+        assertArrayEquals(
+                "hi".getBytes(StandardCharsets.UTF_8), new ServerSecretResolver(env::get).resolve("env:MY_KEY"));
+    }
+
+    @Test
+    void plain_scheme_returns_raw_utf8() {
+        assertArrayEquals(
+                "abc".getBytes(StandardCharsets.UTF_8),
+                new ServerSecretResolver(Collections.<String, String>emptyMap()::get).resolve("plain:abc"));
+    }
+
+    @Test
+    void base64_scheme_decodes_inline_value() {
+        String encoded = Base64.getEncoder().encodeToString("abc".getBytes(StandardCharsets.UTF_8));
+        assertArrayEquals(
+                "abc".getBytes(StandardCharsets.UTF_8),
+                new ServerSecretResolver(Collections.<String, String>emptyMap()::get).resolve("base64:" + encoded));
+    }
+
+    @Test
+    void rejects_missing_env_var() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ServerSecretResolver(Collections.<String, String>emptyMap()::get).resolve("env:MISSING"));
+    }
+
+    @Test
+    void rejects_invalid_scheme_or_blank_input() {
+        ServerSecretResolver r = new ServerSecretResolver(Collections.<String, String>emptyMap()::get);
+        assertThrows(IllegalArgumentException.class, () -> r.resolve(null));
+        assertThrows(IllegalArgumentException.class, () -> r.resolve(""));
+        assertThrows(IllegalArgumentException.class, () -> r.resolve("kms:x"));
+        assertThrows(IllegalArgumentException.class, () -> r.resolve("base64:???"));
+    }
+}


### PR DESCRIPTION

Adds signed-request authentication for the previously unauthenticated NamingServer ↔ Seata Server control plane, with multi-tenant isolation via cluster-id and permission scoping.

Components
----------
- common/security: reusable canonical-request builder, HMAC signer/verifier (constant-time compare), nonce cache with pluggable clock, and structured verification result.
- namingserver/security: inbound Servlet Filter enforcing signature + namespace/cluster/vgroup allow-lists + per-route permission; outbound signer for vGroup writes / Console proxy / MCP calls to TC.
- server/security: inbound filter for /vgroup/v1/* and /api/*/console/* with its own allowed-callers table (supports two coexisting entries for zero-downtime key rotation).

Both filters ship as Spring Boot auto-configuration gated by an enabled flag, with WARN and ENFORCE modes for gray rollout. Secrets are loaded via a SecretResolver supporting env:, base64: and plain: schemes to keep raw key material out of config files.

Tests
-----
122 unit tests across three modules; common module coverage 93% instruction / 89% branch. An InteropIntegrationTest guards against wire-format drift between the two sides.

Docs
----
docs/SECURITY_AUTH_GUIDE.md covers full config reference, three deployment scenarios (single cluster / multi-tenant / Raft HA), key generation, zero- downtime rotation, gray rollout, monitoring, and troubleshooting.

Also adds jakarta.servlet-api (provided scope) to server/pom.xml so the new Spring Boot 4.x-compatible filter compiles.

<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

