### PR TITLE
refactor: centralize node version property to build/pom.xml

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -126,6 +126,7 @@
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
+        <nodeVersion>v19.5.0</nodeVersion>
         <!-- Deploy && GPG -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -50,6 +50,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### refactor:
 
 - [[#8177](https://github.com/apache/incubator-seata/pull/8177)] centralize protobuf and grpc version properties to build/pom.xml
+- [[#8190](https://github.com/apache/incubator-seata/pull/8190)] centralize node version property to build/pom.xml
 
 ### doc:
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -49,6 +49,7 @@
 ### refactor:
 
 - [[#8177](https://github.com/apache/incubator-seata/pull/8177)] 将 protobuf 和 grpc 版本属性集中到 build/pom.xml
+- [[#8190](https://github.com/apache/incubator-seata/pull/8190)] 将 node 版本属性集中到 build/pom.xml
 
 ### doc:
 

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -189,7 +189,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v19.5.0</nodeVersion>
+                            <nodeVersion>${nodeVersion}</nodeVersion>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).


### Ⅰ. Describe what this PR did

Extracted `nodeVersion` of `frontend-maven-plugin` from being hardcoded in `console/pom.xml` to a Maven property `${nodeVersion}` defined in `build/pom.xml`, enabling users to specify the Node.js version to download via the `-DnodeVersion=<version>` command-line argument.

**Changes:**
- `build/pom.xml`: Added `<nodeVersion>v19.5.0</nodeVersion>` property (default value unchanged)
- `console/pom.xml`: Replaced hardcoded `<nodeVersion>v19.5.0</nodeVersion>` with `<nodeVersion>${nodeVersion}</nodeVersion>`

This resolves the issue where builds on non-mainstream architectures (e.g., LoongArch) fail because the hardcoded Node.js version is unavailable, and the `-DnodeVersion=v20.20.2` parameter was ignored. The refactoring follows the same pattern as commit 2376244d9 (refactor: centralize protobuf and grpc version properties to build/pom.xml).

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/apache/incubator-seata/issues/8189

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This change is a Maven POM property extraction — a build configuration refactoring that does not involve business logic changes. It can be verified by:
- The `-DnodeVersion=v20.20.2` parameter is correctly passed through and takes effect
- Default behavior (no parameter) remains unchanged, still downloading v19.5.0

### Ⅳ. Describe how to verify it

1. **Default behavior unchanged**: Run `mvn -pl console -am -DskipTests package`, verify that Node.js v19.5.0 is still downloaded
2. **Command-line override takes effect**: Run `mvn -pl console -am -DskipTests package -DnodeVersion=v20.20.2`, verify that Node.js v20.20.2 is downloaded
3. Check the Node version after build:
   ```shell
   ./console/src/main/resources/static/console-fe/node/node -v
   ```
   It should match the version specified by the `-DnodeVersion` parameter

### Ⅴ. Special notes for reviews

- The default value `v19.5.0` remains unchanged, not affecting existing build workflows
- This pattern is consistent with the previous commit 2376244d9 that centralized protobuf/grpc version properties
