### PR TITLE
bugfix: fix IDENTIFIED_CHANNELS leak causing TC FullGC and OOM

### DIFF
--- a/core/src/main/java/org/apache/seata/core/rpc/RpcContext.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/RpcContext.java
@@ -74,6 +74,7 @@ public class RpcContext {
     public void release() {
         Integer clientPort = ChannelUtil.getClientPortFromChannel(channel);
         if (clientIDHolderMap != null) {
+            clientIDHolderMap.remove(channel);
             clientIDHolderMap = null;
         }
         if (clientRole == NettyPoolKey.TransactionRole.TMROLE && clientTMHolderMap != null) {

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingServer.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingServer.java
@@ -215,6 +215,7 @@ public abstract class AbstractNettyRemotingServer extends AbstractNettyRemoting 
             }
             if (rpcContext != null && rpcContext.getClientRole() != null) {
                 rpcContext.release();
+                ChannelManager.releaseRpcContext(ctx.channel());
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("remove channel:" + ctx.channel() + "context:" + rpcContext);
                 }

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/ChannelManager.java
@@ -287,6 +287,7 @@ public class ChannelManager {
         RpcContext rpcContext = getContextFromIdentified(channel);
         if (rpcContext != null) {
             rpcContext.release();
+            IDENTIFIED_CHANNELS.remove(channel);
         }
     }
 

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -162,6 +162,7 @@ class NettyClientChannelManager {
             if (channel.equals(channels.get(serverAddress))) {
                 channels.remove(serverAddress);
                 serverVersionMap.remove(serverAddress);
+                ChannelManager.releaseRpcContext(channel);
             }
             nettyClientKeyPool.returnObject(poolKeyMap.get(serverAddress), channel);
         } catch (Exception exx) {

--- a/core/src/test/java/org/apache/seata/core/rpc/ChannelManagerOOMTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/ChannelManagerOOMTest.java
@@ -1,0 +1,210 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.seata.core.rpc;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.apache.seata.core.protocol.RegisterRMRequest;
+import org.apache.seata.core.protocol.RegisterTMRequest;
+import org.apache.seata.core.rpc.netty.AbstractNettyRemotingServer;
+import org.apache.seata.core.rpc.netty.ChannelManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *  IDENTIFIED_CHANNELS Channel FullGC OOM
+ *  @author alex-ashuo
+ */
+public class ChannelManagerOOMTest {
+
+    private static final String APP_ID = "business-app";
+    private static final String TX_GROUP = "default_tx_group";
+    private static final String RESOURCE_ID = "jdbc:mysql://127.0.0.1:3306/seata";
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        clearStaticMap("IDENTIFIED_CHANNELS");
+        clearStaticMap("TM_CHANNELS");
+        clearStaticMap("RM_CHANNELS");
+    }
+
+    /**
+     * Mock K8s Pod TM RM IDENTIFIED_CHANNELS FullGC OOM
+     */
+    @Test
+    public void repeatedClientReconnectChannels() throws Exception {
+        int iterations = 200;
+        for (int i = 0; i < iterations; i++) {
+            // TM channel
+            Channel tmChannel = newMockDeadChannel(20000 + i);
+            ChannelManager.registerTMChannel(new RegisterTMRequest(APP_ID, TX_GROUP), tmChannel);
+            ChannelManager.getContextFromIdentified(tmChannel).release();
+
+            // RM channel
+            Channel rmChannel = newMockDeadChannel(30000 + i);
+            RegisterRMRequest rmRequest = new RegisterRMRequest(APP_ID, TX_GROUP);
+            rmRequest.setResourceIds(RESOURCE_ID);
+            ChannelManager.registerRMChannel(rmRequest, rmChannel);
+            ChannelManager.getContextFromIdentified(rmChannel).release();
+        }
+
+        int identifiedSize = staticMap("IDENTIFIED_CHANNELS").size();
+        assertEquals(0, identifiedSize);
+    }
+
+    /**
+     * TM RpcContext.release()
+     */
+    @Test
+    public void tmChannelRelease() throws Exception {
+        Channel channel = newMockDeadChannel(10001);
+        RegisterTMRequest request = new RegisterTMRequest(APP_ID, TX_GROUP);
+
+        // RpcServer.onRegTmMessage → ChannelManager.registerTMChannel
+        ChannelManager.registerTMChannel(request, channel);
+        assertTrue(ChannelManager.isRegistered(channel));
+
+        // RpcServer rpcContext.release()
+        ChannelManager.getContextFromIdentified(channel).release();
+        assertFalse(ChannelManager.isRegistered(channel));
+    }
+
+    /**
+     * RM RpcContext.release()
+     */
+    @Test
+    public void rmChannelRelease() throws Exception {
+        Channel channel = newMockDeadChannel(10002);
+        RegisterRMRequest request = new RegisterRMRequest(APP_ID, TX_GROUP);
+        request.setResourceIds(RESOURCE_ID);
+
+        ChannelManager.registerRMChannel(request, channel);
+        assertTrue(ChannelManager.isRegistered(channel));
+
+        // RpcServer rpcContext.release()
+        ChannelManager.getContextFromIdentified(channel).release();
+        assertFalse(ChannelManager.isRegistered(channel));
+    }
+
+    /**
+     * ChannelManager.releaseRpcContext
+     */
+    @Test
+    public void releaseRpcContextChannels() throws Exception {
+        Channel channel = newMockDeadChannel(40001);
+        ChannelManager.registerTMChannel(new RegisterTMRequest(APP_ID, TX_GROUP), channel);
+        assertTrue(ChannelManager.isRegistered(channel));
+
+        ChannelManager.releaseRpcContext(channel);
+        assertFalse(ChannelManager.isRegistered(channel));
+    }
+
+    /**
+     * TM RpcServer#handleDisconnect(ChannelHandlerContext)
+     */
+    @Test
+    public void rpcServerHandleDisconnectTmChannels() throws Exception {
+        Channel channel = newMockDeadChannel(60001);
+
+        // register TM Channel
+        ChannelManager.registerTMChannel(new RegisterTMRequest(APP_ID, TX_GROUP), channel);
+        assertTrue(ChannelManager.isRegistered(channel));
+
+        // mock ChannelHandlerContext handleDisconnect ctx.channel().remoteAddress()
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+
+        // handleDisconnect
+        AbstractNettyRemotingServer server = Mockito.mock(AbstractNettyRemotingServer.class);
+        Class<?> serverHandlerClass = Class.forName(AbstractNettyRemotingServer.class.getName() + "$ServerHandler");
+        java.lang.reflect.Constructor<?> serverHandlerCtor =
+                serverHandlerClass.getDeclaredConstructor(AbstractNettyRemotingServer.class);
+        serverHandlerCtor.setAccessible(true);
+        Object serverHandler = serverHandlerCtor.newInstance(server);
+
+        Method handleDisconnect = serverHandlerClass.getDeclaredMethod("handleDisconnect", ChannelHandlerContext.class);
+        handleDisconnect.setAccessible(true);
+        handleDisconnect.invoke(serverHandler, ctx);
+
+        assertFalse(ChannelManager.isRegistered(channel));
+
+        assertNull(ChannelManager.getContextFromIdentified(channel));
+    }
+
+    /**
+     * RM RpcServer#handleDisconnect(ChannelHandlerContext)
+     */
+    @Test
+    public void rpcServerHandleDisconnectRmChannels() throws Exception {
+        Channel channel = newMockDeadChannel(60002);
+        RegisterRMRequest rmRequest = new RegisterRMRequest(APP_ID, TX_GROUP);
+        rmRequest.setResourceIds(RESOURCE_ID);
+
+        // register RM Channel
+        ChannelManager.registerRMChannel(rmRequest, channel);
+        assertTrue(ChannelManager.isRegistered(channel));
+
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+
+        // handleDisconnect
+        AbstractNettyRemotingServer server = Mockito.mock(AbstractNettyRemotingServer.class);
+        Class<?> serverHandlerClass = Class.forName(AbstractNettyRemotingServer.class.getName() + "$ServerHandler");
+        java.lang.reflect.Constructor<?> serverHandlerCtor =
+                serverHandlerClass.getDeclaredConstructor(AbstractNettyRemotingServer.class);
+        serverHandlerCtor.setAccessible(true);
+        Object serverHandler = serverHandlerCtor.newInstance(server);
+
+        Method handleDisconnect = serverHandlerClass.getDeclaredMethod("handleDisconnect", ChannelHandlerContext.class);
+        handleDisconnect.setAccessible(true);
+        handleDisconnect.invoke(serverHandler, ctx);
+
+        assertFalse(ChannelManager.isRegistered(channel));
+    }
+
+    /**
+     * Mock remoteAddress K8s Pod IP:Port。
+     */
+    private static Channel newMockDeadChannel(int remotePort) {
+        Channel channel = Mockito.mock(Channel.class);
+        InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", remotePort);
+        Mockito.when(channel.remoteAddress()).thenReturn(remoteAddress);
+        Mockito.when(channel.isActive()).thenReturn(false);
+        return channel;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentMap<Object, Object> staticMap(String fieldName) throws Exception {
+        Field field = ChannelManager.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (ConcurrentMap<Object, Object>) field.get(null);
+    }
+
+    private static void clearStaticMap(String fieldName) throws Exception {
+        staticMap(fieldName).clear();
+    }
+}

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/NettyClientChannelManagerTest.java
@@ -148,6 +148,7 @@ class NettyClientChannelManagerTest {
         channelManager.getChannels().putIfAbsent("127.0.0.1:8091", channel);
         channelManager.releaseChannel(channel, "127.0.0.1:8091");
         assertTrue(channelManager.getChannels().isEmpty());
+        assertFalse(ChannelManager.isRegistered(channel));
         verify(keyedObjectPool).returnObject(nettyPoolKey, channel);
     }
 


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/apache/incubator-seata/blob/2.x/CONTRIBUTING.md) guidelines.
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata/tree/2.x/changes).

### Ⅰ. Describe what this PR did
When TM/RM clients disconnect (e.g. K8s pod rolling update, HPA scaling), RpcContext.release() only nulled the clientIDHolderMap field instead of removing the dead channel from ChannelManager.IDENTIFIED_CHANNELS. Dead Netty channels (with RpcContext/pipeline/ByteBuf) accumulated forever until the TC ran into continuous FullGC and OOM.

- RpcContext.release(): remove the channel from IDENTIFIED_CHANNELS
- ChannelManager.releaseRpcContext(): remove the channel defensively
- AbstractNettyRemotingServer.handleDisconnect: route through the unified releaseRpcContext entry (used by both READER_IDLE and channelInactive)
- NettyClientChannelManager.releaseChannel(): release rpc context too
- add ChannelManagerOOMTest reproducing repeated reconnect/disconnect

Related: [https://github.com/apache/incubator-seata/issues/2531](https://github.com/apache/incubator-seata/issues/2531) 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

