### PR TITLE
refactor: narrow PR trigger paths for native-namingserver workflow

### DIFF
--- a/.github/workflows/native-namingserver.yml
+++ b/.github/workflows/native-namingserver.yml
@@ -23,18 +23,7 @@ on:
     branches: [ 2.x, develop, master ]
     paths:
       - '.github/workflows/native-namingserver.yml'
-      - 'build/pom.xml'
-      - 'pom.xml'
-      - 'common/pom.xml'
-      - 'common/src/main/**'
-      - 'console/pom.xml'
-      - 'console/src/main/**'
-      - 'namingserver/pom.xml'
-      - 'namingserver/src/main/**'
-      - 'test-suite/test-native-namingserver/pom.xml'
-      - 'test-suite/test-native-namingserver/src/**'
-      - 'test-suite/test-native-metadata-merge/pom.xml'
-      - 'test-suite/test-native-metadata-merge/src/**'
+      - 'namingserver/src/main/resources/META-INF/native-image/**'
   workflow_call:
     inputs:
       repository:

--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -20,7 +20,7 @@ Add changes here for all PR submitted to the 2.x branch.
 
 ### feature:
 
-- [[#8165](https://github.com/apache/incubator-seata/pull/8165)] add GraalVM native image build support for seata-namingserver. simplify namingserver logback-spring.xml by removing conditional `<if>` logic and LOG_BASH_DIR property, always using classpath resources for GraalVM native image compatibility
+- [[#8165](https://github.com/apache/incubator-seata/pull/8165)]/[[#8200](https://github.com/apache/incubator-seata/pull/8200)] add GraalVM native image build support for seata-namingserver
 - [[#8140](https://github.com/apache/incubator-seata/pull/8140)] support automatic updated marking after BusinessActionContext modifications
 - [[#8188](https://github.com/apache/incubator-seata/pull/8188)] support action status report and TccHook rollback interceptors in Saga annotation mode for anti-suspension and empty rollback
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -20,7 +20,7 @@
 
 ### feature:
 
-- [[#8165](https://github.com/apache/incubator-seata/pull/8165)] 为 seata-namingserver 添加 GraalVM 原生镜像构建支持。简化 namingserver 的 logback-spring.xml，移除条件 `<if>` 逻辑和 LOG_BASH_DIR 属性，始终使用 classpath 资源以兼容 GraalVM 原生镜像
+- [[#8165](https://github.com/apache/incubator-seata/pull/8165)]/[[#8200](https://github.com/apache/incubator-seata/pull/8200)] 为 seata-namingserver 添加 GraalVM 原生镜像构建支持
 - [[#8140](https://github.com/apache/incubator-seata/pull/8140)] 支持在 BusinessActionContext 变更后自动标记 updated
 - [[#8188](https://github.com/apache/incubator-seata/pull/8188)] Saga 注解模式支持 action status 上报和 TccHook 回滚切面，增强防悬挂和空回滚能力
 


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Narrow the `pull_request` trigger paths in `.github/workflows/native-namingserver.yml` to reduce unnecessary CI runs.

Previously, the workflow was triggered on PR changes across almost all related modules (`build/pom.xml`, `pom.xml`, `common/**`, `console/**`, `namingserver/**`, `test-native-namingserver/**`, `test-native-metadata-merge/**`). Now it only triggers when the workflow file itself or `namingserver/src/main/resources/META-INF/native-image/**` (GraalVM Native Image configuration) is changed.

### Ⅱ. Does this pull request fix one issue?

https://github.com/apache/incubator-seata/issues/8164

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This is a CI workflow configuration change. It does not affect the application code, so no test cases are needed. The correctness can be verified by observing CI trigger behavior.

### Ⅳ. Describe how to verify it

1. PRs that only change non-native-image files (e.g., `common/`, `console/`, `namingserver/src/main/java/`) should **not** trigger the Native Build NamingServer workflow.
2. PRs that change files under `namingserver/src/main/resources/META-INF/native-image/**` should trigger the workflow.
3. PRs that change `.github/workflows/native-namingserver.yml` itself should trigger the workflow.

### Ⅴ. Special notes for reviews

This is a CI optimization that reduces resource consumption by avoiding unnecessary native image builds on PRs that don't touch native-image configuration.
