### PR TITLE
refactor(file): introduce pluggable file store runtime

### DIFF
--- a/common/src/main/java/org/apache/seata/common/ConfigurationKeys.java
+++ b/common/src/main/java/org/apache/seata/common/ConfigurationKeys.java
@@ -139,6 +139,11 @@ public interface ConfigurationKeys {
     String STORE_FILE_DIR = STORE_FILE_PREFIX + "dir";
 
     /**
+     * The constant STORE_FILE_ENGINE
+     */
+    String STORE_FILE_ENGINE = STORE_FILE_PREFIX + "engine";
+
+    /**
      * The constant SERVICE_GROUP_MAPPING_PREFIX.
      */
     String SERVICE_GROUP_MAPPING_PREFIX = SERVICE_PREFIX + "vgroupMapping.";

--- a/server/src/main/java/org/apache/seata/server/console/impl/AbstractService.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/AbstractService.java
@@ -42,8 +42,6 @@ import java.util.stream.Stream;
 public abstract class AbstractService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractService.class);
 
-    protected final LockManager lockManager = LockerManagerFactory.getLockManager();
-
     protected static final List<GlobalStatus> RETRY_COMMIT_STATUS = Arrays.asList(GlobalStatus.CommitRetrying);
 
     protected static final List<GlobalStatus> RETRY_ROLLBACK_STATUS = Arrays.asList(
@@ -73,6 +71,10 @@ public abstract class AbstractService {
 
     protected static final List<GlobalStatus> FINISH_STATUS =
             Arrays.asList(GlobalStatus.Committed, GlobalStatus.Finished, GlobalStatus.Rollbacked);
+
+    protected LockManager getLockManager() {
+        return LockerManagerFactory.getLockManager();
+    }
 
     protected void commonCheck(String xid, String branchId) {
         if (StringUtils.isBlank(xid)) {

--- a/server/src/main/java/org/apache/seata/server/console/impl/file/GlobalLockFileServiceImpl.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/file/GlobalLockFileServiceImpl.java
@@ -95,7 +95,7 @@ public class GlobalLockFileServiceImpl extends AbstractLockService implements Gl
                                 "delete global lock," + "xid:%s ,branchId:%s", param.getXid(), param.getBranchId()));
             }
             try {
-                lockManager.releaseLock(branchSessions.get(0));
+                getLockManager().releaseLock(branchSessions.get(0));
             } catch (TransactionException e) {
                 throw new ConsoleException(
                         e,

--- a/server/src/main/java/org/apache/seata/server/console/impl/redis/GlobalLockRedisServiceImpl.java
+++ b/server/src/main/java/org/apache/seata/server/console/impl/redis/GlobalLockRedisServiceImpl.java
@@ -96,7 +96,7 @@ public class GlobalLockRedisServiceImpl extends AbstractLockService implements G
         branchSession.setXid(param.getXid());
         branchSession.setBranchId(Long.parseLong(param.getBranchId()));
         try {
-            lockManager.releaseLock(branchSession);
+            getLockManager().releaseLock(branchSession);
         } catch (TransactionException e) {
             throw new ConsoleException(
                     e,

--- a/server/src/main/java/org/apache/seata/server/coordinator/AbstractCore.java
+++ b/server/src/main/java/org/apache/seata/server/coordinator/AbstractCore.java
@@ -34,8 +34,6 @@ import org.apache.seata.core.protocol.transaction.BranchCommitResponse;
 import org.apache.seata.core.protocol.transaction.BranchRollbackRequest;
 import org.apache.seata.core.protocol.transaction.BranchRollbackResponse;
 import org.apache.seata.core.rpc.RemotingServer;
-import org.apache.seata.server.lock.LockManager;
-import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHelper;
@@ -61,8 +59,6 @@ import static org.apache.seata.core.exception.TransactionExceptionCode.GlobalTra
 public abstract class AbstractCore implements Core {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractCore.class);
-
-    protected LockManager lockManager = LockerManagerFactory.getLockManager();
 
     private static final Configuration CONFIG = ConfigurationFactory.getInstance();
     private int appDataErrSize;

--- a/server/src/main/java/org/apache/seata/server/lock/LockerManagerFactory.java
+++ b/server/src/main/java/org/apache/seata/server/lock/LockerManagerFactory.java
@@ -16,11 +16,9 @@
  */
 package org.apache.seata.server.lock;
 
+import org.apache.seata.common.exception.StoreException;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.common.store.LockMode;
-import org.apache.seata.common.store.StoreMode;
-import org.apache.seata.config.Configuration;
-import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.server.store.StoreConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +30,6 @@ import org.slf4j.LoggerFactory;
 public class LockerManagerFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LockerManagerFactory.class);
-    private static final Configuration CONFIG = ConfigurationFactory.getInstance();
 
     /**
      * the lock manager
@@ -49,28 +46,62 @@ public class LockerManagerFactory {
         return LOCK_MANAGER;
     }
 
-    public static void init() {
-        init(null);
+    public static boolean init() {
+        return init(null);
     }
 
     public static void destroy() {
         LOCK_MANAGER = null;
     }
 
-    public static void init(LockMode lockMode) {
-        if (LOCK_MANAGER == null) {
-            synchronized (LockerManagerFactory.class) {
-                if (LOCK_MANAGER == null) {
-                    if (null == lockMode) {
-                        lockMode = StoreConfig.getLockMode();
-                    }
-                    LOGGER.info("use lock store mode: {}", lockMode.getName());
-                    // if not exist the lock mode, throw exception
-                    if (null != StoreMode.get(lockMode.name())) {
-                        LOCK_MANAGER = EnhancedServiceLoader.load(LockManager.class, lockMode.getName());
-                    }
-                }
+    public static boolean init(LockMode lockMode) {
+        if (LOCK_MANAGER != null) {
+            return false;
+        }
+        synchronized (LockerManagerFactory.class) {
+            if (LOCK_MANAGER != null) {
+                return false;
             }
+            if (null == lockMode) {
+                lockMode = StoreConfig.getLockMode();
+            }
+            if (LockMode.FILE == lockMode) {
+                throw new StoreException("FileMode lock manager must be installed by FileStoreRuntime before use");
+            }
+            LOGGER.info("use lock store mode: {}", lockMode.getName());
+            LOCK_MANAGER = EnhancedServiceLoader.load(LockManager.class, lockMode.getName());
+            return true;
+        }
+    }
+
+    public static boolean init(LockMode lockMode, Class<?>[] argumentTypes, Object[] arguments) {
+        if (argumentTypes == null || arguments == null) {
+            throw new IllegalArgumentException("argumentTypes and arguments must not be null");
+        }
+        if (argumentTypes.length != arguments.length) {
+            throw new IllegalArgumentException("argumentTypes and arguments must have the same length");
+        }
+        LockMode resolvedLockMode = lockMode == null ? StoreConfig.getLockMode() : lockMode;
+        if (LOCK_MANAGER != null) {
+            rejectExistingTypedFileManager(resolvedLockMode);
+            return false;
+        }
+        synchronized (LockerManagerFactory.class) {
+            if (LOCK_MANAGER != null) {
+                rejectExistingTypedFileManager(resolvedLockMode);
+                return false;
+            }
+            LOGGER.info("use lock store mode: {}", resolvedLockMode.getName());
+            LOCK_MANAGER =
+                    EnhancedServiceLoader.load(LockManager.class, resolvedLockMode.getName(), argumentTypes, arguments);
+            return true;
+        }
+    }
+
+    private static void rejectExistingTypedFileManager(LockMode lockMode) {
+        if (LockMode.FILE == lockMode) {
+            throw new StoreException(
+                    "FileMode lock manager is already installed; refusing to replace its FileLockStore binding");
         }
     }
 }

--- a/server/src/main/java/org/apache/seata/server/session/BranchSession.java
+++ b/server/src/main/java/org/apache/seata/server/session/BranchSession.java
@@ -23,7 +23,6 @@ import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.core.model.BranchType;
 import org.apache.seata.core.model.LockStatus;
 import org.apache.seata.server.cluster.raft.RaftServerManager;
-import org.apache.seata.server.lock.LockManager;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.storage.file.lock.FileLocker;
 import org.apache.seata.server.store.SessionStorable;
@@ -76,8 +75,6 @@ public class BranchSession implements Lockable, Comparable<BranchSession>, Sessi
     private LockStatus lockStatus = Locked;
 
     private final Map<FileLocker.BucketLockMap, Set<String>> lockHolder;
-
-    private final LockManager lockManager = LockerManagerFactory.getLockManager();
 
     public BranchSession() {
         lockHolder = new ConcurrentHashMap<>(2);
@@ -298,7 +295,7 @@ public class BranchSession implements Lockable, Comparable<BranchSession>, Sessi
 
     public boolean lock(boolean autoCommit, boolean skipCheckLock) throws TransactionException {
         if (this.branchType.equals(BranchType.AT)) {
-            return lockManager.acquireLock(this, autoCommit, skipCheckLock);
+            return LockerManagerFactory.getLockManager().acquireLock(this, autoCommit, skipCheckLock);
         }
         return true;
     }
@@ -306,7 +303,7 @@ public class BranchSession implements Lockable, Comparable<BranchSession>, Sessi
     @Override
     public boolean unlock() throws TransactionException {
         if (this.branchType == BranchType.AT) {
-            return lockManager.releaseLock(this);
+            return LockerManagerFactory.getLockManager().releaseLock(this);
         }
         return true;
     }

--- a/server/src/main/java/org/apache/seata/server/session/SessionHelper.java
+++ b/server/src/main/java/org/apache/seata/server/session/SessionHelper.java
@@ -68,11 +68,6 @@ public class SessionHelper {
 
     private static final String GROUP = CONFIG.getConfig(ConfigurationKeys.SERVER_RAFT_GROUP, DEFAULT_SEATA_GROUP);
 
-    /**
-     * The instance of DefaultCoordinator
-     */
-    private static final DefaultCoordinator COORDINATOR = DefaultCoordinator.getInstance();
-
     private static final boolean DELAY_HANDLE_SESSION = !(Objects.equals(StoreConfig.getSessionMode(), SessionMode.FILE)
             || Objects.equals(StoreConfig.getSessionMode(), SessionMode.RAFT));
 
@@ -439,7 +434,7 @@ public class SessionHelper {
             throws TransactionException {
         globalSession.unlockBranch(branchSession);
         if (isEnableBranchRemoveAsync() && isAsync) {
-            COORDINATOR.doBranchRemoveAsync(globalSession, branchSession);
+            DefaultCoordinator.getInstance().doBranchRemoveAsync(globalSession, branchSession);
         } else {
             globalSession.removeBranch(branchSession);
         }
@@ -464,7 +459,7 @@ public class SessionHelper {
             }
         }
         if (isAsyncRemove) {
-            COORDINATOR.doBranchRemoveAllAsync(globalSession);
+            DefaultCoordinator.getInstance().doBranchRemoveAllAsync(globalSession);
         }
     }
 

--- a/server/src/main/java/org/apache/seata/server/session/SessionHolder.java
+++ b/server/src/main/java/org/apache/seata/server/session/SessionHolder.java
@@ -21,6 +21,7 @@ import org.apache.seata.common.XID;
 import org.apache.seata.common.exception.ShouldNeverHappenException;
 import org.apache.seata.common.exception.StoreException;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.common.store.LockMode;
 import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.common.util.StringUtils;
@@ -33,13 +34,21 @@ import org.apache.seata.core.store.DistributedLockDO;
 import org.apache.seata.core.store.DistributedLocker;
 import org.apache.seata.server.cluster.raft.RaftServerManager;
 import org.apache.seata.server.cluster.raft.context.SeataClusterContext;
+import org.apache.seata.server.lock.LockManager;
+import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.lock.distributed.DistributedLockerFactory;
+import org.apache.seata.server.storage.file.FileStoreProviderFactory;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.file.spi.FileStoreContext;
+import org.apache.seata.server.storage.file.spi.FileStoreProvider;
+import org.apache.seata.server.storage.file.spi.FileStoreRuntime;
 import org.apache.seata.server.store.StoreConfig;
 import org.apache.seata.server.store.VGroupMappingStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -87,6 +96,8 @@ public class SessionHolder {
 
     private static DistributedLocker DISTRIBUTED_LOCKER;
 
+    private static volatile FileStoreRuntime FILE_STORE_RUNTIME;
+
     public static void init() {
         init(null);
     }
@@ -102,6 +113,35 @@ public class SessionHolder {
             sessionMode = StoreConfig.getSessionMode();
         }
         LOGGER.info("use session store mode: {}", sessionMode.getName());
+        LockMode lockMode = StoreConfig.getLockMode();
+        boolean fileSessionMode = SessionMode.FILE.equals(sessionMode);
+        boolean fileLockMode = LockMode.FILE.equals(lockMode);
+        if (fileSessionMode != fileLockMode) {
+            String message = fileSessionMode
+                    ? "file session mode must use file lock mode"
+                    : "file lock mode must use file session mode";
+            throw new StoreException(message);
+        }
+        if (!fileSessionMode) {
+            initLegacyMode(sessionMode);
+            return;
+        }
+
+        FileStoreRuntime runtime = null;
+        boolean lockManagerInstalled = false;
+        try {
+            runtime = openFileStoreRuntime();
+            FILE_STORE_RUNTIME = runtime;
+            lockManagerInstalled = LockerManagerFactory.init(
+                    LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {runtime.lockStore()});
+            initFileMode(runtime);
+        } catch (RuntimeException | Error startupFailure) {
+            rollbackFailedFileInitialization(startupFailure, runtime, lockManagerInstalled);
+            throw startupFailure;
+        }
+    }
+
+    private static void initLegacyMode(SessionMode sessionMode) {
         DISTRIBUTED_LOCKER = DistributedLockerFactory.getDistributedLocker(sessionMode.getName());
         if (SessionMode.DB.equals(sessionMode)) {
             ROOT_SESSION_MANAGER = EnhancedServiceLoader.load(SessionManager.class, SessionMode.DB.getName());
@@ -109,44 +149,16 @@ public class SessionHolder {
 
             ROOT_VGROUP_MAPPING_MANAGER =
                     EnhancedServiceLoader.load(VGroupMappingStoreManager.class, SessionMode.DB.getName());
-        } else if (SessionMode.RAFT.equals(sessionMode) || SessionMode.FILE.equals(sessionMode)) {
-            if (SessionMode.RAFT.equals(sessionMode)) {
-                String group = CONFIG.getConfig(ConfigurationKeys.SERVER_RAFT_GROUP, DEFAULT_SEATA_GROUP);
-                ROOT_SESSION_MANAGER = EnhancedServiceLoader.load(
-                        SessionManager.class, SessionMode.RAFT.getName(), new Object[] {ROOT_SESSION_MANAGER_NAME});
-                SESSION_MANAGER_MAP = new HashMap<>();
-                SESSION_MANAGER_MAP.put(group, ROOT_SESSION_MANAGER);
-                ROOT_VGROUP_MAPPING_MANAGER =
-                        EnhancedServiceLoader.load(VGroupMappingStoreManager.class, SessionMode.RAFT.getName());
-                RaftServerManager.init();
-                RaftServerManager.start();
-            } else {
-                String vGroupMappingStorePath =
-                        CONFIG.getConfig(ConfigurationKeys.STORE_FILE_DIR, DEFAULT_VGROUP_MAPPING_STORE_FILE_DIR)
-                                + separator
-                                + XID.getPort();
-                String sessionStorePath =
-                        CONFIG.getConfig(ConfigurationKeys.STORE_FILE_DIR, DEFAULT_SESSION_STORE_FILE_DIR)
-                                + separator
-                                + XID.getPort();
-                if (StringUtils.isBlank(sessionStorePath) || StringUtils.isBlank(vGroupMappingStorePath)) {
-                    throw new StoreException("the {store.file.dir} is empty.");
-                }
-                ROOT_VGROUP_MAPPING_MANAGER = EnhancedServiceLoader.load(
-                        VGroupMappingStoreManager.class,
-                        SessionMode.FILE.getName(),
-                        new Object[] {vGroupMappingStorePath});
-
-                ROOT_SESSION_MANAGER =
-                        EnhancedServiceLoader.load(SessionManager.class, SessionMode.FILE.getName(), new Object[] {
-                            ROOT_SESSION_MANAGER_NAME, sessionStorePath
-                        });
-                ROOT_SESSION_MANAGER =
-                        EnhancedServiceLoader.load(SessionManager.class, SessionMode.FILE.getName(), new Object[] {
-                            ROOT_SESSION_MANAGER_NAME, sessionStorePath
-                        });
-                reload(sessionMode);
-            }
+        } else if (SessionMode.RAFT.equals(sessionMode)) {
+            String group = CONFIG.getConfig(ConfigurationKeys.SERVER_RAFT_GROUP, DEFAULT_SEATA_GROUP);
+            ROOT_SESSION_MANAGER = EnhancedServiceLoader.load(
+                    SessionManager.class, SessionMode.RAFT.getName(), new Object[] {ROOT_SESSION_MANAGER_NAME});
+            SESSION_MANAGER_MAP = new HashMap<>();
+            SESSION_MANAGER_MAP.put(group, ROOT_SESSION_MANAGER);
+            ROOT_VGROUP_MAPPING_MANAGER =
+                    EnhancedServiceLoader.load(VGroupMappingStoreManager.class, SessionMode.RAFT.getName());
+            RaftServerManager.init();
+            RaftServerManager.start();
         } else if (SessionMode.REDIS.equals(sessionMode)) {
             ROOT_SESSION_MANAGER = EnhancedServiceLoader.load(SessionManager.class, SessionMode.REDIS.getName());
             ROOT_VGROUP_MAPPING_MANAGER =
@@ -158,14 +170,76 @@ public class SessionHolder {
         }
     }
 
+    private static FileStoreRuntime openFileStoreRuntime() {
+        String engineName = StoreConfig.getFileEngineName();
+        FileStoreProvider provider = FileStoreProviderFactory.getProvider(engineName);
+        String sessionStoreDir = CONFIG.getConfig(ConfigurationKeys.STORE_FILE_DIR, DEFAULT_SESSION_STORE_FILE_DIR);
+        if (StringUtils.isBlank(sessionStoreDir)) {
+            throw new StoreException("the {store.file.dir} is empty.");
+        }
+        String sessionStorePath = sessionStoreDir + separator + XID.getPort();
+        return provider.open(new FileStoreContext(ROOT_SESSION_MANAGER_NAME, Paths.get(sessionStorePath)));
+    }
+
+    private static void initFileMode(FileStoreRuntime runtime) {
+        String vGroupMappingStoreDir =
+                CONFIG.getConfig(ConfigurationKeys.STORE_FILE_DIR, DEFAULT_VGROUP_MAPPING_STORE_FILE_DIR);
+        if (StringUtils.isBlank(vGroupMappingStoreDir)) {
+            throw new StoreException("the {store.file.dir} is empty.");
+        }
+        String vGroupMappingStorePath = vGroupMappingStoreDir + separator + XID.getPort();
+        VGroupMappingStoreManager vGroupMappingManager = EnhancedServiceLoader.load(
+                VGroupMappingStoreManager.class, SessionMode.FILE.getName(), new Object[] {vGroupMappingStorePath});
+        DistributedLocker distributedLocker = DistributedLockerFactory.getDistributedLocker(SessionMode.FILE.getName());
+        ROOT_VGROUP_MAPPING_MANAGER = vGroupMappingManager;
+        DISTRIBUTED_LOCKER = distributedLocker;
+        ROOT_SESSION_MANAGER = runtime.sessionManager();
+        runtime.recover(sessions -> reload(sessions, SessionMode.FILE, true, true));
+        runtime.startBackgroundServices();
+    }
+
+    private static void rollbackFailedFileInitialization(
+            Throwable startupFailure, FileStoreRuntime runtime, boolean lockManagerInstalled) {
+        try {
+            if (lockManagerInstalled) {
+                cleanup(startupFailure, LockerManagerFactory::destroy);
+                cleanup(startupFailure, () -> EnhancedServiceLoader.unload(LockManager.class));
+            }
+            cleanup(startupFailure, runtime == null ? null : runtime::close);
+        } finally {
+            clearFileModeReferences();
+        }
+    }
+
+    private static void cleanup(Throwable failure, Runnable action) {
+        if (action == null) {
+            return;
+        }
+        try {
+            action.run();
+        } catch (RuntimeException | Error cleanupFailure) {
+            failure.addSuppressed(cleanupFailure);
+        }
+    }
+
+    private static void clearFileModeReferences() {
+        FILE_STORE_RUNTIME = null;
+        ROOT_SESSION_MANAGER = null;
+        ROOT_VGROUP_MAPPING_MANAGER = null;
+        DISTRIBUTED_LOCKER = null;
+        SESSION_MANAGER_MAP = null;
+    }
+
     /**
      * Reload.
      *
      * @param sessionMode the mode of store
      */
     protected static void reload(SessionMode sessionMode) {
-        if (sessionMode == SessionMode.FILE) {
+        if (sessionMode == SessionMode.FILE && ROOT_SESSION_MANAGER instanceof Reloadable) {
             ((Reloadable) ROOT_SESSION_MANAGER).reload();
+            reload(ROOT_SESSION_MANAGER.allSessions(), sessionMode);
+        } else if (sessionMode == SessionMode.FILE) {
             reload(ROOT_SESSION_MANAGER.allSessions(), sessionMode);
         } else {
             reload(null, sessionMode);
@@ -177,6 +251,11 @@ public class SessionHolder {
     }
 
     public static void reload(Collection<GlobalSession> allSessions, SessionMode storeMode, boolean acquireLock) {
+        reload(allSessions, storeMode, acquireLock, false);
+    }
+
+    private static void reload(
+            Collection<GlobalSession> allSessions, SessionMode storeMode, boolean acquireLock, boolean failFast) {
         if ((SessionMode.FILE == storeMode || SessionMode.RAFT == storeMode)
                 && CollectionUtils.isNotEmpty(allSessions)) {
             long currentTimeMillis = System.currentTimeMillis();
@@ -192,6 +271,7 @@ public class SessionHolder {
                                     "Could not handle the global session, xid: {},error: {}",
                                     globalSession.getXid(),
                                     e.getMessage());
+                            throwIfFileModeStartupReloadFailed(globalSession, e, failFast);
                         }
                         break;
                     case Committed:
@@ -202,6 +282,7 @@ public class SessionHolder {
                                     "Could not handle the global session, xid: {},error: {}",
                                     globalSession.getXid(),
                                     e.getMessage());
+                            throwIfFileModeStartupReloadFailed(globalSession, e, failFast);
                         }
                         break;
                     case Finished:
@@ -209,7 +290,9 @@ public class SessionHolder {
                     case CommitFailed:
                     case RollbackFailed:
                     case TimeoutRollbackFailed:
-                        removeInErrorState(globalSession);
+                    case CommitRetryTimeout:
+                    case RollbackRetryTimeout:
+                        removeInErrorState(globalSession, failFast);
                         break;
                     case AsyncCommitting:
                     case Committing:
@@ -224,6 +307,7 @@ public class SessionHolder {
                                 throw new RuntimeException(e);
                             }
                         }
+                        break;
                     case StopCommitOrCommitRetry:
                     case StopRollbackOrRollbackRetry:
                     case Deleting:
@@ -302,7 +386,18 @@ public class SessionHolder {
         }
     }
 
+    private static void throwIfFileModeStartupReloadFailed(
+            GlobalSession globalSession, TransactionException cause, boolean failFast) {
+        if (failFast) {
+            throw new StoreException(cause, "FileMode startup reload failed, xid: " + globalSession.getXid());
+        }
+    }
+
     private static void removeInErrorState(GlobalSession globalSession) {
+        removeInErrorState(globalSession, false);
+    }
+
+    private static void removeInErrorState(GlobalSession globalSession, boolean failFast) {
         try {
             LOGGER.warn(
                     "The global session should NOT be {}, remove it. xid = {}",
@@ -321,6 +416,9 @@ public class SessionHolder {
                     globalSession.getXid(),
                     globalSession.getStatus(),
                     e);
+            if (failFast) {
+                throw new StoreException(e, "FileMode startup reload failed, xid: " + globalSession.getXid());
+            }
         }
     }
 
@@ -446,12 +544,63 @@ public class SessionHolder {
         return lock;
     }
 
-    public static void destroy() {
-        RaftServerManager.destroy();
-        if (ROOT_SESSION_MANAGER != null) {
-            ROOT_SESSION_MANAGER.destroy();
+    public static synchronized void destroy() {
+        Throwable failure = null;
+        try {
+            RaftServerManager.destroy();
+        } catch (RuntimeException | Error raftFailure) {
+            failure = raftFailure;
         }
-        SESSION_MANAGER_MAP = null;
+        FileStoreRuntime runtime = FILE_STORE_RUNTIME;
+        if (runtime != null) {
+            try {
+                LockerManagerFactory.destroy();
+            } catch (RuntimeException | Error facadeFailure) {
+                failure = appendFailure(failure, facadeFailure);
+            }
+            try {
+                EnhancedServiceLoader.unload(LockManager.class);
+            } catch (RuntimeException | Error unloadFailure) {
+                failure = appendFailure(failure, unloadFailure);
+            }
+            try {
+                runtime.close();
+            } catch (RuntimeException | Error runtimeFailure) {
+                failure = appendFailure(failure, runtimeFailure);
+            } finally {
+                clearFileModeReferences();
+            }
+        } else {
+            try {
+                if (ROOT_SESSION_MANAGER != null) {
+                    ROOT_SESSION_MANAGER.destroy();
+                }
+            } catch (RuntimeException | Error sessionFailure) {
+                failure = appendFailure(failure, sessionFailure);
+            } finally {
+                SESSION_MANAGER_MAP = null;
+            }
+        }
+        rethrow(failure);
+    }
+
+    private static Throwable appendFailure(Throwable failure, Throwable next) {
+        if (failure == null) {
+            return next;
+        }
+        if (failure != next) {
+            failure.addSuppressed(next);
+        }
+        return failure;
+    }
+
+    private static void rethrow(Throwable failure) {
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
     }
 
     @FunctionalInterface

--- a/server/src/main/java/org/apache/seata/server/session/SessionHolder.java
+++ b/server/src/main/java/org/apache/seata/server/session/SessionHolder.java
@@ -108,7 +108,10 @@ public class SessionHolder {
      * @param sessionMode the store mode: file, db, redis
      * @throws IOException the io exception
      */
-    public static void init(SessionMode sessionMode) {
+    public static synchronized void init(SessionMode sessionMode) {
+        if (FILE_STORE_RUNTIME != null) {
+            throw new StoreException("FileStoreRuntime is already initialized; destroy it before reinitializing");
+        }
         if (null == sessionMode) {
             sessionMode = StoreConfig.getSessionMode();
         }

--- a/server/src/main/java/org/apache/seata/server/session/SessionHolder.java
+++ b/server/src/main/java/org/apache/seata/server/session/SessionHolder.java
@@ -293,8 +293,6 @@ public class SessionHolder {
                     case CommitFailed:
                     case RollbackFailed:
                     case TimeoutRollbackFailed:
-                    case CommitRetryTimeout:
-                    case RollbackRetryTimeout:
                         removeInErrorState(globalSession, failFast);
                         break;
                     case AsyncCommitting:

--- a/server/src/main/java/org/apache/seata/server/storage/file/DefaultFileStoreProvider.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/DefaultFileStoreProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file;
+
+import org.apache.seata.common.exception.StoreException;
+import org.apache.seata.common.loader.LoadLevel;
+import org.apache.seata.server.storage.file.lock.DefaultFileLockStore;
+import org.apache.seata.server.storage.file.session.FileSessionManager;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.file.spi.FileStoreContext;
+import org.apache.seata.server.storage.file.spi.FileStoreProvider;
+import org.apache.seata.server.storage.file.spi.FileStoreRuntime;
+
+import java.io.IOException;
+
+@LoadLevel(name = "default")
+public class DefaultFileStoreProvider implements FileStoreProvider {
+
+    @Override
+    public FileStoreRuntime open(FileStoreContext context) {
+        FileSessionManager sessionManager = null;
+        try {
+            sessionManager = createSessionManager(context);
+            FileLockStore lockStore = createLockStore();
+            return new DefaultFileStoreRuntime(sessionManager, lockStore);
+        } catch (IOException e) {
+            StoreException failure = new StoreException(e, "open default file store runtime failed");
+            closeSessionManager(sessionManager, failure);
+            throw failure;
+        } catch (RuntimeException | Error failure) {
+            closeSessionManager(sessionManager, failure);
+            throw failure;
+        }
+    }
+
+    protected FileSessionManager createSessionManager(FileStoreContext context) throws IOException {
+        return new FileSessionManager(
+                context.getRootSessionManagerName(),
+                context.getSessionStorePath().toString());
+    }
+
+    protected FileLockStore createLockStore() {
+        return new DefaultFileLockStore();
+    }
+
+    private static void closeSessionManager(FileSessionManager sessionManager, Throwable failure) {
+        if (sessionManager == null) {
+            return;
+        }
+        try {
+            sessionManager.destroy();
+        } catch (RuntimeException | Error cleanupFailure) {
+            failure.addSuppressed(cleanupFailure);
+        }
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/DefaultFileStoreRuntime.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/DefaultFileStoreRuntime.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file;
+
+import org.apache.seata.common.exception.StoreException;
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.server.session.SessionManager;
+import org.apache.seata.server.storage.file.session.FileSessionManager;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.file.spi.FileStoreRuntime;
+import org.apache.seata.server.storage.file.spi.SessionRecoveryConsumer;
+
+public class DefaultFileStoreRuntime implements FileStoreRuntime {
+
+    private final FileSessionManager sessionManager;
+    private final FileLockStore lockStore;
+    private State state = State.OPEN;
+    private boolean recoveryComplete;
+
+    DefaultFileStoreRuntime(FileSessionManager sessionManager, FileLockStore lockStore) {
+        this.sessionManager = sessionManager;
+        this.lockStore = lockStore;
+    }
+
+    @Override
+    public SessionManager sessionManager() {
+        return sessionManager;
+    }
+
+    @Override
+    public FileLockStore lockStore() {
+        return lockStore;
+    }
+
+    @Override
+    public synchronized void recover(SessionRecoveryConsumer recoveryConsumer) {
+        requireOpen();
+        if (recoveryComplete) {
+            throw new IllegalStateException("file store recovery already completed");
+        }
+        sessionManager.reload();
+        try {
+            recoveryConsumer.accept(sessionManager.allSessions());
+            recoveryComplete = true;
+        } catch (TransactionException e) {
+            throw new StoreException(e, "recover default file store sessions failed");
+        }
+    }
+
+    @Override
+    public synchronized void startBackgroundServices() {
+        requireOpen();
+        if (!recoveryComplete) {
+            throw new IllegalStateException("file store recovery must complete before background services start");
+        }
+        state = State.STARTING_BACKGROUND;
+        state = State.RUNNING;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (state == State.CLOSING || state == State.CLOSED) {
+            return;
+        }
+        state = State.CLOSING;
+        try {
+            sessionManager.destroy();
+        } finally {
+            state = State.CLOSED;
+        }
+    }
+
+    private void requireOpen() {
+        if (state != State.OPEN) {
+            throw new IllegalStateException("file store runtime is not open");
+        }
+    }
+
+    private enum State {
+        OPEN,
+        STARTING_BACKGROUND,
+        RUNNING,
+        CLOSING,
+        CLOSED
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/FileStoreProviderFactory.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/FileStoreProviderFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file;
+
+import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.common.util.CollectionUtils;
+import org.apache.seata.common.util.StringUtils;
+import org.apache.seata.server.storage.file.spi.FileStoreProvider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for file-mode storage providers.
+ */
+public final class FileStoreProviderFactory {
+
+    private static final String DEFAULT_PROVIDER = "default";
+    private static final Map<String, FileStoreProvider> INSTANCES = new ConcurrentHashMap<>();
+
+    private FileStoreProviderFactory() {}
+
+    /**
+     * Gets a file-mode storage provider by name.
+     *
+     * @param name the provider name
+     * @return the cached provider instance
+     */
+    public static FileStoreProvider getProvider(String name) {
+        String providerName = StringUtils.isBlank(name) ? DEFAULT_PROVIDER : name;
+        return CollectionUtils.computeIfAbsent(
+                INSTANCES, providerName, key -> EnhancedServiceLoader.load(FileStoreProvider.class, key));
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/lock/DefaultFileLockStore.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/lock/DefaultFileLockStore.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.lock;
+
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.core.lock.Locker;
+import org.apache.seata.server.session.BranchSession;
+import org.apache.seata.server.session.GlobalSession;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import static org.apache.seata.core.context.RootContext.MDC_KEY_BRANCH_ID;
+
+/**
+ * In-memory file lock store.
+ */
+public class DefaultFileLockStore implements FileLockStore {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFileLockStore.class);
+
+    @Override
+    public Locker getLocker(BranchSession branchSession) {
+        return new FileLocker(branchSession);
+    }
+
+    @Override
+    public boolean releaseBranchLock(BranchSession branchSession) throws TransactionException {
+        if (branchSession == null) {
+            throw new IllegalArgumentException("branchSession can't be null for memory/file locker.");
+        }
+        try {
+            return new FileLocker(branchSession).releaseLock();
+        } catch (Exception t) {
+            LOGGER.error("unLock error, branchSession:{}", branchSession, t);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean releaseGlobalLock(GlobalSession globalSession) throws TransactionException {
+        boolean releaseLockResult = true;
+        for (BranchSession branchSession : globalSession.getBranchSessions()) {
+            try {
+                MDC.put(MDC_KEY_BRANCH_ID, String.valueOf(branchSession.getBranchId()));
+                releaseLockResult = releaseBranchLock(branchSession);
+            } finally {
+                MDC.remove(MDC_KEY_BRANCH_ID);
+            }
+        }
+        return releaseLockResult;
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLockManager.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLockManager.java
@@ -17,44 +17,46 @@
 package org.apache.seata.server.storage.file.lock;
 
 import org.apache.seata.common.loader.LoadLevel;
+import org.apache.seata.common.loader.Scope;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.lock.Locker;
 import org.apache.seata.server.lock.AbstractLockManager;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
-import org.apache.seata.server.storage.raft.lock.RaftLockManager;
-import org.slf4j.MDC;
-
-import java.util.List;
-
-import static org.apache.seata.core.context.RootContext.MDC_KEY_BRANCH_ID;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
 
 /**
  * The type file lock manager.
  *
  */
-@LoadLevel(name = "file")
+@LoadLevel(name = "file", scope = Scope.PROTOTYPE)
 public class FileLockManager extends AbstractLockManager {
+
+    private final FileLockStore lockStore;
+
+    protected FileLockManager() {
+        this(new DefaultFileLockStore());
+    }
+
+    public FileLockManager(FileLockStore lockStore) {
+        if (lockStore == null) {
+            throw new IllegalArgumentException("lockStore must not be null");
+        }
+        this.lockStore = lockStore;
+    }
 
     @Override
     public Locker getLocker(BranchSession branchSession) {
-        return new FileLocker(branchSession);
+        return lockStore.getLocker(branchSession);
+    }
+
+    @Override
+    public boolean releaseLock(BranchSession branchSession) throws TransactionException {
+        return lockStore.releaseBranchLock(branchSession);
     }
 
     @Override
     public boolean releaseGlobalSessionLock(GlobalSession globalSession) throws TransactionException {
-        List<BranchSession> branchSessions = globalSession.getBranchSessions();
-        boolean releaseLockResult = true;
-        for (BranchSession branchSession : branchSessions) {
-            try {
-                MDC.put(MDC_KEY_BRANCH_ID, String.valueOf(branchSession.getBranchId()));
-                releaseLockResult = this instanceof RaftLockManager
-                        ? super.releaseLock(branchSession)
-                        : this.releaseLock(branchSession);
-            } finally {
-                MDC.remove(MDC_KEY_BRANCH_ID);
-            }
-        }
-        return releaseLockResult;
+        return lockStore.releaseGlobalLock(globalSession);
     }
 }

--- a/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLocker.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLocker.java
@@ -95,9 +95,7 @@ public class FileLocker extends AbstractLocker {
                 Set<String> keysInHolder = CollectionUtils.computeIfAbsent(
                         bucketHolder, bucketLockMap, key -> ConcurrentHashMap.newKeySet());
                 keysInHolder.add(pk);
-            } else if (previousLockBranchSession.getTransactionId() == transactionId) {
-                // Locked by me before
-            } else {
+            } else if (previousLockBranchSession.getTransactionId() != transactionId) {
                 LOGGER.info(
                         "Global lock on [{}:{}] is holding by xid {} branchId {}",
                         tableName,

--- a/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLocker.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/lock/FileLocker.java
@@ -130,6 +130,15 @@ public class FileLocker extends AbstractLocker {
             // no lock
             return true;
         }
+        return releaseLock();
+    }
+
+    /**
+     * Releases all locks held by this locker's branch session.
+     *
+     * @return whether the locks were released
+     */
+    public boolean releaseLock() {
         Map<BucketLockMap, Set<String>> lockHolder = branchSession.getLockHolder();
         if (CollectionUtils.isEmpty(lockHolder)) {
             return true;

--- a/server/src/main/java/org/apache/seata/server/storage/file/spi/FileLockStore.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/spi/FileLockStore.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.core.lock.Locker;
+import org.apache.seata.server.session.BranchSession;
+import org.apache.seata.server.session.GlobalSession;
+
+/**
+ * Lock storage operations owned by a file-mode runtime.
+ */
+public interface FileLockStore {
+
+    /**
+     * Gets a locker for the supplied branch session.
+     *
+     * @param branchSession the branch session
+     * @return the locker
+     */
+    Locker getLocker(BranchSession branchSession);
+
+    /**
+     * Releases locks owned by a branch session.
+     *
+     * @param branchSession the branch session
+     * @return whether the locks were released
+     * @throws TransactionException if the locks cannot be released
+     */
+    boolean releaseBranchLock(BranchSession branchSession) throws TransactionException;
+
+    /**
+     * Releases locks owned by a global session.
+     *
+     * @param globalSession the global session
+     * @return whether the locks were released
+     * @throws TransactionException if the locks cannot be released
+     */
+    boolean releaseGlobalLock(GlobalSession globalSession) throws TransactionException;
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/spi/FileStoreContext.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/spi/FileStoreContext.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Immutable startup context for a file-mode storage runtime.
+ */
+public final class FileStoreContext {
+
+    private final String rootSessionManagerName;
+    private final Path sessionStorePath;
+
+    public FileStoreContext(String rootSessionManagerName, Path sessionStorePath) {
+        this.rootSessionManagerName = Objects.requireNonNull(rootSessionManagerName, "rootSessionManagerName");
+        this.sessionStorePath = Objects.requireNonNull(sessionStorePath, "sessionStorePath");
+    }
+
+    public String getRootSessionManagerName() {
+        return rootSessionManagerName;
+    }
+
+    public Path getSessionStorePath() {
+        return sessionStorePath;
+    }
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/spi/FileStoreProvider.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/spi/FileStoreProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+/**
+ * Provider for a file-mode storage runtime.
+ */
+public interface FileStoreProvider {
+
+    /**
+     * Opens a new runtime for the supplied context.
+     *
+     * @param context the file store context
+     * @return a distinct file store runtime
+     */
+    FileStoreRuntime open(FileStoreContext context);
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/spi/FileStoreRuntime.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/spi/FileStoreRuntime.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import org.apache.seata.server.session.SessionManager;
+
+/**
+ * Runtime resources for a file-mode storage provider.
+ */
+public interface FileStoreRuntime extends AutoCloseable {
+
+    /**
+     * Gets the session manager owned by this runtime.
+     *
+     * @return the session manager
+     */
+    SessionManager sessionManager();
+
+    /**
+     * Gets the lock store owned by this runtime.
+     *
+     * @return the lock store
+     */
+    FileLockStore lockStore();
+
+    /**
+     * Recovers sessions through the supplied consumer.
+     *
+     * @param recoveryConsumer the recovery consumer
+     */
+    void recover(SessionRecoveryConsumer recoveryConsumer);
+
+    /**
+     * Starts background services owned by this runtime.
+     */
+    void startBackgroundServices();
+
+    /**
+     * Closes resources owned by this runtime.
+     */
+    @Override
+    void close();
+}

--- a/server/src/main/java/org/apache/seata/server/storage/file/spi/SessionRecoveryConsumer.java
+++ b/server/src/main/java/org/apache/seata/server/storage/file/spi/SessionRecoveryConsumer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.server.session.GlobalSession;
+
+import java.util.Collection;
+
+/**
+ * Consumes a session recovered by a file-mode storage runtime.
+ */
+@FunctionalInterface
+public interface SessionRecoveryConsumer {
+
+    /**
+     * Accepts recovered sessions.
+     *
+     * @param sessions the recovered sessions
+     * @throws TransactionException if recovery fails
+     */
+    void accept(Collection<GlobalSession> sessions) throws TransactionException;
+}

--- a/server/src/main/java/org/apache/seata/server/store/StoreConfig.java
+++ b/server/src/main/java/org/apache/seata/server/store/StoreConfig.java
@@ -16,23 +16,26 @@
  */
 package org.apache.seata.server.store;
 
+import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.store.LockMode;
 import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.store.StoreMode;
 import org.apache.seata.common.util.StringUtils;
 import org.apache.seata.config.Configuration;
 import org.apache.seata.config.ConfigurationFactory;
-import org.apache.seata.core.constants.ConfigurationKeys;
 import org.apache.seata.server.env.ContainerHelper;
 import org.apache.seata.server.storage.file.FlushDiskMode;
 
+import java.util.Locale;
+
+import static org.apache.seata.common.ConfigurationKeys.STORE_FILE_PREFIX;
 import static org.apache.seata.common.DefaultValues.SERVER_DEFAULT_STORE_MODE;
-import static org.apache.seata.core.constants.ConfigurationKeys.STORE_FILE_PREFIX;
 
 /**
  */
 public class StoreConfig {
 
+    private static final String DEFAULT_FILE_ENGINE_NAME = "default";
     private static final Configuration CONFIGURATION = ConfigurationFactory.getInstance();
     private static StoreMode storeMode;
     private static SessionMode sessionMode;
@@ -88,6 +91,13 @@ public class StoreConfig {
         return FlushDiskMode.findDiskMode(CONFIGURATION.getConfig(STORE_FILE_PREFIX + "flushDiskMode"));
     }
 
+    public static String getFileEngineName() {
+        String fileEngine = CONFIGURATION.getConfig(ConfigurationKeys.STORE_FILE_ENGINE, DEFAULT_FILE_ENGINE_NAME);
+        return StringUtils.isBlank(fileEngine)
+                ? DEFAULT_FILE_ENGINE_NAME
+                : fileEngine.trim().toLowerCase(Locale.ROOT);
+    }
+
     /**
      * only for inner call
      *
@@ -128,6 +138,15 @@ public class StoreConfig {
     }
 
     public static LockMode getLockMode() {
+        LockMode configuredLockMode = getConfiguredLockMode();
+        if (configuredLockMode != null) {
+            return configuredLockMode;
+        }
+        // complication old config
+        return LockMode.get(getStoreMode().name());
+    }
+
+    private static LockMode getConfiguredLockMode() {
         // startup
         if (null != lockMode) {
             return lockMode;
@@ -142,7 +161,6 @@ public class StoreConfig {
         if (StringUtils.isNotBlank(lockModeConfig)) {
             return LockMode.get(lockModeConfig);
         }
-        // complication old config
-        return LockMode.get(getStoreMode().name());
+        return null;
     }
 }

--- a/server/src/main/java/org/apache/seata/server/transaction/at/ATCore.java
+++ b/server/src/main/java/org/apache/seata/server/transaction/at/ATCore.java
@@ -25,6 +25,7 @@ import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.core.model.BranchType;
 import org.apache.seata.core.rpc.RemotingServer;
 import org.apache.seata.server.coordinator.AbstractCore;
+import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 
@@ -103,7 +104,7 @@ public class ATCore extends AbstractCore {
     @Override
     public boolean lockQuery(BranchType branchType, String resourceId, String xid, String lockKeys)
             throws TransactionException {
-        return lockManager.isLockable(xid, resourceId, lockKeys);
+        return LockerManagerFactory.getLockManager().isLockable(xid, resourceId, lockKeys);
     }
 
     @Override

--- a/server/src/main/resources/META-INF/services/org.apache.seata.server.storage.file.spi.FileStoreProvider
+++ b/server/src/main/resources/META-INF/services/org.apache.seata.server.storage.file.spi.FileStoreProvider
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.seata.server.storage.file.DefaultFileStoreProvider

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -189,6 +189,8 @@ seata:
     lock:
       mode: file
     file:
+      # support: default and other FileStoreProvider implementations
+      engine: default
       dir: sessionStore
       max-branch-session-size: 16384
       max-global-session-size: 512

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -53,5 +53,8 @@ seata:
   store:
     # support: file 、 db 、 redis 、 raft
     mode: file
+    file:
+      # support: default and other FileStoreProvider implementations
+      engine: default
   #  server:
   #    service-port: 8091 #If not configured, the default is '${server.port} + 1000'

--- a/server/src/test/java/org/apache/seata/server/BaseSpringBootTest.java
+++ b/server/src/test/java/org/apache/seata/server/BaseSpringBootTest.java
@@ -26,26 +26,33 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = {"server.port=${random.int[10000,60000]}"})
+import java.io.IOException;
+import java.net.ServerSocket;
+
+@TestPropertySource(properties = {"server.port=${seata.test.server-port}"})
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class BaseSpringBootTest {
 
     @BeforeAll
-    public static void beforeAll() {
+    public static void beforeAll() throws IOException {
         System.setProperty(ConfigurationKeys.SHUTDOWN_WAIT, "1");
         ConfigurationCache.clear();
         System.clearProperty(ConfigurationKeys.SERVER_SERVICE_PORT_CAMEL);
+        try (ServerSocket socket = new ServerSocket(0)) {
+            System.setProperty("seata.test.server-port", String.valueOf(socket.getLocalPort()));
+        }
     }
 
     @AfterAll
     public static void afterAll() {
         ConfigurationCache.clear();
         System.clearProperty(ConfigurationKeys.SERVER_SERVICE_PORT_CAMEL);
+        System.clearProperty("seata.test.server-port");
     }
 
     @AfterEach
-    public void AfterEach() {
+    public void reloadConfigurationAfterEach() {
         ConfigurationFactory.reload();
         System.clearProperty(ConfigurationKeys.SERVER_SERVICE_PORT_CAMEL);
     }

--- a/server/src/test/java/org/apache/seata/server/cluster/raft/RaftServerTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/raft/RaftServerTest.java
@@ -18,15 +18,20 @@ package org.apache.seata.server.cluster.raft;
 
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.XID;
+import org.apache.seata.common.exception.ShouldNeverHappenException;
 import org.apache.seata.common.store.LockMode;
 import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.store.StoreMode;
 import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.config.ConfigurationFactory;
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.core.model.GlobalStatus;
 import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.LockerManagerFactory;
+import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
+import org.apache.seata.server.session.SessionManager;
 import org.apache.seata.server.storage.raft.session.RaftSessionManager;
 import org.apache.seata.server.storage.raft.store.RaftVGroupMappingStoreManager;
 import org.apache.seata.server.store.StoreConfig;
@@ -36,6 +41,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -134,6 +141,25 @@ public class RaftServerTest extends BaseSpringBootTest {
         Assertions.assertNotNull(RaftServerManager.getCliClientServiceInstance());
         Assertions.assertFalse(RaftServerManager.isLeader("default"));
         RaftServerManager.start();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = GlobalStatus.class,
+            names = {"CommitRetryTimeout", "RollbackRetryTimeout"})
+    public void testReloadPreservesRetryTimeoutSession(GlobalStatus status) throws TransactionException {
+        SessionManager sessionManager = SessionHolder.getRootSessionManager();
+        GlobalSession session = new GlobalSession("app", "group", "transaction", 60000);
+        session.setStatus(status);
+        sessionManager.addGlobalSession(session);
+
+        // PR1 keeps the existing recovery policy for records awaiting manual intervention.
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(
+                        ShouldNeverHappenException.class,
+                        () -> SessionHolder.reload(sessionManager.allSessions(), SessionMode.RAFT, false)),
+                () -> Assertions.assertSame(session, sessionManager.findGlobalSession(session.getXid())),
+                () -> Assertions.assertEquals(status, session.getStatus()));
     }
 
     @Test

--- a/server/src/test/java/org/apache/seata/server/cluster/raft/RaftServerTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/raft/RaftServerTest.java
@@ -18,17 +18,28 @@ package org.apache.seata.server.cluster.raft;
 
 import org.apache.seata.common.ConfigurationKeys;
 import org.apache.seata.common.XID;
+import org.apache.seata.common.store.LockMode;
+import org.apache.seata.common.store.SessionMode;
+import org.apache.seata.common.store.StoreMode;
 import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.config.ConfigurationFactory;
 import org.apache.seata.server.BaseSpringBootTest;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.SessionHolder;
+import org.apache.seata.server.storage.raft.session.RaftSessionManager;
+import org.apache.seata.server.storage.raft.store.RaftVGroupMappingStoreManager;
 import org.apache.seata.server.store.StoreConfig;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
 
 import static org.apache.seata.common.ConfigurationKeys.SERVER_RAFT_SSL_CLIENT_KEYSTORE_PATH;
 import static org.apache.seata.common.ConfigurationKeys.SERVER_RAFT_SSL_ENABLED;
@@ -38,22 +49,66 @@ import static org.apache.seata.common.ConfigurationKeys.SERVER_RAFT_SSL_TMF_ALGO
 
 public class RaftServerTest extends BaseSpringBootTest {
 
+    private static StoreMode originalStoreMode;
+    private static SessionMode originalSessionMode;
+    private static LockMode originalLockMode;
+    private static String originalRaftPort;
+    private static String originalRaftServerAddr;
+
     @BeforeAll
     public static void setUp(ApplicationContext context) {
+        originalStoreMode = (StoreMode) ReflectionTestUtils.getField(StoreConfig.class, "storeMode");
+        originalSessionMode = (SessionMode) ReflectionTestUtils.getField(StoreConfig.class, "sessionMode");
+        originalLockMode = (LockMode) ReflectionTestUtils.getField(StoreConfig.class, "lockMode");
+        originalRaftPort = System.getProperty("server.raftPort");
+        originalRaftServerAddr = System.getProperty(ConfigurationKeys.SERVER_RAFT_SERVER_ADDR);
+        DefaultCoordinator.getInstance().destroy();
         LockerManagerFactory.destroy();
-        SessionHolder.destroy();
-        RaftServerManager.destroy();
+    }
+
+    @BeforeEach
+    public void prepareSessionDependencies() throws IOException {
+        System.setProperty("server.raftPort", "0");
+        System.setProperty(ConfigurationKeys.SERVER_RAFT_SERVER_ADDR, "");
+        ConfigurationCache.clear();
+        StoreConfig.setStartupParameter("raft", "raft", "raft");
+        // Provide real state-machine dependencies while leaving RaftServerManager uninitialized.
+        ReflectionTestUtils.setField(
+                SessionHolder.class,
+                "ROOT_SESSION_MANAGER",
+                new RaftSessionManager(SessionHolder.ROOT_SESSION_MANAGER_NAME));
+        ReflectionTestUtils.setField(
+                SessionHolder.class, "ROOT_VGROUP_MAPPING_MANAGER", new RaftVGroupMappingStoreManager());
+        LockerManagerFactory.init(LockMode.RAFT);
     }
 
     @AfterEach
     public void destroy() {
-        System.setProperty("server.raftPort", "0");
-        System.setProperty(ConfigurationKeys.SERVER_RAFT_SERVER_ADDR, "");
+        try {
+            SessionHolder.destroy();
+        } finally {
+            LockerManagerFactory.destroy();
+        }
+    }
+
+    @AfterAll
+    public static void restoreStore() {
+        ReflectionTestUtils.setField(StoreConfig.class, "storeMode", originalStoreMode);
+        ReflectionTestUtils.setField(StoreConfig.class, "sessionMode", originalSessionMode);
+        ReflectionTestUtils.setField(StoreConfig.class, "lockMode", originalLockMode);
+        restoreProperty("server.raftPort", originalRaftPort);
+        restoreProperty(ConfigurationKeys.SERVER_RAFT_SERVER_ADDR, originalRaftServerAddr);
         ConfigurationCache.clear();
-        StoreConfig.setStartupParameter("file", "file", "file");
-        LockerManagerFactory.destroy();
-        SessionHolder.destroy();
-        RaftServerManager.destroy();
+        SessionHolder.init();
+        LockerManagerFactory.init();
+    }
+
+    private static void restoreProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/seata/server/cluster/raft/RaftSyncMessageTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/raft/RaftSyncMessageTest.java
@@ -19,7 +19,6 @@ package org.apache.seata.server.cluster.raft;
 import org.apache.seata.common.exception.SeataRuntimeException;
 import org.apache.seata.common.metadata.ClusterRole;
 import org.apache.seata.common.metadata.Node;
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchType;
 import org.apache.seata.server.BaseSpringBootTest;
@@ -36,12 +35,8 @@ import org.apache.seata.server.cluster.raft.sync.msg.dto.GlobalTransactionDTO;
 import org.apache.seata.server.cluster.raft.sync.msg.dto.RaftClusterMetadata;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHelper;
-import org.apache.seata.server.session.SessionHolder;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationContext;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,16 +50,6 @@ import java.util.Map;
 /**
  */
 public class RaftSyncMessageTest extends BaseSpringBootTest {
-
-    @BeforeAll
-    public static void setUp(ApplicationContext context) {
-        SessionHolder.init(SessionMode.FILE);
-    }
-
-    @AfterAll
-    public static void destroy() {
-        SessionHolder.destroy();
-    }
 
     @Test
     public void testSecurityMsgSerialize() throws IOException {

--- a/server/src/test/java/org/apache/seata/server/cluster/raft/execute/BranchSessionExecuteTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/raft/execute/BranchSessionExecuteTest.java
@@ -31,16 +31,19 @@ import org.apache.seata.server.cluster.raft.execute.branch.RemoveBranchSessionEx
 import org.apache.seata.server.cluster.raft.execute.branch.UpdateBranchSessionExecute;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftBranchSessionSyncMsg;
 import org.apache.seata.server.cluster.raft.sync.msg.dto.BranchTransactionDTO;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.storage.SessionConverter;
+import org.apache.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,11 +58,22 @@ class BranchSessionExecuteTest extends BaseSpringBootTest {
 
     private static final long BRANCH_ID = 0L;
 
+    private static SessionMode originalSessionMode;
+    private static LockMode originalLockMode;
+    private static String originalRaftServerAddr;
+
     @BeforeAll
     public static void setUp(ApplicationContext context) throws TransactionException {
-        System.setProperty("server.raft.serverAddr", NetUtil.getLocalIp() + ":9091");
-        SessionHolder.init(SessionMode.RAFT);
+        originalSessionMode = (SessionMode) ReflectionTestUtils.getField(StoreConfig.class, "sessionMode");
+        originalLockMode = (LockMode) ReflectionTestUtils.getField(StoreConfig.class, "lockMode");
+        originalRaftServerAddr = System.getProperty("server.raft.serverAddr");
+        // Executor tests own session transitions without coordinator retry tasks.
+        DefaultCoordinator.getInstance().destroy();
         LockerManagerFactory.destroy();
+        StoreConfig.setStartupParameter(null, SessionMode.RAFT.getName(), LockMode.RAFT.getName());
+        System.setProperty("server.raft.serverAddr", NetUtil.getLocalIp() + ":9091");
+        ConfigurationCache.clear();
+        SessionHolder.init(SessionMode.RAFT);
         LockerManagerFactory.init(LockMode.RAFT);
         GLOBAL_SESSION = mockGlobalSession();
         SessionHolder.getRootSessionManager().addGlobalSession(GLOBAL_SESSION);
@@ -67,16 +81,28 @@ class BranchSessionExecuteTest extends BaseSpringBootTest {
 
     @AfterAll
     public static void destroy() throws Throwable {
-        testRemove();
-        SessionHolder.getRootSessionManager().removeGlobalSession(GLOBAL_SESSION);
-        // Clear configuration
-        ConfigurationCache.clear();
-        System.clearProperty("server.raft.serverAddr");
-
-        // Destroy SessionHolder and LockerManagerFactory
-        SessionHolder.destroy();
-        SessionHolder.init(null);
-        LockerManagerFactory.destroy();
+        try {
+            if (GLOBAL_SESSION != null) {
+                testRemove();
+                SessionHolder.getRootSessionManager().removeGlobalSession(GLOBAL_SESSION);
+            }
+        } finally {
+            try {
+                SessionHolder.destroy();
+            } finally {
+                LockerManagerFactory.destroy();
+                ReflectionTestUtils.setField(StoreConfig.class, "sessionMode", originalSessionMode);
+                ReflectionTestUtils.setField(StoreConfig.class, "lockMode", originalLockMode);
+                if (originalRaftServerAddr == null) {
+                    System.clearProperty("server.raft.serverAddr");
+                } else {
+                    System.setProperty("server.raft.serverAddr", originalRaftServerAddr);
+                }
+                ConfigurationCache.clear();
+                SessionHolder.init();
+                LockerManagerFactory.init();
+            }
+        }
     }
 
     @Test

--- a/server/src/test/java/org/apache/seata/server/cluster/raft/execute/GlobalSessionExecuteTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/raft/execute/GlobalSessionExecuteTest.java
@@ -28,39 +28,61 @@ import org.apache.seata.server.cluster.raft.execute.global.RemoveGlobalSessionEx
 import org.apache.seata.server.cluster.raft.execute.global.UpdateGlobalSessionExecute;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftGlobalSessionSyncMsg;
 import org.apache.seata.server.cluster.raft.sync.msg.dto.GlobalTransactionDTO;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.session.SessionManager;
 import org.apache.seata.server.storage.SessionConverter;
+import org.apache.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  */
 class GlobalSessionExecuteTest extends BaseSpringBootTest {
+
+    private static SessionMode originalSessionMode;
+    private static LockMode originalLockMode;
+    private static String originalRaftServerAddr;
+
     @BeforeAll
     public static void setUp(ApplicationContext context) {
-        System.setProperty("server.raft.serverAddr", NetUtil.getLocalIp() + ":9091");
-        SessionHolder.init(SessionMode.RAFT);
+        originalSessionMode = (SessionMode) ReflectionTestUtils.getField(StoreConfig.class, "sessionMode");
+        originalLockMode = (LockMode) ReflectionTestUtils.getField(StoreConfig.class, "lockMode");
+        originalRaftServerAddr = System.getProperty("server.raft.serverAddr");
+        // Executor tests own session transitions without coordinator retry tasks.
+        DefaultCoordinator.getInstance().destroy();
         LockerManagerFactory.destroy();
+        StoreConfig.setStartupParameter(null, SessionMode.RAFT.getName(), LockMode.RAFT.getName());
+        System.setProperty("server.raft.serverAddr", NetUtil.getLocalIp() + ":9091");
+        ConfigurationCache.clear();
+        SessionHolder.init(SessionMode.RAFT);
         LockerManagerFactory.init(LockMode.RAFT);
     }
 
     @AfterAll
     public static void destroy() {
-        // Clear configuration
-        ConfigurationCache.clear();
-        System.clearProperty("server.raft.serverAddr");
-
-        // Destroy SessionHolder and LockerManagerFactory
-        SessionHolder.destroy();
-        SessionHolder.init(null);
-        LockerManagerFactory.destroy();
+        try {
+            SessionHolder.destroy();
+        } finally {
+            LockerManagerFactory.destroy();
+            ReflectionTestUtils.setField(StoreConfig.class, "sessionMode", originalSessionMode);
+            ReflectionTestUtils.setField(StoreConfig.class, "lockMode", originalLockMode);
+            if (originalRaftServerAddr == null) {
+                System.clearProperty("server.raft.serverAddr");
+            } else {
+                System.setProperty("server.raft.serverAddr", originalRaftServerAddr);
+            }
+            ConfigurationCache.clear();
+            SessionHolder.init();
+            LockerManagerFactory.init();
+        }
     }
 
     @AfterEach

--- a/server/src/test/java/org/apache/seata/server/cluster/raft/execute/LockExecuteTest.java
+++ b/server/src/test/java/org/apache/seata/server/cluster/raft/execute/LockExecuteTest.java
@@ -31,12 +31,14 @@ import org.apache.seata.server.cluster.raft.sync.msg.RaftBranchSessionSyncMsg;
 import org.apache.seata.server.cluster.raft.sync.msg.RaftGlobalSessionSyncMsg;
 import org.apache.seata.server.cluster.raft.sync.msg.dto.BranchTransactionDTO;
 import org.apache.seata.server.cluster.raft.sync.msg.dto.GlobalTransactionDTO;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.LockManager;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.storage.SessionConverter;
+import org.apache.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -44,6 +46,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,24 +61,42 @@ class LockExecuteTest extends BaseSpringBootTest {
 
     private static final long BRANCH_ID = 0L;
 
+    private static SessionMode originalSessionMode;
+    private static LockMode originalLockMode;
+    private static String originalRaftServerAddr;
+
     @BeforeAll
     public static void setUp(ApplicationContext context) throws TransactionException {
-        System.setProperty("server.raft.serverAddr", NetUtil.getLocalIp() + ":9091");
-        SessionHolder.init(SessionMode.RAFT);
+        originalSessionMode = (SessionMode) ReflectionTestUtils.getField(StoreConfig.class, "sessionMode");
+        originalLockMode = (LockMode) ReflectionTestUtils.getField(StoreConfig.class, "lockMode");
+        originalRaftServerAddr = System.getProperty("server.raft.serverAddr");
+        // Executor tests own session transitions without coordinator retry tasks.
+        DefaultCoordinator.getInstance().destroy();
         LockerManagerFactory.destroy();
+        StoreConfig.setStartupParameter(null, SessionMode.RAFT.getName(), LockMode.RAFT.getName());
+        System.setProperty("server.raft.serverAddr", NetUtil.getLocalIp() + ":9091");
+        ConfigurationCache.clear();
+        SessionHolder.init(SessionMode.RAFT);
         LockerManagerFactory.init(LockMode.RAFT);
     }
 
     @AfterAll
     public static void destroy() throws TransactionException {
-        // Clear configuration
-        ConfigurationCache.clear();
-        System.clearProperty("server.raft.serverAddr");
-
-        // Destroy SessionHolder and LockerManagerFactory
-        SessionHolder.destroy();
-        SessionHolder.init(null);
-        LockerManagerFactory.destroy();
+        try {
+            SessionHolder.destroy();
+        } finally {
+            LockerManagerFactory.destroy();
+            ReflectionTestUtils.setField(StoreConfig.class, "sessionMode", originalSessionMode);
+            ReflectionTestUtils.setField(StoreConfig.class, "lockMode", originalLockMode);
+            if (originalRaftServerAddr == null) {
+                System.clearProperty("server.raft.serverAddr");
+            } else {
+                System.setProperty("server.raft.serverAddr", originalRaftServerAddr);
+            }
+            ConfigurationCache.clear();
+            SessionHolder.init();
+            LockerManagerFactory.init();
+        }
     }
 
     @BeforeEach

--- a/server/src/test/java/org/apache/seata/server/console/impl/AbstractServiceTest.java
+++ b/server/src/test/java/org/apache/seata/server/console/impl/AbstractServiceTest.java
@@ -20,9 +20,12 @@ import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.coordinator.DefaultCoordinator;
+import org.apache.seata.server.lock.LockManager;
+import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,13 +43,37 @@ public class AbstractServiceTest extends BaseSpringBootTest {
     private GlobalSession mockGlobalSession;
     private BranchSession mockBranchSession;
 
-    private static class TestAbstractService extends AbstractService {}
+    private static class TestAbstractService extends AbstractService {
+        private LockManager currentLockManager() {
+            return getLockManager();
+        }
+    }
 
     @BeforeEach
     public void setUp() {
         service = new TestAbstractService();
         mockGlobalSession = mock(GlobalSession.class);
         mockBranchSession = mock(BranchSession.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        LockerManagerFactory.destroy();
+    }
+
+    @Test
+    public void testConstructionDoesNotInitializeLockManager() throws Exception {
+        LockerManagerFactory.destroy();
+
+        TestAbstractService uninitializedService = new TestAbstractService();
+
+        java.lang.reflect.Field field = LockerManagerFactory.class.getDeclaredField("LOCK_MANAGER");
+        field.setAccessible(true);
+        Assertions.assertNull(field.get(null));
+
+        LockManager current = mock(LockManager.class);
+        field.set(null, current);
+        Assertions.assertSame(current, uninitializedService.currentLockManager());
     }
 
     @Test

--- a/server/src/test/java/org/apache/seata/server/console/impl/AbstractServiceTest.java
+++ b/server/src/test/java/org/apache/seata/server/console/impl/AbstractServiceTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings("checkstyle:AbstractClassName")
 public class AbstractServiceTest extends BaseSpringBootTest {
 
     private TestAbstractService service;

--- a/server/src/test/java/org/apache/seata/server/coordinator/AbstractCoreTest.java
+++ b/server/src/test/java/org/apache/seata/server/coordinator/AbstractCoreTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.server.coordinator;
 
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.core.exception.BranchTransactionException;
 import org.apache.seata.core.exception.GlobalTransactionException;
 import org.apache.seata.core.model.BranchStatus;
@@ -27,7 +26,6 @@ import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,30 +37,25 @@ import java.util.Collection;
 /**
  * The type Abstract core test.
  */
+@SuppressWarnings("checkstyle:AbstractClassName")
 public class AbstractCoreTest extends BaseSpringBootTest {
 
     private static TestableAbstractCore abstractCore;
     private static RemotingServer remotingServer;
 
-    private static final String applicationId = "demo-app";
-    private static final String txServiceGroup = "default_tx_group";
-    private static final String txName = "test-tx";
-    private static final int timeout = 3000;
-    private static final String resourceId = "tb_test";
-    private static final String clientId = "test_client";
-    private static final String lockKeys = "tb_test:1";
-    private static final String applicationData = "{\"data\":\"test\"}";
+    private static final String APPLICATION_ID = "demo-app";
+    private static final String TX_SERVICE_GROUP = "default_tx_group";
+    private static final String TX_NAME = "test-tx";
+    private static final int TIMEOUT = 3000;
+    private static final String RESOURCE_ID = "tb_test";
+    private static final String CLIENT_ID = "test_client";
+    private static final String LOCK_KEYS = "tb_test:1";
+    private static final String APPLICATION_DATA = "{\"data\":\"test\"}";
 
     @BeforeAll
     public static void initSessionManager(ApplicationContext context) throws Exception {
-        SessionHolder.init(SessionMode.FILE);
         remotingServer = new DefaultCoordinatorTest.MockServerMessageSender();
         abstractCore = new TestableAbstractCore(remotingServer);
-    }
-
-    @AfterAll
-    public static void destroySessionManager() {
-        SessionHolder.destroy();
     }
 
     @AfterEach
@@ -92,7 +85,7 @@ public class AbstractCoreTest extends BaseSpringBootTest {
         GlobalSession globalSession = createGlobalSession();
 
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
 
         Assertions.assertNotNull(branchId);
         Assertions.assertTrue(branchId > 0);
@@ -104,11 +97,11 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LBranchRegisterWithNullLockKeysTest() throws Exception {
+    public void lBranchRegisterWithNullLockKeysTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
 
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, null);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, null);
 
         Assertions.assertNotNull(branchId);
         Assertions.assertTrue(branchId > 0);
@@ -117,46 +110,47 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LBranchRegisterGlobalSessionNotFoundTest() {
+    public void lBranchRegisterGlobalSessionNotFoundTest() {
         Assertions.assertThrows(GlobalTransactionException.class, () -> {
-            abstractCore.branchRegister(BranchType.AT, resourceId, clientId, "invalid_xid", applicationData, lockKeys);
+            abstractCore.branchRegister(
+                    BranchType.AT, RESOURCE_ID, CLIENT_ID, "invalid_xid", APPLICATION_DATA, LOCK_KEYS);
         });
     }
 
     @Test
-    public void LBranchRegisterGlobalSessionNotActiveTest() throws Exception {
+    public void lBranchRegisterGlobalSessionNotActiveTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         globalSession.changeGlobalStatus(GlobalStatus.Committed);
 
         Assertions.assertThrows(GlobalTransactionException.class, () -> {
             abstractCore.branchRegister(
-                    BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                    BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
         });
 
         globalSession.end();
     }
 
     @Test
-    public void LBranchRegisterGlobalSessionStatusInvalidTest() throws Exception {
+    public void lBranchRegisterGlobalSessionStatusInvalidTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         globalSession.changeGlobalStatus(GlobalStatus.Committing);
 
         Assertions.assertThrows(GlobalTransactionException.class, () -> {
             abstractCore.branchRegister(
-                    BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                    BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
         });
 
         globalSession.end();
     }
 
     @Test
-    public void LBranchReportSuccessTest() throws Exception {
+    public void lBranchReportSuccessTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
 
         abstractCore.branchReport(
-                BranchType.AT, globalSession.getXid(), branchId, BranchStatus.PhaseOne_Done, applicationData);
+                BranchType.AT, globalSession.getXid(), branchId, BranchStatus.PhaseOne_Done, APPLICATION_DATA);
 
         GlobalSession foundSession = SessionHolder.findGlobalSession(globalSession.getXid());
         BranchSession branchSession = foundSession.getBranch(branchId);
@@ -166,29 +160,29 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LBranchReportGlobalSessionNotFoundTest() {
+    public void lBranchReportGlobalSessionNotFoundTest() {
         Assertions.assertThrows(GlobalTransactionException.class, () -> {
-            abstractCore.branchReport(BranchType.AT, "invalid_xid", 1L, BranchStatus.PhaseOne_Done, applicationData);
+            abstractCore.branchReport(BranchType.AT, "invalid_xid", 1L, BranchStatus.PhaseOne_Done, APPLICATION_DATA);
         });
     }
 
     @Test
-    public void LBranchReportBranchSessionNotFoundTest() throws Exception {
+    public void lBranchReportBranchSessionNotFoundTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
 
         Assertions.assertThrows(BranchTransactionException.class, () -> {
             abstractCore.branchReport(
-                    BranchType.AT, globalSession.getXid(), 999L, BranchStatus.PhaseOne_Done, applicationData);
+                    BranchType.AT, globalSession.getXid(), 999L, BranchStatus.PhaseOne_Done, APPLICATION_DATA);
         });
 
         globalSession.end();
     }
 
     @Test
-    public void LBranchReportUpdateApplicationDataTest() throws Exception {
+    public void lBranchReportUpdateApplicationDataTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
 
         String newApplicationData = "{\"data\":\"updated\"}";
         abstractCore.branchReport(
@@ -202,16 +196,16 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LLockQueryDefaultReturnTrueTest() throws Exception {
-        boolean result = abstractCore.lockQuery(BranchType.AT, resourceId, "test_xid", lockKeys);
+    public void lLockQueryDefaultReturnTrueTest() throws Exception {
+        boolean result = abstractCore.lockQuery(BranchType.AT, RESOURCE_ID, "test_xid", LOCK_KEYS);
         Assertions.assertTrue(result);
     }
 
     @Test
-    public void LBranchCommitSuccessTest() throws Exception {
+    public void lBranchCommitSuccessTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
 
         BranchSession branchSession = globalSession.getBranch(branchId);
         BranchStatus status = abstractCore.branchCommit(globalSession, branchSession);
@@ -222,10 +216,10 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LBranchRollbackSuccessTest() throws Exception {
+    public void lBranchRollbackSuccessTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
 
         BranchSession branchSession = globalSession.getBranch(branchId);
         BranchStatus status = abstractCore.branchRollback(globalSession, branchSession);
@@ -236,7 +230,7 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LGlobalSessionStatusCheckActiveSessionTest() throws Exception {
+    public void lGlobalSessionStatusCheckActiveSessionTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
 
         // Should not throw exception
@@ -246,7 +240,7 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LGlobalSessionStatusCheckInactiveSessionTest() throws Exception {
+    public void lGlobalSessionStatusCheckInactiveSessionTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         globalSession.changeGlobalStatus(GlobalStatus.Committed);
 
@@ -258,7 +252,7 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LGlobalSessionStatusCheckInvalidStatusTest() throws Exception {
+    public void lGlobalSessionStatusCheckInvalidStatusTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         globalSession.changeGlobalStatus(GlobalStatus.Committing);
 
@@ -270,19 +264,19 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LBeginReturnsNullTest() throws Exception {
-        String result = abstractCore.begin(applicationId, txServiceGroup, txName, timeout);
+    public void lBeginReturnsNullTest() throws Exception {
+        String result = abstractCore.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         Assertions.assertNull(result);
     }
 
     @Test
-    public void LCommitReturnsNullTest() throws Exception {
+    public void lCommitReturnsNullTest() throws Exception {
         GlobalStatus result = abstractCore.commit("test_xid");
         Assertions.assertNull(result);
     }
 
     @Test
-    public void LDoGlobalCommitReturnsTrueTest() throws Exception {
+    public void lDoGlobalCommitReturnsTrueTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         boolean result = abstractCore.doGlobalCommit(globalSession, false);
         Assertions.assertTrue(result);
@@ -290,19 +284,19 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LGlobalReportReturnsNullTest() throws Exception {
+    public void lGlobalReportReturnsNullTest() throws Exception {
         GlobalStatus result = abstractCore.globalReport("test_xid", GlobalStatus.Committed);
         Assertions.assertNull(result);
     }
 
     @Test
-    public void LRollbackReturnsNullTest() throws Exception {
+    public void lRollbackReturnsNullTest() throws Exception {
         GlobalStatus result = abstractCore.rollback("test_xid");
         Assertions.assertNull(result);
     }
 
     @Test
-    public void LDoGlobalRollbackReturnsTrueTest() throws Exception {
+    public void lDoGlobalRollbackReturnsTrueTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         boolean result = abstractCore.doGlobalRollback(globalSession, false);
         Assertions.assertTrue(result);
@@ -310,13 +304,13 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LGetStatusReturnsNullTest() throws Exception {
+    public void lGetStatusReturnsNullTest() throws Exception {
         GlobalStatus result = abstractCore.getStatus("test_xid");
         Assertions.assertNull(result);
     }
 
     @Test
-    public void LDoGlobalReportNoExceptionTest() throws Exception {
+    public void lDoGlobalReportNoExceptionTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         // Should not throw exception
         abstractCore.doGlobalReport(globalSession, globalSession.getXid(), GlobalStatus.Committed);
@@ -324,10 +318,10 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LDoBranchDeleteReturnsTrueTest() throws Exception {
+    public void lDoBranchDeleteReturnsTrueTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
         BranchSession branchSession = globalSession.getBranch(branchId);
 
         Boolean result = abstractCore.doBranchDelete(globalSession, branchSession);
@@ -337,10 +331,10 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void LBranchDeleteReturnsNullTest() throws Exception {
+    public void lBranchDeleteReturnsNullTest() throws Exception {
         GlobalSession globalSession = createGlobalSession();
         Long branchId = abstractCore.branchRegister(
-                BranchType.AT, resourceId, clientId, globalSession.getXid(), applicationData, lockKeys);
+                BranchType.AT, RESOURCE_ID, CLIENT_ID, globalSession.getXid(), APPLICATION_DATA, LOCK_KEYS);
         BranchSession branchSession = globalSession.getBranch(branchId);
 
         BranchStatus result = abstractCore.branchDelete(globalSession, branchSession);
@@ -350,7 +344,8 @@ public class AbstractCoreTest extends BaseSpringBootTest {
     }
 
     private GlobalSession createGlobalSession() throws Exception {
-        GlobalSession globalSession = GlobalSession.createGlobalSession(applicationId, txServiceGroup, txName, timeout);
+        GlobalSession globalSession =
+                GlobalSession.createGlobalSession(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession.begin();
         return globalSession;
     }

--- a/server/src/test/java/org/apache/seata/server/coordinator/DefaultCoordinatorTest.java
+++ b/server/src/test/java/org/apache/seata/server/coordinator/DefaultCoordinatorTest.java
@@ -20,7 +20,6 @@ import io.netty.channel.Channel;
 import org.apache.seata.common.DefaultValues;
 import org.apache.seata.common.XID;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.util.NetUtil;
 import org.apache.seata.common.util.ReflectionUtil;
 import org.apache.seata.config.Configuration;
@@ -56,7 +55,6 @@ import org.apache.seata.server.metrics.MetricsManager;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
-import org.apache.seata.server.util.StoreUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -71,7 +69,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.context.ApplicationContext;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -125,14 +122,10 @@ public class DefaultCoordinatorTest extends BaseSpringBootTest {
         defaultCoordinator = DefaultCoordinator.getInstance(remotingServer);
         defaultCoordinator.setRemotingServer(remotingServer);
         core = new DefaultCore(remotingServer);
-        // Initialize SessionHolder once for all tests
-        SessionHolder.init(SessionMode.FILE);
     }
 
     @BeforeEach
-    public void tearUp() throws IOException {
-        // Only delete data files before each test
-        StoreUtil.deleteDataFile();
+    public void tearUp() {
         // Reinitialize core before each test to clear previous mocks
         core = new DefaultCore(remotingServer);
     }
@@ -269,14 +262,11 @@ public class DefaultCoordinatorTest extends BaseSpringBootTest {
         for (GlobalSession globalSession : globalSessions) {
             globalSession.closeAndClean();
         }
-        // Destroy SessionHolder to clean up static state
-        SessionHolder.destroy();
     }
 
     @AfterEach
-    public void tearDown() throws IOException {
+    public void tearDown() {
         MetricsManager.get().getRegistry().clearUp();
-        StoreUtil.deleteDataFile();
     }
 
     static Stream<Arguments> xidAndBranchIdProviderForRollback() throws Exception {

--- a/server/src/test/java/org/apache/seata/server/coordinator/DefaultCoreTest.java
+++ b/server/src/test/java/org/apache/seata/server/coordinator/DefaultCoreTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.seata.server.coordinator;
 
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.core.model.BranchType;
@@ -27,7 +26,6 @@ import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHelper;
 import org.apache.seata.server.session.SessionHolder;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,23 +47,23 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     private static DefaultCore core;
     private static RemotingServer remotingServer;
 
-    private static final String applicationId = "demo-child-app";
+    private static final String APPLICATION_ID = "demo-child-app";
 
-    private static final String txServiceGroup = "default_tx_group";
+    private static final String TX_SERVICE_GROUP = "default_tx_group";
 
-    private static final String txName = "tx-1";
+    private static final String TX_NAME = "tx-1";
 
-    private static final int timeout = 3000;
+    private static final int TIMEOUT = 3000;
 
-    private static final String resourceId = "tb_1";
+    private static final String RESOURCE_ID = "tb_1";
 
-    private static final String clientId = "c_1";
+    private static final String CLIENT_ID = "c_1";
 
-    private static final String lockKeys_1 = "tb_11:11";
+    private static final String LOCK_KEYS_1 = "tb_11:11";
 
-    private static final String lockKeys_2 = "tb_12:12";
+    private static final String LOCK_KEYS_2 = "tb_12:12";
 
-    private static final String applicationData = "{\"data\":\"test\"}";
+    private static final String APPLICATION_DATA = "{\"data\":\"test\"}";
 
     private GlobalSession globalSession;
 
@@ -76,17 +74,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
      */
     @BeforeAll
     public static void initSessionManager(ApplicationContext context) throws Exception {
-        SessionHolder.init(SessionMode.FILE);
         remotingServer = new DefaultCoordinatorTest.MockServerMessageSender();
         core = new DefaultCore(remotingServer);
-    }
-
-    /**
-     * Destroy session manager.
-     */
-    @AfterAll
-    public static void destroySessionManager() {
-        SessionHolder.destroy();
     }
 
     /**
@@ -125,7 +114,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     @ParameterizedTest
     @MethodSource("xidProvider")
     public void branchRegisterTest(String xid) throws Exception {
-        core.branchRegister(BranchType.AT, resourceId, clientId, xid, "abc", lockKeys_1);
+        core.branchRegister(BranchType.AT, RESOURCE_ID, CLIENT_ID, xid, "abc", LOCK_KEYS_1);
         globalSession = SessionHolder.findGlobalSession(xid);
         Assertions.assertEquals(globalSession.getSortedBranches().size(), 1);
     }
@@ -140,7 +129,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     @ParameterizedTest
     @MethodSource("xidAndBranchIdProvider")
     public void branchReportTest(String xid, Long branchId) throws Exception {
-        core.branchReport(BranchType.AT, xid, branchId, BranchStatus.PhaseOne_Done, applicationData);
+        core.branchReport(BranchType.AT, xid, branchId, BranchStatus.PhaseOne_Done, APPLICATION_DATA);
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = globalSession.getBranch(branchId);
         Assertions.assertEquals(branchSession.getStatus(), BranchStatus.PhaseOne_Done);
@@ -153,7 +142,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
      */
     @Test
     public void beginTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession = SessionHolder.findGlobalSession(xid);
         Assertions.assertNotNull(globalSession);
     }
@@ -182,7 +171,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     public void doGlobalCommitCommitTest(String xid) throws Exception {
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.XA, resourceId, applicationData, "t1:1", clientId);
+                globalSession, BranchType.XA, RESOURCE_ID, APPLICATION_DATA, "t1:1", CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Done);
         core.mockCore(BranchType.XA, new MockCore(BranchStatus.PhaseTwo_Committed, BranchStatus.PhaseOne_Done));
@@ -201,7 +190,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     public void doGlobalCommitUnretryableTest(String xid) throws Exception {
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.TCC, resourceId, applicationData, "t1:1", clientId);
+                globalSession, BranchType.TCC, RESOURCE_ID, APPLICATION_DATA, "t1:1", CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Done);
         core.mockCore(
@@ -222,7 +211,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     public void doGlobalCommitExpTest(String xid) throws Exception {
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.XA, resourceId, applicationData, "t1:1", clientId);
+                globalSession, BranchType.XA, RESOURCE_ID, APPLICATION_DATA, "t1:1", CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Done);
         core.mockCore(BranchType.XA, new MockCore(BranchStatus.PhaseOne_Timeout, BranchStatus.PhaseOne_Done));
@@ -254,7 +243,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     public void doGlobalRollBackRollbackedTest(String xid) throws Exception {
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.AT, resourceId, applicationData, "t1:1", clientId);
+                globalSession, BranchType.AT, RESOURCE_ID, APPLICATION_DATA, "t1:1", CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Done);
         core.mockCore(BranchType.AT, new MockCore(BranchStatus.PhaseTwo_Committed, BranchStatus.PhaseTwo_Rollbacked));
@@ -273,7 +262,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     public void doGlobalRollBackUnretryableTest(String xid) throws Exception {
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.AT, resourceId, applicationData, "t1:1", clientId);
+                globalSession, BranchType.AT, RESOURCE_ID, APPLICATION_DATA, "t1:1", CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Done);
         core.mockCore(
@@ -294,7 +283,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
     public void doGlobalRollBackRetryableExpTest(String xid) throws Exception {
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.AT, resourceId, applicationData, "t1:1", clientId);
+                globalSession, BranchType.AT, RESOURCE_ID, APPLICATION_DATA, "t1:1", CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Done);
         core.mockCore(
@@ -311,7 +300,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
      * @throws Exception the exception
      */
     static Stream<Arguments> xidProvider() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         Assertions.assertNotNull(xid);
         return Stream.of(Arguments.of(xid));
     }
@@ -323,8 +312,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
      * @throws Exception the exception
      */
     static Stream<Arguments> xidAndBranchIdProvider() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
-        Long branchId = core.branchRegister(BranchType.AT, resourceId, clientId, xid, null, lockKeys_2);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
+        Long branchId = core.branchRegister(BranchType.AT, RESOURCE_ID, CLIENT_ID, xid, null, LOCK_KEYS_2);
         Assertions.assertNotNull(xid);
         Assertions.assertTrue(branchId != 0);
         return Stream.of(Arguments.of(xid, branchId));
@@ -358,8 +347,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void lockQueryTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
-        boolean result = core.lockQuery(BranchType.AT, resourceId, xid, lockKeys_1);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
+        boolean result = core.lockQuery(BranchType.AT, RESOURCE_ID, xid, LOCK_KEYS_1);
         Assertions.assertTrue(result);
 
         globalSession = SessionHolder.findGlobalSession(xid);
@@ -374,7 +363,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void getStatusSessionFoundTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         GlobalStatus status = core.getStatus(xid);
         Assertions.assertEquals(GlobalStatus.Begin, status);
 
@@ -396,7 +385,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void commitTimeoutTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, 1);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, 1);
         Thread.sleep(100);
 
         GlobalStatus status = core.commit(xid);
@@ -416,7 +405,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void rollbackStatusNotBeginTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession = SessionHolder.findGlobalSession(xid);
         globalSession.changeGlobalStatus(GlobalStatus.Committed);
 
@@ -428,7 +417,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void doGlobalCommitNoBranchesTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession = SessionHolder.findGlobalSession(xid);
         globalSession.changeGlobalStatus(GlobalStatus.Committing);
 
@@ -438,7 +427,7 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void doGlobalRollbackNoBranchesTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession = SessionHolder.findGlobalSession(xid);
         globalSession.changeGlobalStatus(GlobalStatus.Rollbacking);
 
@@ -448,11 +437,11 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void doGlobalCommitPhaseOne_FailedTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession = SessionHolder.findGlobalSession(xid);
 
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.AT, resourceId, applicationData, lockKeys_1, clientId);
+                globalSession, BranchType.AT, RESOURCE_ID, APPLICATION_DATA, LOCK_KEYS_1, CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Failed);
         globalSession.changeGlobalStatus(GlobalStatus.Committing);
@@ -463,11 +452,11 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void doGlobalRollbackPhaseOneFailedTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
         globalSession = SessionHolder.findGlobalSession(xid);
 
         BranchSession branchSession = SessionHelper.newBranchByGlobal(
-                globalSession, BranchType.AT, resourceId, applicationData, lockKeys_1, clientId);
+                globalSession, BranchType.AT, RESOURCE_ID, APPLICATION_DATA, LOCK_KEYS_1, CLIENT_ID);
         globalSession.addBranch(branchSession);
         globalSession.changeBranchStatus(branchSession, BranchStatus.PhaseOne_Failed);
         globalSession.changeGlobalStatus(GlobalStatus.Rollbacking);
@@ -478,8 +467,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void branchDeleteATTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
-        Long branchId = core.branchRegister(BranchType.AT, resourceId, clientId, xid, applicationData, lockKeys_1);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
+        Long branchId = core.branchRegister(BranchType.AT, RESOURCE_ID, CLIENT_ID, xid, APPLICATION_DATA, LOCK_KEYS_1);
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = globalSession.getBranch(branchId);
 
@@ -491,8 +480,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void doBranchDeleteATPhaseTwoCommittedTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
-        Long branchId = core.branchRegister(BranchType.AT, resourceId, clientId, xid, applicationData, lockKeys_1);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
+        Long branchId = core.branchRegister(BranchType.AT, RESOURCE_ID, CLIENT_ID, xid, APPLICATION_DATA, LOCK_KEYS_1);
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = globalSession.getBranch(branchId);
 
@@ -511,8 +500,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void doBranchDeleteUnretryableTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
-        Long branchId = core.branchRegister(BranchType.AT, resourceId, clientId, xid, applicationData, lockKeys_1);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
+        Long branchId = core.branchRegister(BranchType.AT, RESOURCE_ID, CLIENT_ID, xid, APPLICATION_DATA, LOCK_KEYS_1);
         globalSession = SessionHolder.findGlobalSession(xid);
         BranchSession branchSession = globalSession.getBranch(branchId);
 
@@ -531,8 +520,8 @@ public class DefaultCoreTest extends BaseSpringBootTest {
 
     @Test
     public void commitAsyncCommitTest() throws Exception {
-        String xid = core.begin(applicationId, txServiceGroup, txName, timeout);
-        core.branchRegister(BranchType.AT, resourceId, clientId, xid, applicationData, lockKeys_1);
+        String xid = core.begin(APPLICATION_ID, TX_SERVICE_GROUP, TX_NAME, TIMEOUT);
+        core.branchRegister(BranchType.AT, RESOURCE_ID, CLIENT_ID, xid, APPLICATION_DATA, LOCK_KEYS_1);
         globalSession = SessionHolder.findGlobalSession(xid);
 
         core.mockCore(BranchType.AT, new MockCore(BranchStatus.PhaseTwo_Committed, BranchStatus.PhaseTwo_Rollbacked) {

--- a/server/src/test/java/org/apache/seata/server/coordinator/RaftCoordinatorTest.java
+++ b/server/src/test/java/org/apache/seata/server/coordinator/RaftCoordinatorTest.java
@@ -20,8 +20,6 @@ import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.core.rpc.RemotingServer;
 import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.cluster.listener.ClusterChangeEvent;
-import org.apache.seata.server.session.SessionHolder;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,14 +41,8 @@ public class RaftCoordinatorTest extends BaseSpringBootTest {
 
     @BeforeAll
     public static void setup(ApplicationContext context) throws Exception {
-        SessionHolder.init(SessionMode.FILE);
         remotingServer = new DefaultCoordinatorTest.MockServerMessageSender();
         raftCoordinator = new RaftCoordinator(remotingServer);
-    }
-
-    @AfterAll
-    public static void cleanup() {
-        SessionHolder.destroy();
     }
 
     @AfterEach

--- a/server/src/test/java/org/apache/seata/server/event/DefaultCoreForEventBusTest.java
+++ b/server/src/test/java/org/apache/seata/server/event/DefaultCoreForEventBusTest.java
@@ -29,9 +29,7 @@ import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.coordinator.DefaultCoordinatorTest;
 import org.apache.seata.server.coordinator.DefaultCore;
 import org.apache.seata.server.metrics.MetricsManager;
-import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.store.StoreConfig;
-import org.apache.seata.server.util.StoreUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,7 +54,6 @@ public class DefaultCoreForEventBusTest extends BaseSpringBootTest {
 
     @BeforeAll
     public static void setUp(ApplicationContext context) throws InterruptedException {
-        StoreUtil.deleteDataFile();
         Thread.sleep(5000);
     }
 
@@ -102,12 +99,9 @@ public class DefaultCoreForEventBusTest extends BaseSpringBootTest {
             }
         }
         RemotingServer remotingServer = new DefaultCoordinatorTest.MockServerMessageSender();
-        DefaultCoordinator coordinator = DefaultCoordinator.getInstance(remotingServer);
-        coordinator.init();
         GlobalTransactionEventSubscriber subscriber = null;
         try {
             DefaultCore core = new DefaultCore(remotingServer);
-            SessionHolder.init(null);
             subscriber = new GlobalTransactionEventSubscriber();
             EventBusManager.get().unregisterAll();
             EventBusManager.get().register(subscriber);

--- a/server/src/test/java/org/apache/seata/server/lock/LockManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/lock/LockManagerTest.java
@@ -18,7 +18,6 @@ package org.apache.seata.server.lock;
 
 import jakarta.annotation.Resource;
 import org.apache.seata.common.result.PageResult;
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.core.exception.TransactionException;
@@ -27,11 +26,13 @@ import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.console.entity.param.GlobalLockParam;
 import org.apache.seata.server.console.entity.vo.GlobalLockVO;
 import org.apache.seata.server.console.service.GlobalLockService;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.file.FileLockManagerForTest;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
 import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.session.SessionManager;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -61,6 +62,11 @@ public class LockManagerTest extends BaseSpringBootTest {
 
     @BeforeAll
     public static void setUp(ApplicationContext context) {}
+
+    @AfterAll
+    public static void tearDown() {
+        DefaultCoordinator.getInstance().destroy();
+    }
 
     /**
      * Acquire lock success.
@@ -219,8 +225,6 @@ public class LockManagerTest extends BaseSpringBootTest {
     @MethodSource("globalSessionForLockTestProvider")
     public void lockQueryTest(GlobalSession globalSessions1, GlobalSession globalSessions2)
             throws TransactionException, ParseException {
-        SessionHolder.getRootSessionManager().destroy();
-        SessionHolder.init(SessionMode.FILE);
         final SessionManager sessionManager = SessionHolder.getRootSessionManager();
         // make sure sessionMaanager is empty
         Collection<GlobalSession> sessions = sessionManager.allSessions();
@@ -343,7 +347,6 @@ public class LockManagerTest extends BaseSpringBootTest {
         } finally {
             sessionManager.removeGlobalSession(globalSessions1);
             sessionManager.removeGlobalSession(globalSessions2);
-            sessionManager.destroy();
         }
     }
 

--- a/server/src/test/java/org/apache/seata/server/lock/LockerManagerFactoryTest.java
+++ b/server/src/test/java/org/apache/seata/server/lock/LockerManagerFactoryTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.lock;
+
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.exception.StoreException;
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.common.loader.EnhancedServiceNotFoundException;
+import org.apache.seata.common.store.LockMode;
+import org.apache.seata.config.ConfigurationCache;
+import org.apache.seata.core.lock.Locker;
+import org.apache.seata.server.session.BranchSession;
+import org.apache.seata.server.storage.db.lock.DataBaseLockManager;
+import org.apache.seata.server.storage.file.lock.FileLockManager;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.raft.lock.RaftLockManager;
+import org.apache.seata.server.storage.redis.lock.RedisLockManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+class LockerManagerFactoryTest {
+
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void beforeEach() {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        clearConfig();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        clearConfig();
+        restoreEnvironment();
+    }
+
+    @Test
+    void testUntypedFileModeAccessFailsBeforeRuntimeInstallation() {
+        StoreException exception = Assertions.assertThrows(StoreException.class, LockerManagerFactory::getLockManager);
+
+        Assertions.assertTrue(exception.getMessage().contains("FileStoreRuntime"));
+    }
+
+    @Test
+    void testTypedInitInjectsExactFileLockStore() throws Exception {
+        FileLockStore lockStore = mock(FileLockStore.class);
+        Locker locker = mock(Locker.class);
+        BranchSession branchSession = new BranchSession();
+        org.mockito.Mockito.when(lockStore.getLocker(branchSession)).thenReturn(locker);
+
+        LockerManagerFactory.init(LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {lockStore});
+
+        FileLockManager lockManager = (FileLockManager) LockerManagerFactory.getLockManager();
+        Assertions.assertSame(locker, lockManager.getLocker(branchSession));
+        lockManager.releaseLock(branchSession);
+        org.mockito.Mockito.verify(lockStore).releaseBranchLock(branchSession);
+    }
+
+    @Test
+    void testUntypedInitIsNoopAfterTypedFileModeInstallation() {
+        FileLockStore lockStore = mock(FileLockStore.class);
+        LockerManagerFactory.init(LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {lockStore});
+        LockManager installed = LockerManagerFactory.getLockManager();
+
+        LockerManagerFactory.init();
+
+        Assertions.assertSame(installed, LockerManagerFactory.getLockManager());
+    }
+
+    @Test
+    void testTypedFileModeInitRejectsExistingManager() throws Exception {
+        FileLockStore originalStore = mock(FileLockStore.class);
+        FileLockStore replacementStore = mock(FileLockStore.class);
+        LockerManagerFactory.init(LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {originalStore});
+        LockManager installed = LockerManagerFactory.getLockManager();
+
+        StoreException thrown = Assertions.assertThrows(
+                StoreException.class,
+                () -> LockerManagerFactory.init(
+                        LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {replacementStore}));
+
+        Assertions.assertTrue(thrown.getMessage().contains("already installed"));
+        Assertions.assertSame(installed, lockManagerField().get(null));
+    }
+
+    @Test
+    void testExplicitDbRedisAndRaftModesRemainLoaderBacked() {
+        Assertions.assertTrue(LockerManagerFactory.init(LockMode.DB));
+        Assertions.assertFalse(LockerManagerFactory.init(LockMode.DB));
+        Assertions.assertInstanceOf(DataBaseLockManager.class, LockerManagerFactory.getLockManager());
+        LockerManagerFactory.destroy();
+        LockerManagerFactory.init(LockMode.REDIS);
+        Assertions.assertInstanceOf(RedisLockManager.class, LockerManagerFactory.getLockManager());
+        LockerManagerFactory.destroy();
+        LockerManagerFactory.init(LockMode.RAFT);
+        Assertions.assertInstanceOf(RaftLockManager.class, LockerManagerFactory.getLockManager());
+    }
+
+    @Test
+    void testTypedInitDoesNotPublishManagerForUnknownConstructor() throws Exception {
+        Assertions.assertThrows(
+                EnhancedServiceNotFoundException.class,
+                () -> LockerManagerFactory.init(
+                        LockMode.FILE, new Class<?>[] {String.class}, new Object[] {"not-a-store"}));
+        Assertions.assertNull(lockManagerField().get(null));
+    }
+
+    @Test
+    void testTypedInitRejectsNullArgumentTypesWithoutPublication() throws Exception {
+        assertTypedInitRejected(null, new Object[] {mock(FileLockStore.class)});
+    }
+
+    @Test
+    void testTypedInitRejectsNullArgumentsWithoutPublication() throws Exception {
+        assertTypedInitRejected(new Class<?>[] {FileLockStore.class}, null);
+    }
+
+    @Test
+    void testTypedInitRejectsUnequalArgumentMetadataWithoutPublication() throws Exception {
+        assertTypedInitRejected(new Class<?>[] {FileLockStore.class}, new Object[0]);
+    }
+
+    private static void assertTypedInitRejected(Class<?>[] argumentTypes, Object[] arguments) throws Exception {
+        Field field = lockManagerField();
+        Assertions.assertAll(
+                () -> Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> LockerManagerFactory.init(LockMode.FILE, argumentTypes, arguments)),
+                () -> Assertions.assertNull(field.get(null)));
+    }
+
+    private static Field lockManagerField() throws NoSuchFieldException {
+        Field field = LockerManagerFactory.class.getDeclaredField("LOCK_MANAGER");
+        field.setAccessible(true);
+        return field;
+    }
+
+    private void clearConfig() {
+        LockerManagerFactory.destroy();
+        System.clearProperty(ConfigurationKeys.STORE_LOCK_MODE);
+        System.clearProperty(ConfigurationKeys.STORE_FILE_ENGINE);
+        ConfigurationCache.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/lock/db/DataBaseLockManagerImplTest.java
+++ b/server/src/test/java/org/apache/seata/server/lock/db/DataBaseLockManagerImplTest.java
@@ -23,9 +23,9 @@ import org.apache.seata.core.lock.Locker;
 import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.lock.LockManager;
 import org.apache.seata.server.session.BranchSession;
+import org.apache.seata.server.storage.db.lock.DataBaseLockManager;
 import org.apache.seata.server.storage.db.lock.DataBaseLocker;
 import org.apache.seata.server.storage.db.lock.LockStoreDataBaseDAO;
-import org.apache.seata.server.storage.file.lock.FileLockManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -263,7 +263,7 @@ public class DataBaseLockManagerImplTest extends BaseSpringBootTest {
         }
     }
 
-    public static class DBLockManagerForTest extends FileLockManager {
+    public static class DBLockManagerForTest extends DataBaseLockManager {
 
         protected LockStoreDataBaseDAO lockStore;
 

--- a/server/src/test/java/org/apache/seata/server/session/BranchSessionTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/BranchSessionTest.java
@@ -20,6 +20,9 @@ import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchType;
 import org.apache.seata.server.BaseSpringBootTest;
+import org.apache.seata.server.lock.LockManager;
+import org.apache.seata.server.lock.LockerManagerFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,6 +34,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import static org.apache.seata.common.DefaultValues.DEFAULT_TX_GROUP;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * The type Branch session test.
@@ -41,6 +47,34 @@ public class BranchSessionTest extends BaseSpringBootTest {
 
     @BeforeAll
     public static void setUp(ApplicationContext context) {}
+
+    @AfterEach
+    void afterEach() {
+        LockerManagerFactory.destroy();
+    }
+
+    @org.junit.jupiter.api.Test
+    void constructionDoesNotInitializeLockManagerAndOperationsResolveCurrentManager() throws Exception {
+        LockerManagerFactory.destroy();
+        BranchSession branchSession = new BranchSession(BranchType.AT);
+        branchSession.setLockKey("t_order:1");
+
+        java.lang.reflect.Field field = LockerManagerFactory.class.getDeclaredField("LOCK_MANAGER");
+        field.setAccessible(true);
+        Assertions.assertNull(field.get(null));
+
+        LockManager first = mock(LockManager.class);
+        when(first.acquireLock(branchSession, true, false)).thenReturn(true);
+        field.set(null, first);
+        Assertions.assertTrue(branchSession.lock());
+        verify(first).acquireLock(branchSession, true, false);
+
+        LockManager second = mock(LockManager.class);
+        when(second.releaseLock(branchSession)).thenReturn(true);
+        field.set(null, second);
+        Assertions.assertTrue(branchSession.unlock());
+        verify(second).releaseLock(branchSession);
+    }
 
     /**
      * Codec test.

--- a/server/src/test/java/org/apache/seata/server/session/FileSessionManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/FileSessionManagerTest.java
@@ -19,9 +19,7 @@ package org.apache.seata.server.session;
 import jakarta.annotation.Resource;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.seata.common.XID;
-import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.common.result.PageResult;
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.util.CollectionUtils;
 import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.core.model.BranchStatus;
@@ -34,17 +32,17 @@ import org.apache.seata.server.console.entity.vo.GlobalSessionVO;
 import org.apache.seata.server.console.service.BranchSessionService;
 import org.apache.seata.server.console.service.GlobalSessionService;
 import org.apache.seata.server.storage.file.session.FileSessionManager;
-import org.apache.seata.server.util.StoreUtil;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.context.ApplicationContext;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -71,25 +69,16 @@ public class FileSessionManagerTest extends BaseSpringBootTest {
     private BranchSessionService branchSessionService;
 
     @BeforeAll
-    public static void setUp(ApplicationContext context) {
-        StoreUtil.deleteDataFile();
-        try {
-            EnhancedServiceLoader.unloadAll();
-            sessionManagerList =
-                    Arrays.asList(new FileSessionManager("root.data", "."), new FileSessionManager("test", null));
-        } catch (IOException e) {
-            e.printStackTrace();
+    public static void setUp(ApplicationContext context, @TempDir Path sessionStorePath) throws IOException {
+        sessionManagerList = Arrays.asList(
+                new FileSessionManager("root.data", sessionStorePath.toString()), new FileSessionManager("test", null));
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        for (SessionManager sessionManager : sessionManagerList) {
+            sessionManager.destroy();
         }
-    }
-
-    @BeforeEach
-    public void setUp() {
-        SessionHolder.init(SessionMode.FILE);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        SessionHolder.destroy();
     }
 
     /**
@@ -396,7 +385,6 @@ public class FileSessionManagerTest extends BaseSpringBootTest {
             for (GlobalSession globalSession : globalSessions) {
                 globalSession.end();
             }
-            SessionHolder.destroy();
         }
     }
 

--- a/server/src/test/java/org/apache/seata/server/session/GlobalSessionTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/GlobalSessionTest.java
@@ -16,19 +16,15 @@
  */
 package org.apache.seata.server.session;
 
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.core.model.BranchType;
 import org.apache.seata.core.model.GlobalStatus;
 import org.apache.seata.server.BaseSpringBootTest;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.context.ApplicationContext;
 
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -41,16 +37,6 @@ import static org.apache.seata.common.DefaultValues.DEFAULT_TX_GROUP;
  * @since 2019 /1/23
  */
 public class GlobalSessionTest extends BaseSpringBootTest {
-
-    @BeforeAll
-    public static void init(ApplicationContext context) {
-        SessionHolder.init(SessionMode.FILE);
-    }
-
-    @AfterAll
-    public static void destroy() {
-        SessionHolder.destroy();
-    }
 
     /**
      * Can be committed async test.

--- a/server/src/test/java/org/apache/seata/server/session/SessionHolderFileStoreRuntimeTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/SessionHolderFileStoreRuntimeTest.java
@@ -24,13 +24,18 @@ import org.apache.seata.common.loader.EnhancedServiceLoader;
 import org.apache.seata.common.store.LockMode;
 import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.config.ConfigurationCache;
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.core.model.GlobalStatus;
 import org.apache.seata.server.lock.LockManager;
 import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.storage.file.FileStoreProviderFactory;
+import org.apache.seata.server.storage.file.session.FileSessionManager;
 import org.apache.seata.server.storage.file.spi.FileLockStore;
 import org.apache.seata.server.storage.file.spi.FileStoreProvider;
+import org.apache.seata.server.storage.file.spi.FileStoreRuntime;
 import org.apache.seata.server.storage.file.spi.SessionHolderFaultFileStoreProvider;
 import org.apache.seata.server.storage.file.spi.SessionHolderFaultFileStoreProvider.FailurePoint;
+import org.apache.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +44,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
@@ -50,9 +56,12 @@ class SessionHolderFileStoreRuntimeTest {
     Path tempDir;
 
     private Object originalEnvironment;
+    private LockMode originalLockMode;
 
     @BeforeEach
     void setUp() throws Exception {
+        originalLockMode = (LockMode) ReflectionTestUtils.getField(StoreConfig.class, "lockMode");
+        ReflectionTestUtils.setField(StoreConfig.class, "lockMode", null);
         originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
         ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
         System.setProperty(
@@ -72,9 +81,79 @@ class SessionHolderFileStoreRuntimeTest {
         System.clearProperty(ConfigurationKeys.STORE_FILE_DIR);
         System.clearProperty(ConfigurationKeys.STORE_FILE_ENGINE);
         System.clearProperty(ConfigurationKeys.STORE_LOCK_MODE);
+        ReflectionTestUtils.setField(StoreConfig.class, "lockMode", originalLockMode);
         ConfigurationCache.clear();
         clearProviderCaches();
         restoreEnvironment();
+    }
+
+    @Test
+    void testRepeatedInitializationPreservesRunningRuntimeAndItsResources() throws Exception {
+        FileSessionManager sessions = new FileSessionManager("root.data");
+        SessionHolderFaultFileStoreProvider.configure(
+                FailurePoint.NONE, null, null, sessions, Mockito.mock(FileLockStore.class));
+        SessionHolder.init(SessionMode.FILE);
+        FileStoreRuntime runtime = (FileStoreRuntime) rawField("FILE_STORE_RUNTIME");
+        LockManager lockManager = LockerManagerFactory.getLockManager();
+        Object mappingManager = rawField("ROOT_VGROUP_MAPPING_MANAGER");
+        Object distributedLocker = rawField("DISTRIBUTED_LOCKER");
+        GlobalSession session = new GlobalSession("app", "group", "transaction", 60000);
+        sessions.addGlobalSession(session);
+        try {
+            Assertions.assertThrows(StoreException.class, () -> SessionHolder.init(SessionMode.FILE));
+
+            Assertions.assertAll(
+                    () -> Assertions.assertSame(runtime, rawField("FILE_STORE_RUNTIME")),
+                    () -> Assertions.assertSame(sessions, SessionHolder.getRootSessionManager()),
+                    () -> Assertions.assertSame(session, SessionHolder.findGlobalSession(session.getXid())),
+                    () -> Assertions.assertSame(lockManager, LockerManagerFactory.getLockManager()),
+                    () -> Assertions.assertSame(mappingManager, rawField("ROOT_VGROUP_MAPPING_MANAGER")),
+                    () -> Assertions.assertSame(distributedLocker, rawField("DISTRIBUTED_LOCKER")),
+                    () -> Assertions.assertEquals(0, SessionHolderFaultFileStoreProvider.closeCount()));
+
+            SessionHolder.destroy();
+            Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+            assertFileModeReferencesCleared();
+        } finally {
+            runtime.close();
+        }
+    }
+
+    @Test
+    void testRecoveryConsumerRemovesTerminalSession() throws Exception {
+        FileSessionManager sessions = new FileSessionManager("root.data");
+        GlobalSession terminal = new GlobalSession("app", "group", "transaction", 60000);
+        terminal.setStatus(GlobalStatus.CommitRetryTimeout);
+        sessions.addGlobalSession(terminal);
+        SessionHolderFaultFileStoreProvider.configure(
+                FailurePoint.NONE, null, null, sessions, Mockito.mock(FileLockStore.class));
+
+        SessionHolder.init(SessionMode.FILE);
+
+        Assertions.assertNull(SessionHolder.findGlobalSession(terminal.getXid()));
+    }
+
+    @Test
+    void testRecoveryConsumerFailureRollsBackRuntime() throws Exception {
+        TransactionException recoveryFailure = new TransactionException("remove recovered session failed");
+        FileSessionManager sessions = new FileSessionManager("root.data") {
+            @Override
+            public void removeGlobalSession(GlobalSession session) throws TransactionException {
+                throw recoveryFailure;
+            }
+        };
+        GlobalSession terminal = new GlobalSession("app", "group", "transaction", 60000);
+        terminal.setStatus(GlobalStatus.CommitRetryTimeout);
+        sessions.addGlobalSession(terminal);
+        SessionHolderFaultFileStoreProvider.configure(
+                FailurePoint.NONE, null, null, sessions, Mockito.mock(FileLockStore.class));
+
+        StoreException thrown =
+                Assertions.assertThrows(StoreException.class, () -> SessionHolder.init(SessionMode.FILE));
+
+        Assertions.assertSame(recoveryFailure, thrown.getCause());
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+        assertFileModeReferencesCleared();
     }
 
     @Test

--- a/server/src/test/java/org/apache/seata/server/session/SessionHolderFileStoreRuntimeTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/SessionHolderFileStoreRuntimeTest.java
@@ -123,7 +123,7 @@ class SessionHolderFileStoreRuntimeTest {
     void testRecoveryConsumerRemovesTerminalSession() throws Exception {
         FileSessionManager sessions = new FileSessionManager("root.data");
         GlobalSession terminal = new GlobalSession("app", "group", "transaction", 60000);
-        terminal.setStatus(GlobalStatus.CommitRetryTimeout);
+        terminal.setStatus(GlobalStatus.Finished);
         sessions.addGlobalSession(terminal);
         SessionHolderFaultFileStoreProvider.configure(
                 FailurePoint.NONE, null, null, sessions, Mockito.mock(FileLockStore.class));
@@ -143,7 +143,7 @@ class SessionHolderFileStoreRuntimeTest {
             }
         };
         GlobalSession terminal = new GlobalSession("app", "group", "transaction", 60000);
-        terminal.setStatus(GlobalStatus.CommitRetryTimeout);
+        terminal.setStatus(GlobalStatus.Finished);
         sessions.addGlobalSession(terminal);
         SessionHolderFaultFileStoreProvider.configure(
                 FailurePoint.NONE, null, null, sessions, Mockito.mock(FileLockStore.class));

--- a/server/src/test/java/org/apache/seata/server/session/SessionHolderFileStoreRuntimeTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/SessionHolderFileStoreRuntimeTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.session;
+
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.exception.StoreException;
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.common.store.LockMode;
+import org.apache.seata.common.store.SessionMode;
+import org.apache.seata.config.ConfigurationCache;
+import org.apache.seata.server.lock.LockManager;
+import org.apache.seata.server.lock.LockerManagerFactory;
+import org.apache.seata.server.storage.file.FileStoreProviderFactory;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.file.spi.FileStoreProvider;
+import org.apache.seata.server.storage.file.spi.SessionHolderFaultFileStoreProvider;
+import org.apache.seata.server.storage.file.spi.SessionHolderFaultFileStoreProvider.FailurePoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Map;
+
+class SessionHolderFileStoreRuntimeTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        System.setProperty(
+                ConfigurationKeys.STORE_FILE_DIR, tempDir.resolve("file").toString());
+        System.setProperty(ConfigurationKeys.STORE_FILE_ENGINE, "session-holder-fault");
+        System.setProperty(ConfigurationKeys.STORE_LOCK_MODE, LockMode.FILE.getName());
+        ConfigurationCache.clear();
+        clearProviderCaches();
+        SessionHolderFaultFileStoreProvider.reset();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        SessionHolderFaultFileStoreProvider.reset();
+        SessionHolder.destroy();
+        LockerManagerFactory.destroy();
+        System.clearProperty(ConfigurationKeys.STORE_FILE_DIR);
+        System.clearProperty(ConfigurationKeys.STORE_FILE_ENGINE);
+        System.clearProperty(ConfigurationKeys.STORE_LOCK_MODE);
+        ConfigurationCache.clear();
+        clearProviderCaches();
+        restoreEnvironment();
+    }
+
+    @Test
+    void testProviderOpenFailureLeavesNoPublishedReferences() throws Exception {
+        RuntimeException startupFailure = new RuntimeException("open");
+        configure(FailurePoint.OPEN, startupFailure, null);
+
+        Assertions.assertSame(
+                startupFailure,
+                Assertions.assertThrows(RuntimeException.class, () -> SessionHolder.init(SessionMode.FILE)));
+
+        assertFileModeReferencesCleared();
+        Assertions.assertEquals(0, SessionHolderFaultFileStoreProvider.closeCount());
+    }
+
+    @Test
+    void testLockStoreFailureClosesRuntimeAndClearsReferences() throws Exception {
+        RuntimeException startupFailure = new RuntimeException("lock store");
+        configure(FailurePoint.LOCK_STORE, startupFailure, null);
+
+        Assertions.assertSame(
+                startupFailure,
+                Assertions.assertThrows(RuntimeException.class, () -> SessionHolder.init(SessionMode.FILE)));
+
+        assertFileModeReferencesCleared();
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+    }
+
+    @Test
+    void testLockInstallFailureClosesRuntimeAndClearsReferences() throws Exception {
+        RuntimeException startupFailure = new RuntimeException("lock install");
+        configure(FailurePoint.NONE, startupFailure, null);
+
+        try (MockedStatic<LockerManagerFactory> factory =
+                Mockito.mockStatic(LockerManagerFactory.class, Mockito.CALLS_REAL_METHODS)) {
+            factory.when(() -> LockerManagerFactory.init(
+                            Mockito.eq(LockMode.FILE), Mockito.any(Class[].class), Mockito.any(Object[].class)))
+                    .thenThrow(startupFailure);
+
+            Assertions.assertSame(
+                    startupFailure,
+                    Assertions.assertThrows(RuntimeException.class, () -> SessionHolder.init(SessionMode.FILE)));
+        }
+
+        assertFileModeReferencesCleared();
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+    }
+
+    @Test
+    void testExistingFileLockManagerRollsBackNewRuntimeWithoutPublication() throws Exception {
+        FileLockStore originalStore = Mockito.mock(FileLockStore.class);
+        FileLockStore replacementStore = Mockito.mock(FileLockStore.class);
+        SessionManager replacementSessionManager = Mockito.mock(SessionManager.class);
+        LockerManagerFactory.init(LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {originalStore});
+        LockManager originalManager = LockerManagerFactory.getLockManager();
+        SessionHolderFaultFileStoreProvider.configure(
+                FailurePoint.NONE, null, null, replacementSessionManager, replacementStore);
+
+        StoreException thrown =
+                Assertions.assertThrows(StoreException.class, () -> SessionHolder.init(SessionMode.FILE));
+
+        Assertions.assertTrue(thrown.getMessage().contains("already installed"));
+        Mockito.verifyNoInteractions(replacementSessionManager);
+        assertSessionReferencesCleared();
+        Assertions.assertSame(originalManager, lockManagerField().get(null));
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+    }
+
+    @Test
+    void testFileSessionWithDbLockFailsBeforeOpeningFileStoreRuntime() throws Exception {
+        System.setProperty(ConfigurationKeys.STORE_LOCK_MODE, LockMode.DB.getName());
+        ConfigurationCache.clear();
+        configure(FailurePoint.NONE, null, null);
+
+        StoreException thrown =
+                Assertions.assertThrows(StoreException.class, () -> SessionHolder.init(SessionMode.FILE));
+
+        Assertions.assertTrue(thrown.getMessage().contains("must use file lock mode"));
+
+        Assertions.assertNull(SessionHolderFaultFileStoreProvider.lastContext());
+    }
+
+    @Test
+    void testDbSessionWithFileLockFailsBeforeOpeningFileStoreRuntime() throws Exception {
+        System.setProperty(ConfigurationKeys.STORE_LOCK_MODE, LockMode.FILE.getName());
+        ConfigurationCache.clear();
+        configure(FailurePoint.NONE, null, null);
+
+        StoreException thrown = Assertions.assertThrows(StoreException.class, () -> SessionHolder.init(SessionMode.DB));
+
+        Assertions.assertTrue(thrown.getMessage().contains("must use file session mode"));
+
+        Assertions.assertNull(SessionHolderFaultFileStoreProvider.lastContext());
+    }
+
+    @Test
+    void testRecoveryFailurePreservesPrimaryAndSuppressesCloseFailure() throws Exception {
+        RuntimeException startupFailure = new RuntimeException("recovery");
+        RuntimeException closeFailure = new RuntimeException("close");
+        configure(FailurePoint.RECOVERY, startupFailure, closeFailure);
+
+        RuntimeException thrown =
+                Assertions.assertThrows(RuntimeException.class, () -> SessionHolder.init(SessionMode.FILE));
+
+        Assertions.assertSame(startupFailure, thrown);
+        Assertions.assertArrayEquals(new Throwable[] {closeFailure}, thrown.getSuppressed());
+        assertFileModeReferencesCleared();
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+    }
+
+    @Test
+    void testBackgroundStartFailureClosesRuntimeAndClearsReferences() throws Exception {
+        RuntimeException startupFailure = new RuntimeException("background");
+        configure(FailurePoint.BACKGROUND, startupFailure, null);
+
+        Assertions.assertSame(
+                startupFailure,
+                Assertions.assertThrows(RuntimeException.class, () -> SessionHolder.init(SessionMode.FILE)));
+
+        assertFileModeReferencesCleared();
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+    }
+
+    @Test
+    void testDestroyClearsReferencesAndRethrowsRuntimeCloseFailure() throws Exception {
+        RuntimeException closeFailure = new RuntimeException("close");
+        configure(FailurePoint.NONE, null, closeFailure);
+        SessionHolder.init(SessionMode.FILE);
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, SessionHolder::destroy);
+
+        Assertions.assertSame(closeFailure, thrown);
+        assertFileModeReferencesCleared();
+        Assertions.assertEquals(1, SessionHolderFaultFileStoreProvider.closeCount());
+        Assertions.assertDoesNotThrow(SessionHolder::destroy);
+    }
+
+    private void configure(FailurePoint point, RuntimeException startupFailure, RuntimeException closeFailure) {
+        SessionHolderFaultFileStoreProvider.configure(
+                point,
+                startupFailure,
+                closeFailure,
+                Mockito.mock(SessionManager.class),
+                Mockito.mock(FileLockStore.class));
+    }
+
+    private void assertFileModeReferencesCleared() throws Exception {
+        Assertions.assertAll(
+                () -> Assertions.assertNull(rawField("FILE_STORE_RUNTIME")),
+                () -> Assertions.assertNull(rawField("ROOT_SESSION_MANAGER")),
+                () -> Assertions.assertNull(rawField("ROOT_VGROUP_MAPPING_MANAGER")),
+                () -> Assertions.assertNull(rawField("DISTRIBUTED_LOCKER")),
+                () -> Assertions.assertNull(rawField("SESSION_MANAGER_MAP")),
+                () -> Assertions.assertNull(lockManagerField().get(null)));
+    }
+
+    private void assertSessionReferencesCleared() throws Exception {
+        Assertions.assertAll(
+                () -> Assertions.assertNull(rawField("FILE_STORE_RUNTIME")),
+                () -> Assertions.assertNull(rawField("ROOT_SESSION_MANAGER")),
+                () -> Assertions.assertNull(rawField("ROOT_VGROUP_MAPPING_MANAGER")),
+                () -> Assertions.assertNull(rawField("DISTRIBUTED_LOCKER")),
+                () -> Assertions.assertNull(rawField("SESSION_MANAGER_MAP")));
+    }
+
+    private Object rawField(String name) throws Exception {
+        Field field = SessionHolder.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    private Field lockManagerField() throws Exception {
+        Field field = LockerManagerFactory.class.getDeclaredField("LOCK_MANAGER");
+        field.setAccessible(true);
+        return field;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearProviderCaches() throws Exception {
+        Field field = FileStoreProviderFactory.class.getDeclaredField("INSTANCES");
+        field.setAccessible(true);
+        ((Map<String, FileStoreProvider>) field.get(null)).clear();
+        EnhancedServiceLoader.unload(FileStoreProvider.class);
+        EnhancedServiceLoader.unload(LockManager.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/session/SessionHolderTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/SessionHolderTest.java
@@ -16,10 +16,15 @@
  */
 package org.apache.seata.server.session;
 
+import org.apache.seata.common.Constants;
 import org.apache.seata.common.XID;
+import org.apache.seata.common.holder.ObjectHolder;
 import org.apache.seata.common.store.SessionMode;
+import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.core.constants.ConfigurationKeys;
-import org.apache.seata.server.BaseSpringBootTest;
+import org.apache.seata.server.lock.LockerManagerFactory;
+import org.apache.seata.server.storage.file.lock.DefaultFileLockStore;
+import org.apache.seata.server.storage.file.lock.FileLockManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,17 +32,19 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.env.MockEnvironment;
 
 import java.io.File;
-import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Map;
 
-import static java.io.File.separator;
 import static org.apache.seata.common.Constants.ASYNC_COMMITTING;
 import static org.apache.seata.common.Constants.RETRY_COMMITTING;
 import static org.apache.seata.common.Constants.RETRY_ROLLBACKING;
 import static org.apache.seata.common.Constants.TX_TIMEOUT_CHECK;
 import static org.apache.seata.common.Constants.UNDOLOG_DELETE;
-import static org.apache.seata.common.DefaultValues.DEFAULT_SESSION_STORE_FILE_DIR;
 import static org.apache.seata.server.session.SessionHolder.ROOT_SESSION_MANAGER_NAME;
 
 /**
@@ -45,15 +52,22 @@ import static org.apache.seata.server.session.SessionHolder.ROOT_SESSION_MANAGER
  *
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class SessionHolderTest extends BaseSpringBootTest {
+public class SessionHolderTest {
+    @TempDir
+    Path tempDir;
+
     private String pathname;
+    private Object originalEnvironment;
 
     @BeforeEach
     public void before() {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        System.setProperty(
+                ConfigurationKeys.STORE_FILE_DIR, tempDir.resolve("file").toString());
+        ConfigurationCache.clear();
         String sessionStorePath =
-                SessionHolder.CONFIG.getConfig(ConfigurationKeys.STORE_FILE_DIR, DEFAULT_SESSION_STORE_FILE_DIR)
-                        + separator
-                        + XID.getPort();
+                tempDir.resolve("file").resolve(String.valueOf(XID.getPort())).toString();
         // delete file previously created
         pathname = sessionStorePath + File.separator + ROOT_SESSION_MANAGER_NAME;
         // SessionHolder.init(StoreMode.REDIS.getName());
@@ -61,7 +75,7 @@ public class SessionHolderTest extends BaseSpringBootTest {
 
     @Test
     @Order(1)
-    public void testInit() throws IOException {
+    public void testInit() throws Exception {
         File rootSessionFile = new File(pathname);
         if (rootSessionFile.exists()) {
             rootSessionFile.delete();
@@ -71,16 +85,43 @@ public class SessionHolderTest extends BaseSpringBootTest {
             final File actual = new File(pathname);
             Assertions.assertTrue(actual.exists());
             Assertions.assertTrue(actual.isFile());
+            Assertions.assertInstanceOf(FileLockManager.class, LockerManagerFactory.getLockManager());
+            Assertions.assertInstanceOf(
+                    DefaultFileLockStore.class, lockStore((FileLockManager) LockerManagerFactory.getLockManager()));
         } finally {
             SessionHolder.destroy();
         }
     }
 
     @AfterEach
-    public void after() {
+    public void after() throws Exception {
+        SessionHolder.destroy();
+        LockerManagerFactory.destroy();
+        System.clearProperty(ConfigurationKeys.STORE_FILE_DIR);
+        System.clearProperty(ConfigurationKeys.STORE_FILE_ENGINE);
+        ConfigurationCache.clear();
         final File actual = new File(pathname);
         if (actual.exists()) {
             actual.delete();
+        }
+        restoreEnvironment();
+    }
+
+    private static Object lockStore(FileLockManager lockManager) throws ReflectiveOperationException {
+        Field field = FileLockManager.class.getDeclaredField("lockStore");
+        field.setAccessible(true);
+        return field.get(lockManager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
         }
     }
 

--- a/server/src/test/java/org/apache/seata/server/session/redis/RedisDistributedLockerTest.java
+++ b/server/src/test/java/org/apache/seata/server/session/redis/RedisDistributedLockerTest.java
@@ -18,20 +18,26 @@ package org.apache.seata.server.session.redis;
 
 import org.apache.seata.common.XID;
 import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.common.store.LockMode;
 import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.store.StoreMode;
+import org.apache.seata.config.ConfigurationCache;
 import org.apache.seata.core.store.DistributedLockDO;
 import org.apache.seata.core.store.DistributedLocker;
 import org.apache.seata.server.BaseSpringBootTest;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
+import org.apache.seata.server.lock.LockerManagerFactory;
 import org.apache.seata.server.lock.distributed.DistributedLockerFactory;
 import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.storage.redis.JedisPooledFactory;
+import org.apache.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 import redis.clients.jedis.Jedis;
 
 import java.io.IOException;
@@ -49,21 +55,46 @@ public class RedisDistributedLockerTest extends BaseSpringBootTest {
     private String lockValue = "127.1.1.1:9081";
     private static DistributedLocker distributedLocker;
     private static Jedis jedis;
+    private static SessionMode originalSessionMode;
+    private static LockMode originalLockMode;
 
     @BeforeAll
     public static void start(ApplicationContext context) throws IOException {
+        originalSessionMode = (SessionMode) ReflectionTestUtils.getField(StoreConfig.class, "sessionMode");
+        originalLockMode = (LockMode) ReflectionTestUtils.getField(StoreConfig.class, "lockMode");
+        // The tests own scheduled-lock keys, so stop the coordinator before switching stores.
+        DefaultCoordinator.getInstance().destroy();
+        LockerManagerFactory.destroy();
+        StoreConfig.setStartupParameter(null, SessionMode.REDIS.getName(), LockMode.REDIS.getName());
+        ConfigurationCache.clear();
         EnhancedServiceLoader.unload(DistributedLocker.class);
         DistributedLockerFactory.cleanLocker();
+        SessionHolder.init(SessionMode.REDIS);
+        LockerManagerFactory.init(LockMode.REDIS);
         distributedLocker = DistributedLockerFactory.getDistributedLocker(StoreMode.REDIS.getName());
         jedis = JedisPooledFactory.getJedisInstance();
     }
 
     @AfterAll
     public static void after() throws IOException {
-        EnhancedServiceLoader.unload(DistributedLocker.class);
-        DistributedLockerFactory.cleanLocker();
-        DistributedLockerFactory.getDistributedLocker(StoreMode.FILE.getName());
-        jedis.close();
+        try {
+            if (jedis != null) {
+                jedis.close();
+            }
+        } finally {
+            try {
+                SessionHolder.destroy();
+            } finally {
+                LockerManagerFactory.destroy();
+                EnhancedServiceLoader.unload(DistributedLocker.class);
+                DistributedLockerFactory.cleanLocker();
+                ReflectionTestUtils.setField(StoreConfig.class, "sessionMode", originalSessionMode);
+                ReflectionTestUtils.setField(StoreConfig.class, "lockMode", originalLockMode);
+                ConfigurationCache.clear();
+                SessionHolder.init();
+                LockerManagerFactory.init();
+            }
+        }
     }
 
     @Test
@@ -80,9 +111,8 @@ public class RedisDistributedLockerTest extends BaseSpringBootTest {
     }
 
     @Test
-    public void test_acquireScheduledLock_success_() {
+    public void testAcquireScheduledLockViaSessionHolder() {
         String lockKey = retryRollbacking2;
-        SessionHolder.init(SessionMode.REDIS);
 
         boolean accquire = SessionHolder.acquireDistributedLock(lockKey);
         Assertions.assertTrue(accquire);
@@ -96,14 +126,14 @@ public class RedisDistributedLockerTest extends BaseSpringBootTest {
     @Test
     public void test_acquireLock_concurrent() {
         // acquire the lock success
-        boolean accquire = distributedLocker.acquireLock(new DistributedLockDO(retryRollbacking, lockValue, 60000l));
+        boolean accquire = distributedLocker.acquireLock(new DistributedLockDO(retryRollbacking, lockValue, 60000L));
         Assertions.assertTrue(accquire);
         String lockValueExisted = jedis.get(retryRollbacking);
         Assertions.assertEquals(lockValue, lockValueExisted);
 
         // concurrent acquire
         for (int i = 0; i < 10; i++) {
-            boolean b = distributedLocker.acquireLock(new DistributedLockDO(retryRollbacking, lockValue + i, 60000l));
+            boolean b = distributedLocker.acquireLock(new DistributedLockDO(retryRollbacking, lockValue + i, 60000L));
             Assertions.assertFalse(b);
         }
 
@@ -127,7 +157,7 @@ public class RedisDistributedLockerTest extends BaseSpringBootTest {
         }
 
         // other2 acquire the lock
-        boolean e = distributedLocker.acquireLock(new DistributedLockDO(retryRollbacking, lockValue + 2, 60000l));
+        boolean e = distributedLocker.acquireLock(new DistributedLockDO(retryRollbacking, lockValue + 2, 60000L));
         Assertions.assertTrue(e);
 
         // clear
@@ -138,7 +168,7 @@ public class RedisDistributedLockerTest extends BaseSpringBootTest {
     public void test_acquireLock_false() {
         String set = jedis.set(retryCommiting, lockValue);
         Assertions.assertEquals("OK", set);
-        boolean acquire = distributedLocker.acquireLock(new DistributedLockDO(retryCommiting, lockValue, 60000l));
+        boolean acquire = distributedLocker.acquireLock(new DistributedLockDO(retryCommiting, lockValue, 60000L));
         Assertions.assertFalse(acquire);
     }
 }

--- a/server/src/test/java/org/apache/seata/server/storage/file/DefaultFileStoreRuntimeTest.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/DefaultFileStoreRuntimeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file;
+
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.server.session.GlobalSession;
+import org.apache.seata.server.storage.file.session.FileSessionManager;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.file.spi.FileStoreContext;
+import org.apache.seata.server.storage.file.spi.SessionRecoveryConsumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+class DefaultFileStoreRuntimeTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void setUp() {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        restoreEnvironment();
+    }
+
+    @Test
+    void testRecoverReloadsAppendLogBeforePassingSessionsToConsumer() throws Exception {
+        FileSessionManager sessionManager = Mockito.mock(FileSessionManager.class);
+        FileLockStore lockStore = Mockito.mock(FileLockStore.class);
+        SessionRecoveryConsumer consumer = Mockito.mock(SessionRecoveryConsumer.class);
+        GlobalSession session = Mockito.mock(GlobalSession.class);
+        Mockito.when(sessionManager.allSessions()).thenReturn(Collections.singletonList(session));
+        DefaultFileStoreRuntime runtime = new DefaultFileStoreRuntime(sessionManager, lockStore);
+
+        runtime.recover(consumer);
+
+        InOrder order = Mockito.inOrder(sessionManager, consumer);
+        order.verify(sessionManager).reload();
+        order.verify(sessionManager).allSessions();
+        order.verify(consumer).accept(Collections.singletonList(session));
+    }
+
+    @Test
+    void testBackgroundStartRequiresRecoveryAndCloseIsIdempotent() {
+        FileSessionManager sessionManager = Mockito.mock(FileSessionManager.class);
+        DefaultFileStoreRuntime runtime =
+                new DefaultFileStoreRuntime(sessionManager, Mockito.mock(FileLockStore.class));
+
+        Assertions.assertThrows(IllegalStateException.class, runtime::startBackgroundServices);
+        runtime.recover(sessions -> {});
+        runtime.startBackgroundServices();
+        runtime.close();
+        runtime.close();
+
+        Mockito.verify(sessionManager).destroy();
+    }
+
+    @Test
+    void testProviderFailureClosesCreatedSessionManagerAndSuppressesCleanupFailure() throws Exception {
+        FileSessionManager sessionManager = Mockito.mock(FileSessionManager.class);
+        RuntimeException openFailure = new RuntimeException("lock store");
+        RuntimeException cleanupFailure = new RuntimeException("session close");
+        Mockito.doThrow(cleanupFailure).when(sessionManager).destroy();
+        DefaultFileStoreProvider provider = new DefaultFileStoreProvider() {
+            @Override
+            protected FileSessionManager createSessionManager(FileStoreContext context) {
+                return sessionManager;
+            }
+
+            @Override
+            protected FileLockStore createLockStore() {
+                throw openFailure;
+            }
+        };
+
+        RuntimeException thrown = Assertions.assertThrows(
+                RuntimeException.class, () -> provider.open(new FileStoreContext("root.data", tempDir)));
+
+        Assertions.assertSame(openFailure, thrown);
+        Assertions.assertArrayEquals(new Throwable[] {cleanupFailure}, thrown.getSuppressed());
+        Mockito.verify(sessionManager).destroy();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/storage/file/FileStoreProviderFactoryTest.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/FileStoreProviderFactoryTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file;
+
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.common.loader.EnhancedServiceLoader;
+import org.apache.seata.common.loader.EnhancedServiceNotFoundException;
+import org.apache.seata.core.exception.TransactionException;
+import org.apache.seata.core.lock.Locker;
+import org.apache.seata.server.session.BranchSession;
+import org.apache.seata.server.session.GlobalSession;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.apache.seata.server.storage.file.spi.FileStoreContext;
+import org.apache.seata.server.storage.file.spi.FileStoreProvider;
+import org.apache.seata.server.storage.file.spi.FileStoreRuntime;
+import org.apache.seata.server.storage.file.spi.SessionRecoveryConsumer;
+import org.apache.seata.server.storage.file.spi.TestNamedFileStoreProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class FileStoreProviderFactoryTest {
+
+    @TempDir
+    java.nio.file.Path tempDir;
+
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void unloadProviders() throws Exception {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        providerCache().clear();
+        EnhancedServiceLoader.unload(FileStoreProvider.class);
+    }
+
+    @AfterEach
+    void cleanupProviders() throws Exception {
+        providerCache().clear();
+        EnhancedServiceLoader.unload(FileStoreProvider.class);
+        restoreEnvironment();
+    }
+
+    @Test
+    public void testGetProvider_default() {
+        FileStoreProvider provider = FileStoreProviderFactory.getProvider("default");
+
+        assertThat(provider).isInstanceOf(DefaultFileStoreProvider.class);
+    }
+
+    @Test
+    public void testGetProvider_named() {
+        FileStoreProvider provider = FileStoreProviderFactory.getProvider("test");
+
+        assertThat(provider).isInstanceOf(TestNamedFileStoreProvider.class);
+    }
+
+    @Test
+    public void testGetProvider_nullOrBlankName_returnsDefault() {
+        FileStoreProvider defaultProvider = FileStoreProviderFactory.getProvider("default");
+
+        assertThat(FileStoreProviderFactory.getProvider(null)).isSameAs(defaultProvider);
+        assertThat(FileStoreProviderFactory.getProvider(" ")).isSameAs(defaultProvider);
+    }
+
+    @Test
+    public void testGetProvider_unknownName_throwsException() {
+        assertThatThrownBy(() -> FileStoreProviderFactory.getProvider("unknown"))
+                .isInstanceOf(EnhancedServiceNotFoundException.class);
+    }
+
+    @Test
+    public void testGetProvider_sameNameReturnsCachedInstance() {
+        FileStoreProvider first = FileStoreProviderFactory.getProvider("test");
+        FileStoreProvider second = FileStoreProviderFactory.getProvider("test");
+
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    public void testOpen_returnsDistinctRuntimesWithIndependentLifecycle() {
+        FileStoreProvider provider = FileStoreProviderFactory.getProvider("default");
+        FileStoreRuntime first = provider.open(new FileStoreContext("root", tempDir.resolve("first")));
+        FileStoreRuntime second = provider.open(new FileStoreContext("root", tempDir.resolve("second")));
+
+        assertThat(second).isNotSameAs(first);
+        first.close();
+        second.close();
+    }
+
+    @Test
+    public void testSpiContracts_areNarrowAndLifecycleAware() {
+        assertAll(
+                () -> assertThat(AutoCloseable.class.isAssignableFrom(FileStoreRuntime.class))
+                        .isTrue(),
+                () -> assertThat(SessionRecoveryConsumer.class
+                                .getMethod("accept", Collection.class)
+                                .getExceptionTypes())
+                        .containsExactly(TransactionException.class),
+                () -> assertThat(FileLockStore.class.getInterfaces()).isEmpty(),
+                () -> assertThat(FileLockStore.class
+                                .getMethod("getLocker", BranchSession.class)
+                                .getReturnType())
+                        .isEqualTo(Locker.class),
+                () -> assertThat(FileLockStore.class
+                                .getMethod("releaseBranchLock", BranchSession.class)
+                                .getExceptionTypes())
+                        .containsExactly(TransactionException.class),
+                () -> assertThat(FileLockStore.class
+                                .getMethod("releaseGlobalLock", GlobalSession.class)
+                                .getExceptionTypes())
+                        .containsExactly(TransactionException.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, FileStoreProvider> providerCache() throws Exception {
+        Field field = FileStoreProviderFactory.class.getDeclaredField("INSTANCES");
+        field.setAccessible(true);
+        return (Map<String, FileStoreProvider>) field.get(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/storage/file/lock/FileLockManagerStrategyTest.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/lock/FileLockManagerStrategyTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.lock;
+
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.common.store.LockMode;
+import org.apache.seata.config.ConfigurationCache;
+import org.apache.seata.core.model.BranchStatus;
+import org.apache.seata.core.model.BranchType;
+import org.apache.seata.core.model.LockStatus;
+import org.apache.seata.server.lock.LockerManagerFactory;
+import org.apache.seata.server.session.BranchSession;
+import org.apache.seata.server.session.GlobalSession;
+import org.apache.seata.server.storage.file.spi.FileLockStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
+
+class FileLockManagerStrategyTest {
+
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void beforeEach() {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        ConfigurationCache.clear();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        LockerManagerFactory.destroy();
+        new FileLocker(null).cleanAllLocks();
+        ConfigurationCache.clear();
+        restoreEnvironment();
+    }
+
+    @Test
+    void testDefaultStoreSelectsFileLockerAndReleasesOwnerHolder() throws Exception {
+        FileLockManager lockManager = install(new DefaultFileLockStore());
+        BranchSession owner = branchSession(1001L, 1L, "t_order:1");
+        BranchSession contender = branchSession(1002L, 2L, "t_order:1");
+
+        Assertions.assertInstanceOf(FileLocker.class, lockManager.getLocker(owner));
+        Assertions.assertTrue(lockManager.acquireLock(owner));
+        Assertions.assertFalse(lockManager.acquireLock(contender));
+
+        owner.setLockKey("");
+        Assertions.assertTrue(lockManager.releaseLock(owner));
+        Assertions.assertTrue(owner.getLockHolder().isEmpty());
+        Assertions.assertTrue(lockManager.acquireLock(contender));
+    }
+
+    @Test
+    void testDefaultStorePreservesGlobalReleaseAndLockerSemantics() throws Exception {
+        FileLockManager lockManager = install(new DefaultFileLockStore());
+        GlobalSession globalSession = new GlobalSession("app", "group", "tx", 60000);
+        BranchSession first = branchSession(globalSession.getTransactionId(), 1L, "t_order:1");
+        BranchSession second = branchSession(globalSession.getTransactionId(), 2L, "t_order:2");
+        first.setXid(globalSession.getXid());
+        second.setXid(globalSession.getXid());
+        globalSession.add(first);
+        globalSession.add(second);
+
+        Assertions.assertTrue(lockManager.acquireLock(first));
+        Assertions.assertTrue(lockManager.acquireLock(second));
+        Assertions.assertFalse(lockManager.isLockable(xid(2001L), first.getResourceId(), "t_order:1,2"));
+
+        lockManager.updateLockStatus(globalSession.getXid(), LockStatus.Rollbacking);
+        Assertions.assertEquals(LockStatus.Locked, first.getLockStatus());
+
+        first.setLockKey("");
+        second.setLockKey("");
+        Assertions.assertTrue(lockManager.releaseGlobalSessionLock(globalSession));
+        Assertions.assertTrue(first.getLockHolder().isEmpty());
+        Assertions.assertTrue(second.getLockHolder().isEmpty());
+        Assertions.assertTrue(lockManager.isLockable(xid(2001L), first.getResourceId(), "t_order:1,2"));
+
+        BranchSession owner = branchSession(3001L, 3L, "t_order:3");
+        Assertions.assertTrue(lockManager.acquireLock(owner));
+        lockManager.cleanAllLocks();
+        Assertions.assertTrue(lockManager.isLockable(xid(3002L), owner.getResourceId(), "t_order:3"));
+    }
+
+    @Test
+    void testDefaultStoreReturnsFalseWhenOwnerReleaseFails() throws Exception {
+        FileLockManager lockManager = install(new DefaultFileLockStore());
+        BranchSession failingOwner = failingOwner();
+
+        Assertions.assertFalse(lockManager.releaseLock(failingOwner));
+    }
+
+    @Test
+    void testDefaultGlobalReleaseContinuesAfterFailureAndReturnsLastSuccess() throws Exception {
+        FileLockManager lockManager = install(new DefaultFileLockStore());
+        GlobalSession globalSession = new GlobalSession("app", "group", "tx", 60000);
+        BranchSession successfulOwner = branchSession(globalSession.getTransactionId(), 2L, "t_order:2");
+        globalSession.add(failingOwner());
+        globalSession.add(successfulOwner);
+        Assertions.assertTrue(lockManager.acquireLock(successfulOwner));
+
+        Assertions.assertTrue(lockManager.releaseGlobalSessionLock(globalSession));
+
+        Assertions.assertTrue(successfulOwner.getLockHolder().isEmpty());
+        Assertions.assertTrue(
+                lockManager.isLockable(xid(2002L), successfulOwner.getResourceId(), successfulOwner.getLockKey()));
+    }
+
+    @Test
+    void testDefaultGlobalReleaseReturnsFinalFailureAfterEarlierSuccess() throws Exception {
+        FileLockManager lockManager = install(new DefaultFileLockStore());
+        GlobalSession globalSession = new GlobalSession("app", "group", "tx", 60000);
+        BranchSession successfulOwner = branchSession(globalSession.getTransactionId(), 1L, "t_order:1");
+        globalSession.add(successfulOwner);
+        globalSession.add(failingOwner());
+        Assertions.assertTrue(lockManager.acquireLock(successfulOwner));
+
+        Assertions.assertFalse(lockManager.releaseGlobalSessionLock(globalSession));
+
+        Assertions.assertTrue(successfulOwner.getLockHolder().isEmpty());
+        Assertions.assertTrue(
+                lockManager.isLockable(xid(2001L), successfulOwner.getResourceId(), successfulOwner.getLockKey()));
+    }
+
+    private BranchSession branchSession(long transactionId, long branchId, String lockKey) {
+        BranchSession branchSession = new BranchSession(BranchType.AT);
+        branchSession.setXid(xid(transactionId));
+        branchSession.setTransactionId(transactionId);
+        branchSession.setBranchId(branchId);
+        branchSession.setStatus(BranchStatus.Registered);
+        branchSession.setResourceId("jdbc:mysql://127.0.0.1/db");
+        branchSession.setLockKey(lockKey);
+        return branchSession;
+    }
+
+    private FileLockManager install(FileLockStore lockStore) {
+        LockerManagerFactory.init(LockMode.FILE, new Class<?>[] {FileLockStore.class}, new Object[] {lockStore});
+        return (FileLockManager) LockerManagerFactory.getLockManager();
+    }
+
+    private static String xid(long transactionId) {
+        return "127.0.0.1:8091:" + transactionId;
+    }
+
+    private static BranchSession failingOwner() {
+        return new BranchSession(BranchType.AT) {
+            @Override
+            public Map<FileLocker.BucketLockMap, Set<String>> getLockHolder() {
+                throw new IllegalStateException("release failed");
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/storage/file/spi/SessionHolderFaultFileStoreProvider.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/spi/SessionHolderFaultFileStoreProvider.java
@@ -16,7 +16,9 @@
  */
 package org.apache.seata.server.storage.file.spi;
 
+import org.apache.seata.common.exception.StoreException;
 import org.apache.seata.common.loader.LoadLevel;
+import org.apache.seata.core.exception.TransactionException;
 import org.apache.seata.server.session.SessionManager;
 
 @LoadLevel(name = "session-holder-fault")
@@ -91,6 +93,11 @@ public final class SessionHolderFaultFileStoreProvider implements FileStoreProvi
             public void recover(SessionRecoveryConsumer consumer) {
                 if (failurePoint == FailurePoint.RECOVERY) {
                     throw startupFailure;
+                }
+                try {
+                    consumer.accept(sessionManager.allSessions());
+                } catch (TransactionException e) {
+                    throw new StoreException(e, "recover test file store sessions failed");
                 }
             }
 

--- a/server/src/test/java/org/apache/seata/server/storage/file/spi/SessionHolderFaultFileStoreProvider.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/spi/SessionHolderFaultFileStoreProvider.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import org.apache.seata.common.loader.LoadLevel;
+import org.apache.seata.server.session.SessionManager;
+
+@LoadLevel(name = "session-holder-fault")
+public final class SessionHolderFaultFileStoreProvider implements FileStoreProvider {
+
+    public enum FailurePoint {
+        NONE,
+        OPEN,
+        LOCK_STORE,
+        RECOVERY,
+        BACKGROUND
+    }
+
+    private static FailurePoint failurePoint = FailurePoint.NONE;
+    private static RuntimeException startupFailure;
+    private static RuntimeException closeFailure;
+    private static SessionManager sessionManager;
+    private static FileLockStore lockStore;
+    private static FileStoreContext lastContext;
+    private static int closeCount;
+
+    public static void configure(
+            FailurePoint point,
+            RuntimeException configuredStartupFailure,
+            RuntimeException configuredCloseFailure,
+            SessionManager configuredSessionManager,
+            FileLockStore configuredLockStore) {
+        failurePoint = point;
+        startupFailure = configuredStartupFailure;
+        closeFailure = configuredCloseFailure;
+        sessionManager = configuredSessionManager;
+        lockStore = configuredLockStore;
+        lastContext = null;
+        closeCount = 0;
+    }
+
+    public static int closeCount() {
+        return closeCount;
+    }
+
+    public static FileStoreContext lastContext() {
+        return lastContext;
+    }
+
+    public static void reset() {
+        configure(FailurePoint.NONE, null, null, null, null);
+    }
+
+    @Override
+    public FileStoreRuntime open(FileStoreContext context) {
+        lastContext = context;
+        if (failurePoint == FailurePoint.OPEN) {
+            throw startupFailure;
+        }
+        return new FileStoreRuntime() {
+            private boolean closed;
+
+            @Override
+            public SessionManager sessionManager() {
+                return sessionManager;
+            }
+
+            @Override
+            public FileLockStore lockStore() {
+                if (failurePoint == FailurePoint.LOCK_STORE) {
+                    throw startupFailure;
+                }
+                return lockStore;
+            }
+
+            @Override
+            public void recover(SessionRecoveryConsumer consumer) {
+                if (failurePoint == FailurePoint.RECOVERY) {
+                    throw startupFailure;
+                }
+            }
+
+            @Override
+            public void startBackgroundServices() {
+                if (failurePoint == FailurePoint.BACKGROUND) {
+                    throw startupFailure;
+                }
+            }
+
+            @Override
+            public void close() {
+                if (closed) {
+                    return;
+                }
+                closed = true;
+                closeCount++;
+                if (closeFailure != null) {
+                    throw closeFailure;
+                }
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/storage/file/spi/TestFileStoreRuntime.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/spi/TestFileStoreRuntime.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import org.apache.seata.server.session.SessionManager;
+
+import static org.mockito.Mockito.mock;
+
+public class TestFileStoreRuntime implements FileStoreRuntime {
+
+    private final SessionManager sessionManager = mock(SessionManager.class);
+    private final FileLockStore lockStore = mock(FileLockStore.class);
+    private boolean backgroundServicesStarted;
+    private boolean closed;
+
+    @Override
+    public SessionManager sessionManager() {
+        return sessionManager;
+    }
+
+    @Override
+    public FileLockStore lockStore() {
+        return lockStore;
+    }
+
+    @Override
+    public void recover(SessionRecoveryConsumer recoveryConsumer) {}
+
+    @Override
+    public void startBackgroundServices() {
+        backgroundServicesStarted = true;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    public boolean isBackgroundServicesStarted() {
+        return backgroundServicesStarted;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/storage/file/spi/TestNamedFileStoreProvider.java
+++ b/server/src/test/java/org/apache/seata/server/storage/file/spi/TestNamedFileStoreProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.storage.file.spi;
+
+import org.apache.seata.common.loader.LoadLevel;
+
+@LoadLevel(name = "test")
+public class TestNamedFileStoreProvider implements FileStoreProvider {
+
+    @Override
+    public FileStoreRuntime open(FileStoreContext context) {
+        return new TestFileStoreRuntime();
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/store/SessionStoreTest.java
+++ b/server/src/test/java/org/apache/seata/server/store/SessionStoreTest.java
@@ -25,6 +25,7 @@ import org.apache.seata.core.model.BranchStatus;
 import org.apache.seata.core.model.BranchType;
 import org.apache.seata.core.model.GlobalStatus;
 import org.apache.seata.server.BaseSpringBootTest;
+import org.apache.seata.server.coordinator.DefaultCoordinator;
 import org.apache.seata.server.lock.LockManager;
 import org.apache.seata.server.lock.file.FileLockManagerForTest;
 import org.apache.seata.server.session.BranchSession;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.context.ApplicationContext;
 
 import java.io.File;
+import java.nio.file.Files;
 
 import static java.io.File.separator;
 import static org.apache.seata.common.DefaultValues.DEFAULT_SESSION_STORE_FILE_DIR;
@@ -62,6 +64,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
 
     @BeforeAll
     public static void setUp(ApplicationContext context) {
+        // Recovery tests own the store lifecycle and must not race the coordinator's retry tasks.
+        DefaultCoordinator.getInstance().destroy();
         CONFIG = ConfigurationFactory.getInstance();
     }
 
@@ -72,18 +76,15 @@ public class SessionStoreTest extends BaseSpringBootTest {
      */
     @BeforeEach
     public void clean() throws Exception {
+        SessionHolder.destroy();
         String sessionStorePath = CONFIG.getConfig(ConfigurationKeys.STORE_FILE_DIR, DEFAULT_SESSION_STORE_FILE_DIR)
                 + separator
                 + XID.getPort();
         File rootDataFile = new File(sessionStorePath + separator + SessionHolder.ROOT_SESSION_MANAGER_NAME);
         File rootDataFileHis = new File(sessionStorePath + separator + SessionHolder.ROOT_SESSION_MANAGER_NAME + ".1");
 
-        if (rootDataFile.exists()) {
-            rootDataFile.delete();
-        }
-        if (rootDataFileHis.exists()) {
-            rootDataFileHis.delete();
-        }
+        Files.deleteIfExists(rootDataFile.toPath());
+        Files.deleteIfExists(rootDataFileHis.toPath());
         LockManager lockManager = new FileLockManagerForTest();
         lockManager.cleanAllLocks();
     }
@@ -132,7 +133,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
             Assertions.assertTrue(lockManager.isLockable(otherXID, RESOURCE_ID, "ta:2"));
             Assertions.assertTrue(lockManager.isLockable(otherXID, RESOURCE_ID, "tb:3"));
 
-            // Re-init SessionHolder: restore sessions from file
+            // Close the writer before reopening the same persisted store.
+            SessionHolder.destroy();
             SessionHolder.init(SessionMode.FILE);
 
             long tid = globalSession.getTransactionId();
@@ -166,7 +168,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
 
             globalSession.begin();
 
-            // Re-init SessionHolder: restore sessions from file
+            // Close the writer before reopening the same persisted store.
+            SessionHolder.destroy();
             SessionHolder.init(SessionMode.FILE);
         } finally {
             SessionHolder.destroy();
@@ -207,7 +210,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
 
             Assertions.assertTrue(lockManager.isLockable(otherXID, RESOURCE_ID, "ta:1"));
 
-            // Re-init SessionHolder: restore sessions from file
+            // Close the writer before reopening the same persisted store.
+            SessionHolder.destroy();
             SessionHolder.init(SessionMode.FILE);
 
             GlobalSession reloadSession = SessionHolder.findGlobalSession(globalSession.getXid());
@@ -263,7 +267,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
 
             Assertions.assertTrue(lockManager.isLockable(otherXID, RESOURCE_ID, "ta:1"));
 
-            // Re-init SessionHolder: restore sessions from file
+            // Close the writer before reopening the same persisted store.
+            SessionHolder.destroy();
             SessionHolder.init(SessionMode.FILE);
 
             long tid = globalSession.getTransactionId();
@@ -323,7 +328,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
 
             Assertions.assertTrue(lockManager.isLockable(otherXID, RESOURCE_ID, "ta:1"));
 
-            // Re-init SessionHolder: restore sessions from file
+            // Close the writer before reopening the same persisted store.
+            SessionHolder.destroy();
             SessionHolder.init(SessionMode.FILE);
 
             long tid = globalSession.getTransactionId();
@@ -386,7 +392,8 @@ public class SessionStoreTest extends BaseSpringBootTest {
 
             Assertions.assertTrue(lockManager.isLockable(otherXID, RESOURCE_ID, "ta:1"));
 
-            // Re-init SessionHolder: restore sessions from file
+            // Close the writer before reopening the same persisted store.
+            SessionHolder.destroy();
             SessionHolder.init(SessionMode.FILE);
 
             long tid = globalSession.getTransactionId();

--- a/server/src/test/java/org/apache/seata/server/store/StoreConfigTest.java
+++ b/server/src/test/java/org/apache/seata/server/store/StoreConfigTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seata.server.store;
+
+import org.apache.seata.common.ConfigurationKeys;
+import org.apache.seata.common.Constants;
+import org.apache.seata.common.holder.ObjectHolder;
+import org.apache.seata.config.ConfigurationCache;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+class StoreConfigTest {
+
+    private Object originalEnvironment;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        originalEnvironment = ObjectHolder.INSTANCE.getObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        ObjectHolder.INSTANCE.setObject(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, new MockEnvironment());
+        clearConfig();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        clearConfig();
+        restoreEnvironment();
+    }
+
+    @Test
+    void testDefaultFileEngineName() {
+        Assertions.assertEquals("default", StoreConfig.getFileEngineName());
+    }
+
+    @Test
+    void testConfiguredFileEngineNameIsNormalized() {
+        System.setProperty(ConfigurationKeys.STORE_FILE_ENGINE, "  TestProvider  ");
+
+        Assertions.assertEquals("testprovider", StoreConfig.getFileEngineName());
+    }
+
+    @Test
+    void testBlankFileEngineNameUsesDefault() {
+        System.setProperty(ConfigurationKeys.STORE_FILE_ENGINE, "  ");
+
+        Assertions.assertEquals("default", StoreConfig.getFileEngineName());
+    }
+
+    @Test
+    void testUnknownFileEngineNameIsPreservedForProviderLookup() {
+        System.setProperty(ConfigurationKeys.STORE_FILE_ENGINE, "  FutureEngine  ");
+
+        Assertions.assertEquals("futureengine", StoreConfig.getFileEngineName());
+    }
+
+    private void clearConfig() throws Exception {
+        System.clearProperty(ConfigurationKeys.STORE_MODE);
+        System.clearProperty(ConfigurationKeys.STORE_LOCK_MODE);
+        System.clearProperty(ConfigurationKeys.STORE_FILE_ENGINE);
+        ConfigurationCache.clear();
+        resetStoreConfig("storeMode");
+        resetStoreConfig("sessionMode");
+        resetStoreConfig("lockMode");
+    }
+
+    private void resetStoreConfig(String fieldName) throws Exception {
+        Field field = StoreConfig.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreEnvironment() throws Exception {
+        Field field = ObjectHolder.class.getDeclaredField("OBJECT_MAP");
+        field.setAccessible(true);
+        Map<String, Object> objectMap = (Map<String, Object>) field.get(ObjectHolder.INSTANCE);
+        if (originalEnvironment == null) {
+            objectMap.remove(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT);
+        } else {
+            objectMap.put(Constants.OBJECT_KEY_SPRING_CONFIGURABLE_ENVIRONMENT, originalEnvironment);
+        }
+    }
+}

--- a/server/src/test/java/org/apache/seata/server/store/file/FileTransactionStoreManagerTest.java
+++ b/server/src/test/java/org/apache/seata/server/store/file/FileTransactionStoreManagerTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.seata.server.store.file;
 
-import org.apache.seata.common.store.SessionMode;
 import org.apache.seata.common.util.BufferUtils;
 import org.apache.seata.common.util.UUIDGenerator;
 import org.apache.seata.server.BaseSpringBootTest;
 import org.apache.seata.server.session.BranchSession;
 import org.apache.seata.server.session.GlobalSession;
-import org.apache.seata.server.session.SessionHolder;
 import org.apache.seata.server.session.SessionManager;
 import org.apache.seata.server.storage.file.TransactionWriteStore;
 import org.apache.seata.server.storage.file.session.FileSessionManager;
@@ -30,9 +28,7 @@ import org.apache.seata.server.storage.file.store.FileTransactionStoreManager;
 import org.apache.seata.server.store.StoreConfig;
 import org.apache.seata.server.store.TransactionStoreManager;
 import org.assertj.core.util.Files;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -44,16 +40,6 @@ import java.util.Collection;
 import java.util.List;
 
 public class FileTransactionStoreManagerTest extends BaseSpringBootTest {
-
-    @BeforeEach
-    public void setUp() {
-        SessionHolder.init(SessionMode.FILE);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        SessionHolder.destroy();
-    }
 
     @Test
     public void testBigDataWrite() throws Exception {

--- a/server/src/test/resources/META-INF/services/org.apache.seata.server.storage.file.spi.FileStoreProvider
+++ b/server/src/test/resources/META-INF/services/org.apache.seata.server.storage.file.spi.FileStoreProvider
@@ -1,0 +1,2 @@
+org.apache.seata.server.storage.file.spi.TestNamedFileStoreProvider
+org.apache.seata.server.storage.file.spi.SessionHolderFaultFileStoreProvider


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
This PR introduces a pluggable runtime abstraction for Seata FileMode storage while preserving the existing file-based implementation as the default provider.

The main changes are:

1. Introduce `FileStoreProvider` and `FileStoreRuntime` abstractions for FileMode storage.
2. Add `FileStoreProviderFactory` to select the provider through `store.file.engine`.
3. Move the existing file session and lock implementations behind `DefaultFileStoreProvider`.
4. Introduce `FileLockStore` and make `FileLockManager` delegate lock operations to the selected store implementation.
5. Let `SessionHolder` manage the complete FileMode runtime lifecycle:
   - open runtime;
   - install the lock manager;
   - recover sessions;
   - start background services;
   - roll back partially initialized resources on startup failure;
   - close resources in reverse order.
6. Make `LockerManagerFactory` support typed FileMode lock-manager installation and reject FileMode access before its runtime is ready.
7. Remove eager caching of `LockManager` and coordinator instances from session, transaction and Console backend components.
8. Keep `store.file.engine=default` as the default configuration so the original FileMode implementation remains available through the new abstraction.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

