### PR TITLE
optimize: update copyright year and ASF organization metadata 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Seata (Incubating)
-Copyright 2023-2025 The Apache Software Foundation
+Copyright 2023-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -43,8 +43,8 @@
     </licenses>
 
     <organization>
-        <name>Apache</name>
-        <url>https://github.com/apache</url>
+        <name>The Apache Software Foundation</name>
+        <url>https://www.apache.org/</url>
     </organization>
 
     <url>https://seata.apache.org</url>

--- a/changes/en-us/2.7.0.md
+++ b/changes/en-us/2.7.0.md
@@ -55,6 +55,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### optimize:
 
+- [[#]()] fix NOTICE copyright year and ASF organization metadata
 - [[#8042](https://github.com/apache/incubator-seata/pull/8042)] enhance Saga benchmark workload and result reporting
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] configure PMD to output messages in English
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] pin Spring version for NamingServer and console

--- a/changes/en-us/2.7.0.md
+++ b/changes/en-us/2.7.0.md
@@ -55,7 +55,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### optimize:
 
-- [[#]()] fix NOTICE copyright year and ASF organization metadata
+- [[#8192](https://github.com/apache/incubator-seata/pull/8192)] fix NOTICE copyright year and ASF organization metadata
 - [[#8042](https://github.com/apache/incubator-seata/pull/8042)] enhance Saga benchmark workload and result reporting
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] configure PMD to output messages in English
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] pin Spring version for NamingServer and console

--- a/changes/zh-cn/2.7.0.md
+++ b/changes/zh-cn/2.7.0.md
@@ -55,6 +55,7 @@
 
 ### optimize:
 
+- [[#]()] 修复 NOTICE 版权年份及 ASF 组织元数据
 - [[#8042](https://github.com/apache/incubator-seata/pull/8042)] 增强 Saga 压测工作负载和结果报告
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] 配置 PMD 输出英文消息
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] 固定 NamingServer 和 console 的 Spring 版本

--- a/changes/zh-cn/2.7.0.md
+++ b/changes/zh-cn/2.7.0.md
@@ -55,7 +55,7 @@
 
 ### optimize:
 
-- [[#]()] 修复 NOTICE 版权年份及 ASF 组织元数据
+- [[#8192](https://github.com/apache/incubator-seata/pull/8192)] 修复 NOTICE 版权年份及 ASF 组织元数据
 - [[#8042](https://github.com/apache/incubator-seata/pull/8042)] 增强 Saga 压测工作负载和结果报告
 - [[#8022](https://github.com/apache/incubator-seata/pull/8022)] 配置 PMD 输出英文消息
 - [[#7930](https://github.com/apache/incubator-seata/pull/7930)] 固定 NamingServer 和 console 的 Spring 版本

--- a/distribution/NOTICE
+++ b/distribution/NOTICE
@@ -1,5 +1,5 @@
 Apache Seata (Incubating)
-Copyright 2023-2025 The Apache Software Foundation
+Copyright 2023-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/distribution/NOTICE-namingserver
+++ b/distribution/NOTICE-namingserver
@@ -1,5 +1,5 @@
 Apache Seata (Incubating)
-Copyright 2023-2025 The Apache Software Foundation
+Copyright 2023-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/distribution/NOTICE-server
+++ b/distribution/NOTICE-server
@@ -1,5 +1,5 @@
 Apache Seata (Incubating)
-Copyright 2023-2025 The Apache Software Foundation
+Copyright 2023-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [X] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [X] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

This PR corrects the NOTICE copyright year and ASF organization metadata for the 2.7.0 release:

- Update the copyright year range from `2023-2025` to `2023-2026` in the root and distribution NOTICE files.
- Change the Maven organization name from `Apache` to `The Apache Software Foundation`.
- Change the Maven organization URL from the GitHub organization page to `https://www.apache.org/`.
- Ensure newly built JAR files use the formal ASF organization name in their generated `META-INF/NOTICE`.
- Register the changes in the English and Chinese 2.7.0 changelogs.

The NOTICE format follows the [ASF Source Header and Copyright Notice Policy](https://www.apache.org/legal/src-headers.html#notice).

### Ⅱ. Does this pull request fix one issue?

No. This PR corrects release metadata identified during the 2.7.0 release candidate verification.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR only changes legal notices, Maven project metadata, and changelog documentation. It does not change executable code or runtime behavior, so unit and integration tests are not applicable.

The changes can be verified by inspecting the source NOTICE files, the effective Maven organization metadata, and the generated `META-INF/NOTICE` in a rebuilt JAR.

### Ⅳ. Describe how to verify it

Verify the copyright year in the source and distribution NOTICE files