### PR TITLE
optimize: exclude frontend Node runtime from console sources jar

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -41,6 +41,7 @@ Add changes here for all PR submitted to the 2.x branch.
 ### optimize:
 - [[#8054](https://github.com/apache/incubator-seata/pull/8054)] console/namingserver modules: spring-boot upgrade to 4.0.6
 - [[#8137](https://github.com/apache/incubator-seata/pull/8137)] server modules: spring-boot upgrade to 4.0.6
+- [[#8207](https://github.com/apache/incubator-seata/pull/8207)] exclude frontend Node runtime from seata-console sources jar
 
 
 ### security:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -41,6 +41,7 @@
 ### optimize:
 - [[#8054](https://github.com/apache/incubator-seata/pull/8054)] console/namingserver 模块: spring-boot 升级到 4.0.6
 - [[#8137](https://github.com/apache/incubator-seata/pull/8137)] server 模块: spring-boot 升级到 4.0.6
+- [[#8207](https://github.com/apache/incubator-seata/pull/8207)] 排除前端 Node 运行时目录，减小 seata-console sources jar 体积
 
 
 ### security:

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -244,7 +244,7 @@
                 <directory>src/main/resources</directory>
                 <excludes>
                     <exclude>**/node_modules/**</exclude>
-                    <exclude>static/console-fe</exclude>
+                    <exclude>static/console-fe/node/**</exclude>
                 </excludes>
             </resource>
         </resources>


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did

Optimize the Maven resource exclusion rules in the `console` module so that the Node runtime directory installed during the frontend build is no longer packaged into the sources jar.

<img width="2092" height="1230" alt="image" src="https://github.com/user-attachments/assets/5f527055-1c8b-4710-bb1e-35dfb35217d0" />

The change is located in `console/pom.xml`:

```diff
 <resources>
     <resource>
         <directory>src/main/resources</directory>
         <excludes>
             <exclude>**/node_modules/**</exclude>
-            <exclude>static/console-fe</exclude>
+            <exclude>static/console-fe/node/**</exclude>
         </excludes>
     </resource>
 </resources>
```

Effect:

- Before the change: `console/target/seata-console-2.8.0-SNAPSHOT-sources.jar` is about **32M**.
    
    <img width="1442" height="376" alt="img_4" src="https://github.com/user-attachments/assets/3acdb7b4-acf4-4793-ad7f-5af20cd53259" />

- After the change: `console/target/seata-console-2.8.0-SNAPSHOT-sources.jar` is about **4.6M**.

    <img width="1460" height="354" alt="img_6" src="https://github.com/user-attachments/assets/f4cbc00a-8781-4787-bc9d-40ed2bdb1375" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
Yes, fixes https://github.com/apache/incubator-seata/issues/8206


### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This is a Maven build resource configuration change. It does not affect Java business logic or runtime behavior, so no unit tests or integration tests are needed. Correctness can be verified by rebuilding and inspecting the contents of the generated sources jar.

### Ⅳ. Describe how to verify it

1. Build the `console` module:

   ```bash
   mvn -pl console package -DskipTests -am
   ```

2. Check the sources jar size:

   ```bash
   ls -lh console/target/seata-console-2.8.0-SNAPSHOT-sources.jar
   ```

   The expected size is about 4.6M instead of about 32M.

3. Confirm that the Node runtime directory is no longer packaged:

   ```bash
   jar tf console/target/seata-console-2.8.0-SNAPSHOT-sources.jar | grep '^static/console-fe/node/'
   ```

   Expected output: none.

4. Confirm that frontend source/build directories are still retained as expected (if necessary):

   ```bash
   jar tf console/target/seata-console-2.8.0-SNAPSHOT-sources.jar | grep '^static/console-fe/'
   ```

### Ⅴ. Special notes for reviews


- `frontend-maven-plugin` installs Node into `src/main/resources/static/console-fe/node`. That directory is only used for the frontend build and should not be included in the sources jar.
- `**/node_modules/**` already covers the npm dependency directory. This change only adds an exclusion for the Node runtime directory and avoids affecting other `console-fe` contents.
- The Node binary size and compression result may vary slightly across platforms. When reviewing, please rely on inspecting the jar contents rather than only comparing exact byte counts.
