### PR TITLE
bugfix: apply ignoredInterfaces and preferredNetworks when the default address is cached

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -33,6 +33,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#8179](https://github.com/apache/incubator-seata/pull/8179)] set java.version to 17 for console module to fix compilation error
 - [[#8170](https://github.com/apache/incubator-seata/pull/8170)] fix ConfigTools encryption corrupting non-ASCII content on non-UTF-8 platforms
 - [[#8182](https://github.com/apache/incubator-seata/issues/8182)] fix registry preferred networks and ignored interfaces from Spring Boot application.yml
+- [[#8202](https://github.com/apache/incubator-seata/pull/8202)] fix `ignoredInterfaces` and `preferredNetworks` being silently ignored when the unfiltered local address is already cached
 
 
 

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -34,6 +34,7 @@
 - [[#8179](https://github.com/apache/incubator-seata/pull/8179)] 将 console 模块的 java.version 设置为 17 以修复编译错误
 - [[#8170](https://github.com/apache/incubator-seata/pull/8170)] 修复 ConfigTools 加密在非 UTF-8 默认字符集平台损坏非 ASCII 内容的问题
 - [[#8182](https://github.com/apache/incubator-seata/issues/8182)] 修复 Spring Boot application.yml 中 registry preferred networks 和 ignored interfaces 配置不生效的问题
+- [[#8202](https://github.com/apache/incubator-seata/pull/8202)] 修复 `ignoredInterfaces` 和 `preferredNetworks` 在无过滤地址已缓存时被静默忽略的问题
 
 
 ### optimize:

--- a/common/src/main/java/org/apache/seata/common/util/NetUtil.java
+++ b/common/src/main/java/org/apache/seata/common/util/NetUtil.java
@@ -265,12 +265,18 @@ public class NetUtil {
      */
     public static InetAddress getIgnoredInterfacesLocalAddress(
             String[] ignoredInterfaces, String... preferredNetworks) {
-        if (LOCAL_ADDRESS != null) {
-            return LOCAL_ADDRESS;
+        // The global cache holds the address of an unfiltered lookup, so it can only answer
+        // an unfiltered lookup. A call carrying patterns must evaluate them, otherwise the
+        // first unfiltered call anywhere in the JVM would silently disable the filtering.
+        if (CollectionUtils.isEmpty(ignoredInterfaces) && CollectionUtils.isEmpty(preferredNetworks)) {
+            if (LOCAL_ADDRESS != null) {
+                return LOCAL_ADDRESS;
+            }
+            InetAddress localAddress = getLocalAddress0(ignoredInterfaces, preferredNetworks);
+            LOCAL_ADDRESS = localAddress;
+            return localAddress;
         }
-        InetAddress localAddress = getLocalAddress0(ignoredInterfaces, preferredNetworks);
-        LOCAL_ADDRESS = localAddress;
-        return localAddress;
+        return getLocalAddress0(ignoredInterfaces, preferredNetworks);
     }
 
     private static InetAddress getLocalAddress0(String[] ignoredInterfaces, String... preferredNetworks) {

--- a/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
+++ b/common/src/test/java/org/apache/seata/common/util/NetUtilTest.java
@@ -415,4 +415,40 @@ public class NetUtilTest {
         assertThat(NetUtil.getIgnoredInterfacesLocalAddress(ignoredInterfaces, preferredNetworks))
                 .isNotNull();
     }
+
+    /**
+     * A filtered lookup must evaluate its patterns even when an earlier unfiltered lookup has
+     * already populated the global cache. Ignoring every interface leaves no candidate, so the
+     * result is null rather than the cached address.
+     */
+    @Test
+    public void testIgnoredInterfacesAreAppliedAfterDefaultAddressIsCached() {
+        // Populate the global cache through the unfiltered lookup first.
+        assertThat(NetUtil.getLocalAddress()).isNotNull();
+
+        assertThat(NetUtil.getIgnoredInterfacesLocalAddress(new String[] {".*"}))
+                .isNull();
+    }
+
+    /**
+     * The same early return also bypassed preferredNetworks. Ignoring every interface through the
+     * preferred-network path leaves no candidate either, so the cached address must not leak out.
+     */
+    @Test
+    public void testPreferredNetworksAreAppliedAfterDefaultAddressIsCached() {
+        // Populate the global cache through the unfiltered lookup first.
+        assertThat(NetUtil.getLocalAddress()).isNotNull();
+
+        // A filtered lookup that excludes everything cannot be answered from the unfiltered cache.
+        assertThat(NetUtil.getIgnoredInterfacesLocalAddress(new String[] {".*"}, "192.168.*"))
+                .isNull();
+    }
+
+    /**
+     * The unfiltered lookup keeps using the global cache, so repeated calls stay identical.
+     */
+    @Test
+    public void testUnfilteredLookupRemainsCached() {
+        assertThat(NetUtil.getLocalAddress()).isSameAs(NetUtil.getLocalAddress());
+    }
 }


### PR DESCRIPTION
## Issue

`getIgnoredInterfacesLocalAddress(String[], String...)` returns the global `LOCAL_ADDRESS` immediately when it has already been initialized, regardless of the supplied `ignoredInterfaces` or `preferredNetworks` patterns. Once an unfiltered lookup (through `getLocalAddress()` or `getLocalIp()`) has populated the cache, a subsequent filtered lookup is answered from that cache without evaluating its patterns.

**Symptom:** After `Server.start()` made registry settings reachable from `application.yml` in #8187, the filters configured in YAML are read successfully but then silently ignored here.

This was discovered in #8169:

```java
@Test
public void testIgnoredInterfacesAreAppliedAfterDefaultAddressIsCached() {
    assertThat(NetUtil.getLocalAddress()).isNotNull();
    assertThat(NetUtil.getIgnoredInterfacesLocalAddress(new String[] {".*"})).isNull();
}
```

```text
expected: null
 but was: /192.168.124.25
```

## Change

Keep caching only for semantically unfiltered lookups. A call with non-empty `ignoredInterfaces` or `preferredNetworks` resolves through `getLocalAddress0(...)` without reading or overwriting the default cache:

```java
if (CollectionUtils.isEmpty(ignoredInterfaces) && CollectionUtils.isEmpty(preferredNetworks)) {
    if (LOCAL_ADDRESS != null) {
        return LOCAL_ADDRESS;
    }
    InetAddress localAddress = getLocalAddress0(ignoredInterfaces, preferredNetworks);
    LOCAL_ADDRESS = localAddress;
    return localAddress;
}
return getLocalAddress0(ignoredInterfaces, preferredNetworks);
```

`getLocalAddress()` and `getLocalIp()` (no arguments → both `null`) remain cached. `Server.start()` performs its filtered lookup once at startup, so no hot path loses caching.

The global cache predates the ignored-interface support added in #8090, and the early return was never conditioned on whether the supplied parameters matched the cached call's parameters.

## Tests

Three new cases in `NetUtilTest`:

- **`testIgnoredInterfacesAreAppliedAfterDefaultAddressIsCached`** — the pattern `.*` matches every interface, so the result is `null` rather than the cached address. **Fails before this change.**
- **`testPreferredNetworksAreAppliedAfterDefaultAddressIsCached`** — the same early return bypassed `preferredNetworks`. Ignoring every interface through the preferred-network path also yields no candidate, so the result is `null`. **Fails before this change.**
- **`testUnfilteredLookupRemainsCached`** — the unfiltered lookup keeps returning the same cached instance (no regression).

Both failing tests demonstrate the bug from #8169 and confirm the fix. Existing tests in the same file only assert non-null results and do not verify that the supplied rules affect selection, which is why the bug was not caught earlier.

Verified:
- All 33 tests in `NetUtilTest` pass.
- All 693 tests in the `common` module pass.
- `spotless:check` and `checkstyle:check` pass on the `common` module.

## Checklist

- [x] **Check Ahead**
  - [x] I have searched the [issues](https://github.com/apache/incubator-seata/issues) of this repository and believe that this is not a duplicate.
  - [x] I am willing to try to fix this bug myself.
- [ ] I have added the change log of the current PR to [changes/en-us/2.x.md](https://github.com/apache/incubator-seata/blob/2.x/changes/en-us/2.x.md) and [changes/zh-cn/2.x.md](https://github.com/apache/incubator-seata/blob/2.x/changes/zh-cn/2.x.md). *(Will add once the PR number is assigned.)*
- [x] I have passed all the tests locally.
- [x] I have added the unit test for my change.
