### PR TITLE
bugfix: fix read registry network config from local configuration

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -29,6 +29,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] fix Saga auto-configuration being skipped on Spring Boot 4.x because of a hard `DataSourceAutoConfiguration` class reference
 - [[#8179](https://github.com/apache/incubator-seata/pull/8179)] set java.version to 17 for console module to fix compilation error
 - [[#8170](https://github.com/apache/incubator-seata/pull/8170)] fix ConfigTools encryption corrupting non-ASCII content on non-UTF-8 platforms
+- [[#8182](https://github.com/apache/incubator-seata/issues/8182)] fix registry preferred networks and ignored interfaces from Spring Boot application.yml
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -29,6 +29,7 @@
 - [[#8157](https://github.com/apache/incubator-seata/pull/8157)] 修复 Spring Boot 4.x 下由于硬编码 `DataSourceAutoConfiguration` 类引用导致 Saga 自动配置被跳过的问题
 - [[#8179](https://github.com/apache/incubator-seata/pull/8179)] 将 console 模块的 java.version 设置为 17 以修复编译错误
 - [[#8170](https://github.com/apache/incubator-seata/pull/8170)] 修复 ConfigTools 加密在非 UTF-8 默认字符集平台损坏非 ASCII 内容的问题
+- [[#8182](https://github.com/apache/incubator-seata/issues/8182)] 修复 Spring Boot application.yml 中 registry preferred networks 和 ignored interfaces 配置不生效的问题
 
 
 ### optimize:

--- a/server/src/main/java/org/apache/seata/server/Server.java
+++ b/server/src/main/java/org/apache/seata/server/Server.java
@@ -23,6 +23,7 @@ import org.apache.seata.common.thread.ThreadPoolExecutorFactory;
 import org.apache.seata.common.util.NetUtil;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.common.util.UUIDGenerator;
+import org.apache.seata.config.Configuration;
 import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.core.rpc.netty.NettyRemotingServer;
 import org.apache.seata.core.rpc.netty.NettyServerConfig;
@@ -84,12 +85,12 @@ public class Server {
         } else {
             // Get preferred network patterns from configuration (regex or prefix match)
             // Used to select specific network interfaces when multiple are available
-            String preferredNetworks = ConfigurationFactory.getInstance().getConfig(REGISTRY_PREFERRED_NETWORKS);
+            String preferredNetworks = getRegistryConfig(REGISTRY_PREFERRED_NETWORKS);
 
             // Get ignored interface patterns from configuration (regex supported)
             // Useful for filtering out virtual interfaces like VMware, VirtualBox, Docker, etc.
             // Example: "VMware.*,VirtualBox.*,bridge.*,docker.*,veth.*"
-            String ignoredInterfaces = ConfigurationFactory.getInstance().getConfig(REGISTRY_IGNORED_INTERFACES);
+            String ignoredInterfaces = getRegistryConfig(REGISTRY_IGNORED_INTERFACES);
             String[] ignoredInterfacesSplit = null;
             if (ignoredInterfaces != null) {
                 ignoredInterfacesSplit = ignoredInterfaces.split(",");
@@ -126,5 +127,16 @@ public class Server {
         // let ServerRunner do destroy instead ShutdownHook, see https://github.com/seata/seata/issues/4028
         ServerRunner.addDisposable(coordinator);
         nettyRemotingServer.init();
+    }
+
+    static String getRegistryConfig(String dataId) {
+        Configuration registryConfiguration = ConfigurationFactory.CURRENT_FILE_INSTANCE;
+        if (registryConfiguration != null) {
+            String config = registryConfiguration.getConfig(dataId);
+            if (config != null) {
+                return config;
+            }
+        }
+        return ConfigurationFactory.getInstance().getConfig(dataId);
     }
 }

--- a/server/src/test/java/org/apache/seata/server/ServerConfigTest.java
+++ b/server/src/test/java/org/apache/seata/server/ServerConfigTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server;
+
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.config.Configuration;
+import org.apache.seata.config.ConfigurationFactory;
+import org.apache.seata.spring.boot.autoconfigure.SeataCoreEnvironmentPostProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.apache.seata.common.Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServerConfigTest {
+
+    private Configuration originalFileConfiguration;
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void setUp() {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        SeataCoreEnvironmentPostProcessor.init();
+        originalFileConfiguration = ConfigurationFactory.CURRENT_FILE_INSTANCE;
+    }
+
+    @AfterEach
+    void tearDown() {
+        ConfigurationFactory.CURRENT_FILE_INSTANCE = originalFileConfiguration;
+        if (originalEnvironment != null) {
+            ObjectHolder.INSTANCE.setObject(OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+
+    @Test
+    void shouldUseRegistryConfigurationFirst() {
+        Configuration registryConfiguration = mock(Configuration.class);
+        Configuration configCenterConfiguration = mock(Configuration.class);
+        ConfigurationFactory.CURRENT_FILE_INSTANCE = registryConfiguration;
+        when(registryConfiguration.getConfig("registry.preferredNetworks")).thenReturn("172.30.31.*");
+
+        try (MockedStatic<ConfigurationFactory> configurationFactory =
+                mockStatic(ConfigurationFactory.class, CALLS_REAL_METHODS)) {
+            configurationFactory.when(ConfigurationFactory::getInstance).thenReturn(configCenterConfiguration);
+
+            assertEquals("172.30.31.*", Server.getRegistryConfig("registry.preferredNetworks"));
+            verify(configCenterConfiguration, never()).getConfig("registry.preferredNetworks");
+        }
+    }
+
+    @Test
+    void shouldFallbackToConfigCenterWhenRegistryConfigurationMissing() {
+        Configuration registryConfiguration = mock(Configuration.class);
+        Configuration configCenterConfiguration = mock(Configuration.class);
+        ConfigurationFactory.CURRENT_FILE_INSTANCE = registryConfiguration;
+        when(registryConfiguration.getConfig("registry.ignoredInterfaces")).thenReturn(null);
+        when(configCenterConfiguration.getConfig("registry.ignoredInterfaces")).thenReturn("bridge.*");
+
+        try (MockedStatic<ConfigurationFactory> configurationFactory =
+                mockStatic(ConfigurationFactory.class, CALLS_REAL_METHODS)) {
+            configurationFactory.when(ConfigurationFactory::getInstance).thenReturn(configCenterConfiguration);
+
+            assertEquals("bridge.*", Server.getRegistryConfig("registry.ignoredInterfaces"));
+        }
+    }
+}

--- a/spring/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryProperties.java
+++ b/spring/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryProperties.java
@@ -31,6 +31,8 @@ public class RegistryProperties {
 
     private String preferredNetworks;
 
+    private String ignoredInterfaces;
+
     public String getType() {
         return type;
     }
@@ -46,6 +48,15 @@ public class RegistryProperties {
 
     public RegistryProperties setPreferredNetworks(String preferredNetworks) {
         this.preferredNetworks = preferredNetworks;
+        return this;
+    }
+
+    public String getIgnoredInterfaces() {
+        return ignoredInterfaces;
+    }
+
+    public RegistryProperties setIgnoredInterfaces(String ignoredInterfaces) {
+        this.ignoredInterfaces = ignoredInterfaces;
         return this;
     }
 }

--- a/spring/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryPropertiesTest.java
+++ b/spring/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/test/java/org/apache/seata/spring/boot/autoconfigure/properties/registry/RegistryPropertiesTest.java
@@ -26,7 +26,9 @@ public class RegistryPropertiesTest {
         RegistryProperties registryProperties = new RegistryProperties();
         registryProperties.setType("type");
         registryProperties.setPreferredNetworks("network");
+        registryProperties.setIgnoredInterfaces("interface");
         Assertions.assertEquals("type", registryProperties.getType());
         Assertions.assertEquals("network", registryProperties.getPreferredNetworks());
+        Assertions.assertEquals("interface", registryProperties.getIgnoredInterfaces());
     }
 }


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR fixes the server-side registry network configuration lookup for `registry.preferredNetworks` and `registry.ignoredInterfaces`.

Previously, `Server` read these options through `ConfigurationFactory.getInstance()`. When `seata.config.type=nacos` is configured, that instance points to the config center, so local Spring Boot configuration such as `seata.registry.preferred-networks` and `seata.registry.ignored-interfaces` in `application.yml` may be ignored.

This PR changes the lookup to:
- read from `ConfigurationFactory.CURRENT_FILE_INSTANCE` first, which is consistent with other registry-local configuration lookup paths
- fallback to `ConfigurationFactory.getInstance()` when the local registry configuration does not provide the value
- add `ignoredInterfaces` to `RegistryProperties`
- add regression coverage for the local-first lookup behavior

### Ⅱ. Does this pull request fix one issue?

fixes #8182

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Added test cases.

### Ⅳ. Describe how to verify it

- `mvn -pl server -am -Dtest=org.apache.seata.server.ServerConfigTest -DfailIfNoTests=false test`
- `mvn -pl spring/seata-spring-autoconfigure/seata-spring-autoconfigure-core -am -Dtest=org.apache.seata.spring.boot.autoconfigure.properties.registry.RegistryPropertiesTest -DfailIfNoTests=false test`

### Ⅴ. Special notes for reviews