### PR TITLE
security : upgrade fastjson2 to 2.0.63

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -38,6 +38,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 
 ### security:
+- [[#8195](https://github.com/apache/incubator-seata/pull/8195)] upgrade fastjson2 to 2.0.63- #8195
 
 
 ### test:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -37,6 +37,7 @@
 
 
 ### security:
+- [[#8195](https://github.com/apache/incubator-seata/pull/8195)] 更新 fastjson2 到 2.0.63
 
 
 ### test:

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -81,7 +81,7 @@
         <kryo.version>5.4.0</kryo.version>
         <kryo-serializers.version>0.45</kryo-serializers.version>
         <hessian.version>4.0.63</hessian.version>
-        <fastjson2.version>2.0.52</fastjson2.version>
+        <fastjson2.version>2.0.63</fastjson2.version>
         <groovy.version>4.0.31</groovy.version>
         <zstd.version>1.5.0-4</zstd.version>
         <jackson.version>2.18.3</jackson.version>

--- a/distribution/LICENSE
+++ b/distribution/LICENSE
@@ -223,7 +223,7 @@ Apache-2.0 licenses
     com.alibaba.nacos:nacos-common 1.4.6 Apache-2.0
     com.alibaba:druid 1.2.25 Apache-2.0
     com.alibaba:fastjson 1.2.83 Apache-2.0
-    com.alibaba.fastjson2:fastjson2 2.0.52 Apache-2.0
+    com.alibaba.fastjson2:fastjson2 2.0.63 Apache-2.0
     com.alipay.sofa.common:sofa-common-tools 1.0.12 Apache-2.0
     com.alipay.sofa:bolt 1.6.7 Apache-2.0
     com.alipay.sofa:hessian 4.0.3 Apache-2.0

--- a/distribution/LICENSE-server
+++ b/distribution/LICENSE-server
@@ -250,7 +250,7 @@ Apache-2.0 licenses
     net.logstash.logback:logstash-logback-encoder 6.5 Apache-2.0
     com.google.guava:failureaccess 1.0.1 Apache-2.0
     com.alibaba:fastjson 1.2.83 Apache-2.0
-    com.alibaba.fastjson2:fastjson2 2.0.52 Apache-2.0
+    com.alibaba.fastjson2:fastjson2 2.0.63 Apache-2.0
     io.dropwizard.metrics:metrics-core 4.2.22 Apache-2.0
     io.grpc:grpc-api 1.55.1 Apache-2.0
     io.grpc:grpc-context 1.55.1 Apache-2.0

--- a/distribution/NOTICE.md
+++ b/distribution/NOTICE.md
@@ -568,7 +568,7 @@ Please copy database driver dependencies, such as `mysql-connector-java.jar`, to
     │   ├── failsafe-2.3.3.jar
     │   ├── failureaccess-1.0.1.jar
     │   ├── fastjson-1.2.83.jar
-    │   ├── fastjson2-2.0.52.jar
+    │   ├── fastjson2-2.0.63.jar
     │   ├── fury-core-0.8.0.jar
     │   ├── grpc-api-1.55.1.jar
     │   ├── grpc-context-1.55.1.jar
@@ -1725,7 +1725,7 @@ Please copy database driver dependencies, such as `mysql-connector-java.jar`, to
     │   ├── failsafe-2.3.3.jar
     │   ├── failureaccess-1.0.1.jar
     │   ├── fastjson-1.2.83.jar
-    │   ├── fastjson2-2.0.52.jar
+    │   ├── fastjson2-2.0.63.jar
     │   ├── fury-core-0.8.0.jar
     │   ├── grpc-api-1.55.1.jar
     │   ├── grpc-context-1.55.1.jar


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
Upgrade fastjson2 to a secure version

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

