### PR TITLE
optimize: merge channel availability log output and adjust log level

### DIFF
--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -251,17 +251,21 @@ class NettyClientChannelManager {
                 }
             }
             if (failedMap.size() > 0) {
+                // Merge all failed addresses into a single log entry to avoid flooding logs.
+                // info level: output summary without stack traces
                 if (LOGGER.isInfoEnabled()) {
-                    LOGGER.error(
+                    LOGGER.info(
                             "{} can not connect to {} cause:{}",
                             FrameworkErrorCode.NetConnect.getErrCode(),
                             failedMap.keySet(),
                             failedMap.values().stream()
                                     .map(Throwable::getMessage)
                                     .collect(Collectors.toSet()));
-                } else if (LOGGER.isDebugEnabled()) {
+                }
+                // debug level: output detailed stack traces for each failed address
+                if (LOGGER.isDebugEnabled()) {
                     failedMap.forEach((key, value) -> {
-                        LOGGER.error(
+                        LOGGER.debug(
                                 "{} can not connect to {} cause:{} trace information:",
                                 FrameworkErrorCode.NetConnect.getErrCode(),
                                 key,


### PR DESCRIPTION
## What this PR does

Optimizes the channel availability thread log output in `NettyClientChannelManager`.

### Changes

1. **info level: no stack traces** — Changed `LOGGER.error()` to `LOGGER.info()` for the summary log, which outputs all failed addresses in a single entry without stack traces.
2. **debug level: detailed stack traces** — Changed `LOGGER.error()` to `LOGGER.debug()` for per-address detailed logs with full stack traces.
3. **Merged output** — All failed addresses are output in one log entry at info level (using `failedMap.keySet()`), instead of one log per failed address.
4. **Independent log levels** — Changed `else if` to two independent `if` blocks, so info and debug levels work independently rather than being mutually exclusive.

### Issue Link

Fixes #5474

### Before

- `LOGGER.isInfoEnabled()` → `LOGGER.error()` (wrong level, outputs error-level logs when info is enabled)
- `else if LOGGER.isDebugEnabled()` → `LOGGER.error()` (only reached when info is disabled)
- Log level mismatch: info branch uses error, debug branch uses error

### After

- `LOGGER.isInfoEnabled()` → `LOGGER.info()` (summary, no stack traces)
- `LOGGER.isDebugEnabled()` → `LOGGER.debug()` (per-address detailed stack traces)
- Both levels work independently

### Checklist

- [x] I have searched the [issues](https://github.com/apache/incubator-seata/issues) of this repository and believe that this is not a duplicate.
- [x] I have checked that this modification does not cause CI to fail.
- [x] I will sign the Apache CLA if required.