### PR TITLE
optimize: park merge send thread when idle to avoid 1ms polling CPU spin

### DIFF
--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -587,6 +587,20 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
             while (true) {
                 mergeLock.lock();
                 try {
+                    // Park until there are pending messages, so the merge thread no longer
+                    // burns CPU with a 1ms polling cycle when idle. The check-and-wait is
+                    // atomic under mergeLock and producers offer to the basket before
+                    // signalling (see sendSyncRequest), so no wake-up can be lost.
+                    while (isBasketEmpty()) {
+                        isSending = false;
+                        mergeCondition.await();
+                    }
+                    isSending = true;
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("merge send thread woken up with pending messages");
+                    }
+                    // Keep the original 1ms merge window, so messages arriving within this
+                    // window are still batched into a single request as before.
                     mergeCondition.await(MAX_MERGE_SEND_MILLS, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -637,6 +651,21 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
                 });
                 isSending = false;
             }
+        }
+
+        /**
+         * Checks whether all baskets are empty. The merge thread parks itself
+         * when this returns true, avoiding the idle 1ms polling busy loop.
+         *
+         * @return true if every basket in basketMap is empty
+         */
+        private boolean isBasketEmpty() {
+            for (BlockingQueue<RpcMessage> basket : basketMap.values()) {
+                if (!basket.isEmpty()) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         private void printMergeMessageLog(MergedWarpMessage mergeMessage) {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -82,7 +82,6 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
     private static final String MSG_ID_PREFIX = "msgId:";
     private static final String FUTURES_PREFIX = "futures:";
     private static final String SINGLE_LOG_POSTFIX = ";";
-    private static final int MAX_MERGE_SEND_MILLS = 1;
     private static final String THREAD_PREFIX_SPLIT_CHAR = "_";
     private static final int MAX_MERGE_SEND_THREAD = 1;
     private static final long KEEP_ALIVE_TIME = Integer.MAX_VALUE;
@@ -596,12 +595,6 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
                         mergeCondition.await();
                     }
                     isSending = true;
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("merge send thread woken up with pending messages");
-                    }
-                    // Keep the original 1ms merge window, so messages arriving within this
-                    // window are still batched into a single request as before.
-                    mergeCondition.await(MAX_MERGE_SEND_MILLS, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     LOGGER.warn("MergedSendRunnable wait interrupted", e);

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyRemotingClientBehaviorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyRemotingClientBehaviorTest.java
@@ -1493,12 +1493,13 @@ public class NettyRemotingClientBehaviorTest {
 
             // The merge thread must be parked on Condition.await (WAITING) instead of
             // spinning on a 1ms timed wait (TIMED_WAITING) when idle
-            for (Map.Entry<Thread, StackTraceElement[]> entry : Thread.getAllStackTraces().entrySet()) {
+            for (Map.Entry<Thread, StackTraceElement[]> entry :
+                    Thread.getAllStackTraces().entrySet()) {
                 Thread thread = entry.getKey();
                 if (thread.getName().startsWith("rpcMergeMessageSend")) {
-                    assertFalse(Thread.State.TIMED_WAITING == thread.getState(),
-                            "merge send thread should not spin on a 1ms timed wait when idle: "
-                                    + thread.getName());
+                    assertFalse(
+                            Thread.State.TIMED_WAITING == thread.getState(),
+                            "merge send thread should not spin on a 1ms timed wait when idle: " + thread.getName());
                 }
             }
 
@@ -1513,7 +1514,8 @@ public class NettyRemotingClientBehaviorTest {
             }
 
             Thread.sleep(300);
-            assertTrue(mergeClient.basketMap.values().stream().allMatch(BlockingQueue::isEmpty),
+            assertTrue(
+                    mergeClient.basketMap.values().stream().allMatch(BlockingQueue::isEmpty),
                     "basket should be drained by the merge send thread after wake-up");
         } finally {
             try {

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyRemotingClientBehaviorTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyRemotingClientBehaviorTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -1476,6 +1477,50 @@ public class NettyRemotingClientBehaviorTest {
 
         } finally {
             mergeClient.destroy();
+        }
+    }
+
+    @Test
+    public void testMergedSendRunnableIdleWaitState() throws Exception {
+        TestNettyRemotingClientWithMergeRunnable mergeClient =
+                new TestNettyRemotingClientWithMergeRunnable(clientConfig, messageExecutor);
+
+        try {
+            mergeClient.init();
+
+            // Wait for the merge send thread to start and park itself
+            Thread.sleep(300);
+
+            // The merge thread must be parked on Condition.await (WAITING) instead of
+            // spinning on a 1ms timed wait (TIMED_WAITING) when idle
+            for (Map.Entry<Thread, StackTraceElement[]> entry : Thread.getAllStackTraces().entrySet()) {
+                Thread thread = entry.getKey();
+                if (thread.getName().startsWith("rpcMergeMessageSend")) {
+                    assertFalse(Thread.State.TIMED_WAITING == thread.getState(),
+                            "merge send thread should not spin on a 1ms timed wait when idle: "
+                                    + thread.getName());
+                }
+            }
+
+            // A message must wake the thread and get drained from the basket
+            GlobalBeginRequest request = new GlobalBeginRequest();
+            request.setTransactionName("test-tx-idle-wake");
+            try {
+                mergeClient.sendSyncRequest(request);
+            } catch (Exception e) {
+                // Expected: no real server at 127.0.0.1:8080, the merge thread
+                // drains the basket and fast-fails the future
+            }
+
+            Thread.sleep(300);
+            assertTrue(mergeClient.basketMap.values().stream().allMatch(BlockingQueue::isEmpty),
+                    "basket should be drained by the merge send thread after wake-up");
+        } finally {
+            try {
+                mergeClient.destroy();
+            } catch (Exception e) {
+                // Ignore
+            }
         }
     }
 


### PR DESCRIPTION




Fixes #6041

## Problem

`MergedSendRunnable` polls every 1ms (`MAX_MERGE_SEND_MILLS = 1`) even when all baskets are empty. With no traffic, the thread wakes up 1000 times per second, each cycle acquiring `mergeLock`, iterating `basketMap` and going back to sleep. Issue #6041 reported this at ~30% CPU per thread (thread dump shows the `rpcMergeMessageSend_*_1` threads in `TIMED_WAITING`), and it still reproduces on 2.x (RM client enables batch send by default: `DEFAULT_ENABLE_RM_CLIENT_BATCH_SEND_REQUEST = true`).

## Solution

When `basketMap` is empty, the merge thread parks on `mergeCondition.await()` (no timeout) instead of a 1ms timed wait. Producers already offer to the basket and then signal (`sendSyncRequest`), so the parked thread is woken up as soon as a message arrives and drains the basket immediately.

About the removed 1ms timed wait:
- The offer-then-signal path has existed since the early implementation (the merge thread predates `AbstractRpcRemotingClient`; see the history of `AbstractNettyRemotingClient.java`, e.g. PR #1105 and PR #1966) — `sendSyncRequest` always signals when the merge thread is not sending.
- funky-eyes pointed out the same idea in issue #6041: the signal from `sendSyncRequest` is enough to wake the thread, so a timed wait is not required for correctness.
- The 1ms wait therefore acted as a fallback poll on top of the signal path; keeping it after the park adds a >=1ms floor to the first message after an idle period without buying meaningful batching (see measurements below).

### Race safety

- The check-and-wait is atomic: `isBasketEmpty()` is evaluated and `await()` is entered while holding `mergeLock`.
- Producers offer to the basket *before* acquiring `mergeLock` and signalling (unchanged code), so a message can never sit in the basket with the merge thread parked indefinitely: either the producer's signal wakes the parked thread, or the producer sees `isSending == true` and the thread is already in the send loop which drains the basket on the next iteration.
- No lost wake-up: a producer can only signal after the thread has parked (`Condition.await` releases the lock atomically), and the empty-check is re-evaluated inside the `while` loop.

## Measurements

Measured locally with an instrumented test client (basket-level offer/poll instrumentation, no network needed) across three variants. Thread CPU time via `ThreadMXBean.getThreadCpuTime` over a 10s idle window; batch sizes over 10 rounds of a 4x25 concurrent burst.

| variant | idle CPU (10s window) | first-message drain latency | batch size (avg / max) |
|---|---|---|---|
| original (1ms poll) | 31ms (0.312%), TIMED_WAITING | 0.17 - 6.2ms | 21.3 / 95 |
| park + 1ms await | 0ms (0.000%), WAITING | 1.4 - 15.3ms | 83.3 / 100 |
| park + immediate drain (this PR) | 0ms (0.000%), WAITING | 0.09 - 0.21ms | 50.0 / 100 |

The absolute idle-CPU ratio depends on the machine and CPU quota (issue #6041 measured ~30% in a constrained container). The relevant comparison is original > 0 vs this PR = 0. The "park + 1ms await" variant shows the >=1ms latency floor that this change removes, while batching does not regress vs the original.

## Tests

- Added `testMergedSendRunnableIdleWaitState`: asserts the `rpcMergeMessageSend` thread is NOT in `TIMED_WAITING` after 300ms idle, then submits a request and verifies the basket is drained.
- Full `NettyRemotingClientBehaviorTest`: 69 tests, 0 failures.
